### PR TITLE
Resolves #13 Backend vollständig in Docker containerisieren

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+target/
+.mvn/wrapper/maven-wrapper.jar
+.git/
+.gitignore
+*.md
+dev.ps1
+dev.bat

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Stage 1: Build — Maven + JDK 21
+FROM maven:3.9-eclipse-temurin-21-alpine AS build
+WORKDIR /app
+
+# Copy pom.xml first so dependency layer is cached separately from source code.
+# This means 'mvn dependency:go-offline' is only re-run when pom.xml changes.
+COPY pom.xml .
+RUN mvn dependency:go-offline -B
+
+# Copy source and build the JAR (skip tests — tests run in CI)
+COPY src ./src
+RUN mvn package -DskipTests -B
+
+# Stage 2: Runtime — minimal JRE image
+FROM eclipse-temurin:21-jre-alpine AS runtime
+WORKDIR /app
+
+COPY --from=build /app/target/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Jede Anfrage wird über einen JWT-Token authentifiziert (außer Login/Register).
 
 | Technologie | Zweck | Version |
 |---|---|---|
-| Java | Programmiersprache | 21 |
-| Maven Wrapper | Build-Tool (kein globales Maven nötig) | 3.9.9 |
+| Java | Programmiersprache (läuft im Docker-Container) | 21 |
+| Maven | Build-Tool (läuft im Docker-Container, kein lokales Maven nötig) | 3.9.9 |
 | Spring Boot | Framework (Web, Security, JPA) | 3.4.4 |
 | PostgreSQL | Datenbank | 16 |
 | Flyway | Datenbank-Migrations | - |
@@ -128,19 +128,10 @@ https://domain.de/api/   → Backend (Spring Boot, intern Port 8080)
 
 ## 4. Voraussetzungen
 
-Folgendes muss auf deinem Rechner installiert sein:
+Einzige Voraussetzung: **Docker Desktop**
 
-### Java 21+
-```bash
-java -version
-# Erwartet: openjdk 21 ... (oder höher)
-```
-Download: https://adoptium.net (Eclipse Temurin 21 LTS)
+Das Backend (Spring Boot + Java 21) und die Datenbank (PostgreSQL) laufen vollständig in Docker-Containern — kein Java und kein Maven lokal nötig.
 
-> **Hinweis:** Java 24 funktioniert ebenfalls — die `pom.xml` enthält alle nötigen Kompatibilitäts-Fixes für Lombok.
-
-### Docker Desktop
-Wird für die lokale PostgreSQL-Datenbank benötigt.
 ```bash
 docker --version
 docker compose version
@@ -169,36 +160,36 @@ cd Webshop-Backend
 ./dev.bat start
 ```
 
-Das Script startet automatisch:
-1. Maven Wrapper JAR herunterladen (einmalig beim ersten Clone, braucht Internet)
-2. Den PostgreSQL Docker-Container (wartet bis er `healthy` ist)
-3. Das Spring Boot Backend kompilieren + starten (wartet bis `Started WebshopApplication`)
+Das Script baut und startet alle Container automatisch:
+1. PostgreSQL-Container starten (wartet bis er `healthy` ist)
+2. Spring Boot-Image bauen (Maven läuft im Container — kein Java lokal nötig)
+3. Backend-Container starten und auf `/api/health` warten
 
 Das Backend ist dann erreichbar unter: `http://localhost:8080`
 
-Spring Boot Ausgabe (Downloads, Compile-Log, Startup-Logs) erscheint direkt im Terminal.
+> **Erster Start:** Maven lädt alle Dependencies (~200 MB) **innerhalb des Containers** herunter.
+> Das kann beim ersten Mal einige Minuten dauern. Nachfolgende Starts nutzen den Docker Layer-Cache
+> und sind deutlich schneller.
 
 **Alle Befehle im Überblick:**
 
 | Befehl | Was passiert |
 |--------|-------------|
-| `./dev.bat start` | PostgreSQL + Spring Boot starten |
-| `./dev.bat stop` | Spring Boot + PostgreSQL beenden (graceful JMX-Shutdown) |
-| `./dev.bat stop --keep-db` | Nur Spring Boot beenden, DB läuft weiter (schnellerer Neustart) |
-| `./dev.bat restart` | Stop + Start in einem Schritt |
+| `./dev.bat start` | PostgreSQL + Backend bauen und starten |
+| `./dev.bat stop` | Alle Container beenden |
+| `./dev.bat stop --keep-db` | Nur Backend-Container beenden, PostgreSQL läuft weiter |
+| `./dev.bat restart` | Backend-Container neu starten |
 | `./dev.bat restart --keep-db` | Neustart ohne PostgreSQL-Neustart |
-| `./dev.bat rebuild` | `target/` löschen + neu kompilieren + starten |
-| `./dev.bat rebuild --keep-db` | Rebuild ohne PostgreSQL-Neustart |
+| `./dev.bat rebuild` | Alle Container neu bauen (kein Layer-Cache) + starten |
+| `./dev.bat rebuild --keep-db` | Rebuild Backend ohne PostgreSQL-Neustart |
 
 > **Wann `./dev.bat rebuild` statt `./dev.bat restart`?**
-> Änderungen an `application.properties` oder anderen Ressourcen werden beim normalen
-> Restart manchmal nicht übernommen, weil Maven den kompilierten Cache in `target/`
-> wiederverwendet. `rebuild` löscht `target/` zuerst und erzwingt eine vollständige
-> Neukompilierung — z.B. nach Konfigurationsänderungen.
+> Nach Änderungen am `Dockerfile` oder wenn der Layer-Cache einen veralteten Stand hat.
+> Für normale Code-Änderungen reicht `restart`.
 
 ### Schritt 3 — Testdaten einspielen (einmalig)
-```powershell
-Get-Content src/main/resources/db/dev-seed.sql | docker exec -i webshop-postgres psql -U webshop -d webshop
+```bat
+docker exec -i webshop-postgres psql -U webshop -d webshop < src/main/resources/db/dev-seed.sql
 ```
 
 ### Schritt 4 — Verifizieren

--- a/dev.ps1
+++ b/dev.ps1
@@ -1,17 +1,18 @@
-# dev.ps1 - Start, stop, restart or rebuild the Spring Boot backend (incl. Docker/PostgreSQL)
+# dev.ps1 - Start, stop, restart or rebuild the Webshop backend via Docker
 # Usage:  ./dev.bat start   | stop | restart | rebuild
-#         ./dev.bat stop --keep-db     (keeps the PostgreSQL container running)
+#         ./dev.bat stop    --keep-db   (stop backend container, keep PostgreSQL running)
 #         ./dev.bat restart --keep-db
 #         ./dev.bat rebuild --keep-db
 #
-# How it works:
-#   start   -> docker compose up  ->  mvnw compile spring-boot:start  (blocks until app is ready)
-#   stop    -> mvnw spring-boot:stop  (graceful JMX shutdown)  ->  docker compose down
-#   restart -> stop + start
-#   rebuild -> stop + delete target/ + start  (forces full recompile)
+# Requirements: Docker Desktop (no Java or Maven needed locally)
 #
-# mvnw is called directly from PowerShell - NOT via cmd.exe - so paths with special
-# characters (e.g. ! in folder names) are handled correctly.
+# How it works:
+#   start   -> docker compose up -d --build
+#              (first run: Maven downloads ~200 MB of dependencies inside the container)
+#              Polls /api/health until the app responds, then prints the ready message.
+#   stop    -> docker compose down  (or stop only backend with --keep-db)
+#   restart -> stop backend + start backend
+#   rebuild -> docker compose up -d --build --force-recreate
 
 param(
     [Parameter(Mandatory)][ValidateSet("start","stop","restart","rebuild")]
@@ -21,49 +22,11 @@ param(
 
 $Root = $PSScriptRoot
 $Port = 8080
-
-# mvnw.cmd v3.3.2 no longer passes -Dmaven.multiModuleProjectDirectory to the JVM,
-# but Maven 3.9.x requires it. Setting it via MAVEN_OPTS is the official workaround.
-# PowerShell handles the path correctly even when it contains ! characters.
-$env:MAVEN_OPTS = "$($env:MAVEN_OPTS) -Dmaven.multiModuleProjectDirectory=`"$Root`"".Trim()
+$HealthUrl = "http://localhost:$Port/api/health"
 
 # --- helpers -----------------------------------------------------------------
 
-function Get-AppPid {
-    Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue |
-        Select-Object -ExpandProperty OwningProcess -First 1
-}
-
-function Initialize-MavenWrapper {
-    $wrapperJar = "$Root\.mvn\wrapper\maven-wrapper.jar"
-    if (Test-Path $wrapperJar) { return $true }
-
-    # mvnw.cmd has a bug: it sets WRAPPER_URL inside a cmd.exe block, but %WRAPPER_URL%
-    # is expanded at parse-time (before the FOR loop runs), so the URL is always empty.
-    # We download the JAR correctly from PowerShell instead.
-    $wrapperUrl = Get-Content "$Root\.mvn\wrapper\maven-wrapper.properties" |
-        Where-Object { $_ -match "^wrapperUrl=" } |
-        ForEach-Object { ($_ -split "=", 2)[1].Trim() }
-
-    Write-Host "Maven wrapper JAR not found - downloading..."
-    try {
-        Invoke-WebRequest -Uri $wrapperUrl -OutFile $wrapperJar -UseBasicParsing
-        Write-Host "Maven wrapper JAR downloaded."
-        return $true
-    } catch {
-        Write-Host "ERROR: Download failed: $_"
-        Write-Host "  Manual fix:"
-        Write-Host "  Invoke-WebRequest -Uri '$wrapperUrl' -OutFile '.mvn\wrapper\maven-wrapper.jar'"
-        return $false
-    }
-}
-
-function Test-Prerequisites {
-    if (-not (Get-Command java -ErrorAction SilentlyContinue)) {
-        Write-Host "ERROR: 'java' not found in PATH."
-        Write-Host "  Install Java 21: https://adoptium.net"
-        return $false
-    }
+function Test-DockerRunning {
     docker info 2>$null | Out-Null
     if ($LASTEXITCODE -ne 0) {
         Write-Host "ERROR: Docker is not running. Start Docker Desktop and retry."
@@ -72,38 +35,41 @@ function Test-Prerequisites {
     return $true
 }
 
-function Wait-ForPostgres {
-    Write-Host "Waiting for PostgreSQL to be healthy..." -NoNewline
-    for ($i = 0; $i -lt 30; $i++) {
-        $health = docker inspect "--format={{.State.Health.Status}}" webshop-postgres 2>$null
-        if ($health -eq "healthy") { Write-Host " ready."; return $true }
+function Wait-ForBackend {
+    Write-Host "Waiting for backend to be ready..." -NoNewline
+    for ($i = 0; $i -lt 90; $i++) {
+        try {
+            $response = Invoke-WebRequest -Uri $HealthUrl -UseBasicParsing -TimeoutSec 2 -ErrorAction Stop
+            if ($response.StatusCode -eq 200) {
+                Write-Host " ready."
+                return $true
+            }
+        } catch {
+            # not ready yet
+        }
         Write-Host -NoNewline "."
         Start-Sleep -Seconds 2
     }
     Write-Host " timed out!"
+    Write-Host "Check container logs: docker logs webshop-backend"
     return $false
+}
+
+function Show-SeedHint {
+    Write-Host ""
+    Write-Host "--- Seed data (optional, run once) ---"
+    Write-Host "  docker exec -i webshop-postgres psql -U webshop -d webshop < src/main/resources/db/dev-seed.sql"
+    Write-Host ""
 }
 
 # --- stop --------------------------------------------------------------------
 
 function Stop-Backend {
-    $appPid = Get-AppPid
-    if ($appPid) {
-        Write-Host "Stopping Spring Boot..."
-        # Graceful shutdown via the Maven plugin (uses JMX internally)
-        & "$Root\mvnw.cmd" spring-boot:stop --quiet
-        if ($LASTEXITCODE -ne 0) {
-            # Fallback: kill the Java process that owns port 8080
-            Write-Host "JMX stop failed - killing process $appPid..."
-            Stop-Process -Id $appPid -Force -ErrorAction SilentlyContinue
-        }
-        Write-Host "Spring Boot stopped."
+    if ($KeepDb) {
+        Write-Host "Stopping backend container (keeping PostgreSQL running)..."
+        docker compose -f "$Root\docker-compose.yml" stop backend
     } else {
-        Write-Host "Spring Boot is not running."
-    }
-
-    if (-not $KeepDb) {
-        Write-Host "Stopping PostgreSQL container..."
+        Write-Host "Stopping all containers..."
         docker compose -f "$Root\docker-compose.yml" down
     }
 }
@@ -111,72 +77,59 @@ function Stop-Backend {
 # --- start -------------------------------------------------------------------
 
 function Start-Backend {
-    if (Get-AppPid) {
-        Write-Host "Spring Boot is already running on port $Port. Use './dev.bat stop' first."
-        return
-    }
+    if (-not (Test-DockerRunning)) { return }
 
-    if (-not (Test-Prerequisites)) { return }
-    if (-not (Initialize-MavenWrapper)) { return }
-
-    # Start PostgreSQL if not already running
-    $containerState = docker inspect "--format={{.State.Status}}" webshop-postgres 2>$null
-    if ($containerState -ne "running") {
-        Write-Host "Starting PostgreSQL container..."
-        docker compose -f "$Root\docker-compose.yml" up -d
-    } else {
-        Write-Host "PostgreSQL container already running."
-    }
-
-    if (-not (Wait-ForPostgres)) {
-        Write-Host "ERROR: PostgreSQL did not become healthy. Aborting."
-        return
-    }
-
-    # spring-boot:start forks Spring Boot into a background JVM, then BLOCKS here
-    # until the application context is fully loaded (via JMX handshake).
-    # Maven output (downloads, compilation, Spring Boot startup logs) is printed
-    # directly to this terminal. Returns only when the app is ready - or fails.
-    #
-    # First run: Maven downloads ~200 MB of dependencies. This can take several
-    # minutes. Subsequent runs use the local ~/.m2 cache and start in ~20 seconds.
     Write-Host ""
-    Write-Host "Starting Spring Boot (first run downloads dependencies - may take a few minutes)..."
+    Write-Host "Building and starting backend..."
+    Write-Host "(First run: Maven downloads dependencies inside the container - may take a few minutes)"
     Write-Host "-------------------------------------------------------------------------------"
-    # compile is required before spring-boot:start (unlike spring-boot:run, start does not compile)
-    & "$Root\mvnw.cmd" compile spring-boot:start
 
-    if ($LASTEXITCODE -eq 0) {
+    if ($KeepDb) {
+        # PostgreSQL is already running - only start/rebuild the backend service
+        docker compose -f "$Root\docker-compose.yml" up -d --build backend
+    } else {
+        docker compose -f "$Root\docker-compose.yml" up -d --build
+    }
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "ERROR: docker compose up failed."
+        return
+    }
+
+    if (Wait-ForBackend) {
         Write-Host "-------------------------------------------------------------------------------"
         Write-Host "Backend is up at     http://localhost:$Port"
         Write-Host "Swagger UI:          http://localhost:$Port/swagger-ui/index.html"
-        Write-Host ""
+        Show-SeedHint
         Write-Host "Run './dev.bat stop' to shut down."
-    } else {
-        Write-Host "-------------------------------------------------------------------------------"
-        Write-Host "ERROR: Spring Boot failed to start (exit code $LASTEXITCODE)."
-        Write-Host "Scroll up to see the error in the Maven output above."
     }
 }
 
 # --- rebuild -----------------------------------------------------------------
 
-function Reset-Backend {
-    Stop-Backend
+function Rebuild-Backend {
+    Write-Host "Forcing full rebuild (no layer cache)..."
+    if (-not (Test-DockerRunning)) { return }
 
-    Write-Host "Deleting target/ (forces full recompile)..."
-    $targetPath = "$Root\target"
-    if (Test-Path $targetPath) {
-        Remove-Item -Recurse -Force $targetPath -ErrorAction SilentlyContinue
-        if (Test-Path $targetPath) {
-            Write-Host "WARNING: Could not fully delete target/ (OneDrive lock?). Continuing anyway."
-        } else {
-            Write-Host "target/ deleted."
-        }
+    if ($KeepDb) {
+        docker compose -f "$Root\docker-compose.yml" up -d --build --force-recreate backend
+    } else {
+        docker compose -f "$Root\docker-compose.yml" down
+        docker compose -f "$Root\docker-compose.yml" up -d --build --force-recreate
     }
 
-    Start-Sleep -Seconds 1
-    Start-Backend
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "ERROR: docker compose rebuild failed."
+        return
+    }
+
+    if (Wait-ForBackend) {
+        Write-Host "-------------------------------------------------------------------------------"
+        Write-Host "Backend is up at     http://localhost:$Port"
+        Write-Host "Swagger UI:          http://localhost:$Port/swagger-ui/index.html"
+        Show-SeedHint
+        Write-Host "Run './dev.bat stop' to shut down."
+    }
 }
 
 # --- dispatch ----------------------------------------------------------------
@@ -185,5 +138,5 @@ switch ($Command) {
     "start"   { Start-Backend }
     "stop"    { Stop-Backend }
     "restart" { Stop-Backend; Start-Sleep -Seconds 1; Start-Backend }
-    "rebuild" { Reset-Backend }
+    "rebuild" { Rebuild-Backend }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,5 +16,23 @@ services:
       timeout: 5s
       retries: 5
 
+  backend:
+    build: .
+    container_name: webshop-backend
+    ports:
+      - "8080:8080"
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/webshop
+      SPRING_DATASOURCE_USERNAME: webshop
+      SPRING_DATASOURCE_PASSWORD: ${DB_PASSWORD:-localdev}
+      APP_JWT_SECRET: ${JWT_SECRET:-fallback-secret-change-in-production-32chars}
+      APP_CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-http://localhost:5173}
+      SPRING_MAIL_HOST: ${MAIL_HOST:-localhost}
+      SPRING_MAIL_PORT: ${MAIL_PORT:-1025}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+
 volumes:
   postgres_data:


### PR DESCRIPTION
## Summary
- Adds `Dockerfile` (multi-stage build: Maven compiles in container → minimal JRE runtime image)
- Adds `.dockerignore`
- Extends `docker-compose.yml` with `backend` service that depends on `postgres` healthcheck
- Rewrites `dev.ps1`: removes all Java/Maven host requirements, uses `docker compose up/down`
- Updates `README.md`: sole requirement is now Docker Desktop, updated seed command and all dev script documentation

## After this PR
```bash
./dev.bat start   # builds and starts everything — no Java needed locally
```

## Test plan
- [ ] `./dev.bat start` builds image and starts backend + postgres
- [ ] `http://localhost:8080/api/health` returns `{"status":"UP"}`
- [ ] `http://localhost:8080/swagger-ui/index.html` is accessible
- [ ] Seed data loads: `docker exec -i webshop-postgres psql -U webshop -d webshop < src/main/resources/db/dev-seed.sql`
- [ ] Login with `alice` / `Password1!` returns JWT
- [ ] `./dev.bat stop` shuts down all containers
- [ ] `./dev.bat stop --keep-db` stops only backend, postgres keeps running
- [ ] `./dev.bat rebuild` forces full rebuild (no layer cache)
- [ ] Works on a machine without Java installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)