### PR TITLE
docs: API-Dokumentation für alle Frontend-Milestones

### DIFF
--- a/docs/ROLLEN.md
+++ b/docs/ROLLEN.md
@@ -1,0 +1,217 @@
+# Rollenkonzept — Webshop Backend
+
+Diese Datei ist die **kanonische Rollenreferenz** für das Gesamtprojekt.
+Jede Milestone-Dokumentation verweist hierher für die vollständige Berechtigungsmatrix.
+
+---
+
+## Zwei unabhängige Konzepte
+
+Das Backend unterscheidet zwei orthogonale Konzepte am User-Objekt:
+
+| Feld | Typ | Bedeutung |
+|------|-----|-----------|
+| `role` | `UserRole` | **Berechtigung** — was darf dieser User? |
+| `userType` | `UserType` | **Kundenart** — B2C oder B2B? (nur für CUSTOMERs relevant) |
+
+---
+
+## Rollen (`role`)
+
+| Rolle | Wert (String) | Wer | Registrierung möglich? |
+|-------|--------------|-----|------------------------|
+| Kunde | `CUSTOMER` | Endkunden (Privat & Business) | **Ja** — automatisch bei `POST /api/auth/register` |
+| Mitarbeiter | `EMPLOYEE` | Internes Personal (Lager, Support) | Nein — nur per Admin oder direkt in DB |
+| Vertriebsmitarbeiter | `SALES_EMPLOYEE` | Vertriebsteam | Nein — nur per Admin oder direkt in DB |
+| Administrator | `ADMIN` | Systemadministrator | Nein — nur per Admin oder direkt in DB |
+
+> **Wichtig:** Die Rolle wird vom Backend vergeben, nie vom Frontend gesetzt.
+> Jeder der sich über `/api/auth/register` registriert, bekommt automatisch `CUSTOMER`.
+> Die einzige Ausnahme ist der Admin-Impersonation-Endpunkt, der einen Token mit der Rolle des Zielnutzers ausstellt.
+
+---
+
+## Kundenart (`userType`)
+
+| Wert | Bedeutung | Wählbar bei Registrierung? |
+|------|-----------|---------------------------|
+| `PRIVATE` | Privatkunde (B2C) | Ja |
+| `BUSINESS` | Unternehmenskunde (B2B) | Ja |
+
+`userType` ist nur für `CUSTOMER`-Nutzer semantisch relevant. Mitarbeiter, Vertrieb und Admins
+haben technisch auch einen `userType`, dieser hat aber keine geschäftliche Bedeutung.
+
+---
+
+## Vollständige Endpunkt-Berechtigungsmatrix
+
+### Auth
+
+| Methode | Endpunkt | Berechtigung | Beschreibung |
+|---------|----------|--------------|--------------|
+| POST | `/api/auth/login` | Public | Login → JWT-Token + User-Info |
+| POST | `/api/auth/register` | Public | Registrierung → JWT-Token + User-Info (Rolle immer CUSTOMER) |
+| POST | `/api/auth/logout` | Authenticated | Token blacklisten |
+
+### Produkte
+
+| Methode | Endpunkt | Berechtigung | Beschreibung |
+|---------|----------|--------------|--------------|
+| GET | `/api/products` | Public | Produktliste (Filter: `purchasable`, `category`, `search`) |
+| GET | `/api/products/{id}` | Public | Einzelnes Produkt |
+| GET | `/api/products/{id}/price-for-customer` | CUSTOMER | Preis nach Kundenrabatten |
+| POST | `/api/products` | EMPLOYEE, SALES_EMPLOYEE, ADMIN | Produkt anlegen |
+| DELETE | `/api/products/{id}` | EMPLOYEE, SALES_EMPLOYEE, ADMIN | Produkt löschen |
+| PUT | `/api/products/{id}/purchasable` | EMPLOYEE, SALES_EMPLOYEE, ADMIN | Kaufbar-Flag setzen |
+| PUT | `/api/products/{id}/description` | EMPLOYEE, SALES_EMPLOYEE, ADMIN | Beschreibung bearbeiten |
+| PUT | `/api/products/{id}/image` | EMPLOYEE, SALES_EMPLOYEE, ADMIN | Bild-URL setzen |
+| PUT | `/api/products/{id}/price` | SALES_EMPLOYEE, ADMIN | UVP bearbeiten |
+| PUT | `/api/products/{id}/promoted` | SALES_EMPLOYEE, ADMIN | Promoted-Flag setzen |
+| GET | `/api/products/{id}/statistics` | SALES_EMPLOYEE, ADMIN | Verkaufsstatistiken |
+
+### Warenkorb
+
+| Methode | Endpunkt | Berechtigung | Beschreibung |
+|---------|----------|--------------|--------------|
+| GET | `/api/cart` | CUSTOMER | Eigenen Warenkorb einsehen |
+| POST | `/api/cart/items` | CUSTOMER | Artikel in Warenkorb legen |
+| DELETE | `/api/cart/items/{productId}` | CUSTOMER | Artikel aus Warenkorb entfernen |
+| POST | `/api/cart/reorder/{orderId}` | CUSTOMER | Artikel aus alter Bestellung in Warenkorb legen |
+
+### Bestellungen
+
+| Methode | Endpunkt | Berechtigung | Beschreibung |
+|---------|----------|--------------|--------------|
+| GET | `/api/orders` | CUSTOMER | Eigene Bestellhistorie |
+| GET | `/api/orders/{id}` | CUSTOMER | Einzelne Bestellung |
+| POST | `/api/orders` | CUSTOMER | Warenkorb bestellen |
+
+### Benutzerprofil
+
+| Methode | Endpunkt | Berechtigung | Beschreibung |
+|---------|----------|--------------|--------------|
+| GET | `/api/users/me` | Authenticated | Eigenes Profil (inkl. Kundennummer) |
+| PUT | `/api/users/me/password` | Authenticated | Passwort ändern |
+| PUT | `/api/users/me/email` | Authenticated | E-Mail ändern |
+| DELETE | `/api/users/me` | Authenticated | Account deaktivieren (Soft-Delete) |
+| PUT | `/api/users/me/delivery-address` | Authenticated | Lieferadresse speichern/ersetzen |
+| PUT | `/api/users/me/payment-method` | Authenticated | Zahlungsart speichern/ersetzen |
+
+### Daueraufträge *(Standing Orders)*
+
+| Methode | Endpunkt | Berechtigung | Beschreibung |
+|---------|----------|--------------|--------------|
+| GET | `/api/standing-orders` | CUSTOMER | Eigene Daueraufträge |
+| POST | `/api/standing-orders` | CUSTOMER | Dauerauftrag erstellen |
+| PUT | `/api/standing-orders/{id}` | CUSTOMER | Dauerauftrag ändern |
+| DELETE | `/api/standing-orders/{id}` | CUSTOMER | Dauerauftrag stornieren |
+
+### Kundenverwaltung (Mitarbeiter-Endpunkte)
+
+| Methode | Endpunkt | Berechtigung | Beschreibung |
+|---------|----------|--------------|--------------|
+| GET | `/api/customers` | EMPLOYEE, SALES_EMPLOYEE, ADMIN | Alle Kunden (Filter: `search`) |
+| GET | `/api/customers/{id}` | EMPLOYEE, SALES_EMPLOYEE, ADMIN | Einzelner Kunde |
+| GET | `/api/customers/{id}/cart` | EMPLOYEE, SALES_EMPLOYEE, ADMIN | Warenkorb eines Kunden einsehen |
+| POST | `/api/customers/{id}/cart/items` | EMPLOYEE, SALES_EMPLOYEE, ADMIN | Artikel für Kunden in Warenkorb legen |
+| DELETE | `/api/customers/{id}/cart/items/{productId}` | EMPLOYEE, SALES_EMPLOYEE, ADMIN | Artikel aus Kunden-Warenkorb entfernen |
+| GET | `/api/customers/{id}/orders` | SALES_EMPLOYEE, ADMIN | Bestellhistorie eines Kunden |
+| GET | `/api/customers/{id}/revenue` | SALES_EMPLOYEE, ADMIN | Umsatzstatistik eines Kunden |
+| POST | `/api/customers/{id}/discounts` | SALES_EMPLOYEE, ADMIN | Rabatt vergeben |
+| POST | `/api/customers/{id}/coupons` | SALES_EMPLOYEE, ADMIN | Coupon vergeben |
+| GET | `/api/customers/{id}/business-info` | SALES_EMPLOYEE, ADMIN | Unternehmenskunden-Daten |
+| POST | `/api/customers/{id}/email` | SALES_EMPLOYEE, ADMIN | E-Mail an Kunden senden |
+
+### Administration
+
+| Methode | Endpunkt | Berechtigung | Beschreibung |
+|---------|----------|--------------|--------------|
+| GET | `/api/admin/users` | ADMIN | Alle User (Filter: `search`) |
+| DELETE | `/api/admin/users/{id}` | ADMIN | User deaktivieren |
+| POST | `/api/admin/impersonate/{userId}` | ADMIN | Token im Namen eines Users ausstellen |
+| GET | `/api/admin/audit-log` | ADMIN | Vollständiges Audit-Log |
+
+---
+
+## Frontend-Integration
+
+### User-Objekt nach Login/Register (`useAuth()`)
+
+```js
+const { user } = useAuth();
+
+// user ist null wenn nicht eingeloggt
+user.id             // Long   — interne User-ID
+user.username       // String — z.B. "alice"
+user.email          // String — z.B. "alice@example.com"
+user.role           // String — 'CUSTOMER' | 'EMPLOYEE' | 'SALES_EMPLOYEE' | 'ADMIN'
+user.userType       // String — 'PRIVATE' | 'BUSINESS'
+user.customerNumber // String | null — z.B. "100001" (nur bei CUSTOMER gesetzt)
+```
+
+### Rollenbasiertes Rendering
+
+```jsx
+const { user } = useAuth();
+
+// Nur für eingeloggte Mitarbeiter (alle Staff-Rollen)
+const isStaff = ['EMPLOYEE', 'SALES_EMPLOYEE', 'ADMIN'].includes(user?.role);
+
+// Nur für Vertrieb + Admin
+const isSalesOrAdmin = ['SALES_EMPLOYEE', 'ADMIN'].includes(user?.role);
+
+// Beispiel: Bearbeitungs-Button nur für Staff anzeigen
+{isStaff && <Button label="Artikel bearbeiten" icon="pi pi-pencil" />}
+
+// Beispiel: Preis-Bearbeitung nur für Vertrieb/Admin
+{isSalesOrAdmin && <Button label="UVP ändern" icon="pi pi-euro" />}
+
+// Beispiel: Unternehmenskunden-spezifischer Bereich
+{user?.userType === 'BUSINESS' && <BusinessInfoSection />}
+```
+
+### Seiten schützen (`ProtectedRoute`)
+
+```jsx
+// In App.jsx — Seite nur für eingeloggte User:
+<Route path="/orders" element={
+  <ProtectedRoute><OrdersPage /></ProtectedRoute>
+} />
+```
+
+> Für rollenbasierte Route-Guards (z.B. `/admin` nur für ADMIN) den `role`-Check
+> innerhalb der Seite selbst vornehmen und bei falsche Rolle auf `/` redirecten.
+
+### Umgang mit 401 / 403
+
+- **401 Unauthorized**: Token abgelaufen oder ungültig → zu `/login` navigieren
+- **403 Forbidden**: Eingeloggt, aber falsche Rolle → Fehlermeldung anzeigen
+
+```jsx
+try {
+  const data = await apiFetch('/api/orders');
+} catch (err) {
+  if (err.message.includes('401')) navigate('/login');
+  else if (err.message.includes('403')) setError('Keine Berechtigung.');
+  else setError(err.message);
+}
+```
+
+---
+
+## Seed-User (lokale Entwicklung)
+
+Alle Passwörter: `Password1!`
+
+| Username | E-Mail | Rolle | UserType | Kundennummer |
+|----------|--------|-------|----------|--------------|
+| `alice` | alice@example.com | CUSTOMER | PRIVATE | 100001 |
+| `bob` | bob@example.com | CUSTOMER | BUSINESS | 100002 |
+| `carol` | carol@example.com | EMPLOYEE | PRIVATE | — |
+| `dave` | dave@example.com | SALES_EMPLOYEE | PRIVATE | — |
+| `admin` | admin@example.com | ADMIN | PRIVATE | — |
+
+Seed laden:
+```bash
+docker exec -i webshop-postgres psql -U webshop -d webshop < src/main/resources/db/dev-seed.sql
+```

--- a/docs/milestone-1-auth-benutzerverwaltung.md
+++ b/docs/milestone-1-auth-benutzerverwaltung.md
@@ -1,0 +1,282 @@
+# Milestone 1: Auth & Benutzerverwaltung
+
+> Vollständiges Rollenkonzept & Berechtigungsmatrix: [ROLLEN.md](./ROLLEN.md)
+
+**Issues:** #1, #2, #3, #4, #5, #6, #7, #9, #56, #57
+
+---
+
+## Beteiligte Rollen
+
+| Rolle | Relevanz in diesem Milestone |
+|-------|------------------------------|
+| (kein Login) | Kann sich registrieren und einloggen |
+| `CUSTOMER` | Alle Auth-Aktionen + Profilverwaltung |
+| `EMPLOYEE`, `SALES_EMPLOYEE`, `ADMIN` | Identische Auth-Aktionen wie CUSTOMER |
+
+> Die Profil-Endpunkte (`/api/users/me/*`) funktionieren für **alle** eingeloggten Rollen.
+
+---
+
+## User Stories → Endpunkte
+
+---
+
+### #1 — Benutzername und Passwort (Login)
+
+**Endpunkt:** `POST /api/auth/login`
+**Berechtigung:** Public
+
+**Request:**
+```json
+{
+  "username": "alice",
+  "password": "Password1!"
+}
+```
+
+**Response `200 OK`:**
+```json
+{
+  "token": "eyJhbGciOiJIUzI1NiJ9...",
+  "userId": 1,
+  "username": "alice",
+  "email": "alice@example.com",
+  "role": "CUSTOMER",
+  "userType": "PRIVATE",
+  "customerNumber": "100001"
+}
+```
+
+**Was das Backend macht:**
+- Prüft Benutzername + BCrypt-Passwort-Hash
+- Gibt einen signierten JWT zurück (24 Stunden gültig)
+- Bei falschem Passwort: `401 Unauthorized`
+
+**Frontend:**
+```js
+import { login } from '../api/auth';
+const data = await login(username, password);
+// data.token im localStorage speichern → useAuth() übernimmt das automatisch
+```
+
+---
+
+### #2 — E-Mail Registrierung
+
+**Endpunkt:** `POST /api/auth/register`
+**Berechtigung:** Public
+
+**Request:**
+```json
+{
+  "username": "maxmustermann",
+  "email": "max@example.com",
+  "password": "MeinPasswort1!",
+  "userType": "PRIVATE"
+}
+```
+
+Validierung (Backend):
+- `username`: 3–100 Zeichen, nicht leer
+- `email`: gültiges E-Mail-Format
+- `password`: mind. 8 Zeichen
+- `userType`: `"PRIVATE"` oder `"BUSINESS"` (Pflichtfeld)
+
+**Response `201 Created`:** Identisch mit Login-Response (Token + User-Info)
+
+**Was das Backend macht:**
+- Prüft ob Username/E-Mail bereits vergeben (`409 Conflict`)
+- Setzt Rolle immer auf `CUSTOMER` — unabhängig von der Eingabe
+- Vergibt automatisch eine Kundennummer (für CUSTOMER)
+
+---
+
+### #3 — Rollen
+
+Rollen werden **nie vom Frontend vergeben**. Der `userType` (PRIVATE/BUSINESS) wird bei der
+Registrierung übergeben. Die `role` (CUSTOMER) vergibt das Backend automatisch.
+
+**Frontend:** Das Registrierungsformular zeigt einen SelectButton für den Kundentyp:
+```jsx
+const USER_TYPE_OPTIONS = [
+  { label: 'Privatkunde', value: 'PRIVATE' },
+  { label: 'Unternehmenskunde', value: 'BUSINESS' },
+];
+```
+
+Nach dem Login enthält das User-Objekt beide Felder:
+```js
+user.role     // "CUSTOMER"
+user.userType // "PRIVATE" | "BUSINESS"
+```
+
+---
+
+### #9 — Kundennummer einsehen (als Kunde)
+
+**Endpunkt:** `GET /api/users/me`
+**Berechtigung:** Authenticated (jede Rolle)
+
+**Response `200 OK`:**
+```json
+{
+  "id": 1,
+  "username": "alice",
+  "email": "alice@example.com",
+  "role": "CUSTOMER",
+  "userType": "PRIVATE",
+  "customerNumber": "100001"
+}
+```
+
+> `customerNumber` ist nur bei `CUSTOMER`-Rolle gesetzt. Bei EMPLOYEE/ADMIN ist das Feld `null`.
+
+**Frontend:** Die Kundennummer ist bereits im Login-Response enthalten (`user.customerNumber`).
+Für eine dedizierte Profilseite kann `/api/users/me` aufgerufen werden.
+
+---
+
+### #4 — Passwort ändern
+
+**Endpunkt:** `PUT /api/users/me/password`
+**Berechtigung:** Authenticated
+
+**Request:**
+```json
+{
+  "currentPassword": "AltesPasswort1!",
+  "newPassword": "NeuesPasswort2!"
+}
+```
+
+Validierung: `newPassword` mind. 8 Zeichen
+
+**Response `204 No Content`** (kein Body bei Erfolg)
+
+**Fehler:**
+- `400 Bad Request`: altes Passwort falsch
+- `400 Bad Request`: neues Passwort zu kurz
+
+**Frontend-Hinweis:** Kein neuer Token wird ausgestellt — der bestehende Token bleibt gültig.
+
+---
+
+### #5 — E-Mail verändern
+
+**Endpunkt:** `PUT /api/users/me/email`
+**Berechtigung:** Authenticated
+
+**Request:**
+```json
+{
+  "newEmail": "neue@email.de"
+}
+```
+
+**Response `204 No Content`**
+
+**Fehler:** `409 Conflict` wenn E-Mail bereits vergeben
+
+**Frontend:** Nach Erfolg den User-State im AuthContext aktualisieren:
+```js
+updateUserEmail('neue@email.de');
+```
+
+---
+
+### #6 — Abmelden von Benutzer
+
+**Endpunkt:** `POST /api/auth/logout`
+**Berechtigung:** Authenticated (Bearer-Token im Header)
+
+**Request:** Kein Body — Token kommt aus dem `Authorization`-Header
+
+**Response `204 No Content`**
+
+**Was das Backend macht:**
+- Trägt den Token in eine Blacklist ein → Token kann nicht mehr genutzt werden
+- Auch nach Ablauf der 24h-Gültigkeit ist der Token damit sofort ungültig
+
+**Frontend-Hinweis:** Selbst wenn der Backend-Call fehlschlägt, muss der Token lokal gelöscht werden.
+Das ist bereits in `AuthContext.logout()` so implementiert.
+
+---
+
+### #7 — Deregistrieren vom System
+
+**Endpunkt:** `DELETE /api/users/me`
+**Berechtigung:** Authenticated
+
+**Request:** Kein Body
+
+**Response `204 No Content`**
+
+**Was das Backend macht:**
+- Setzt `active = false` am User (Soft-Delete — Daten bleiben erhalten)
+- Nach der Deaktivierung: Login mit diesem Account schlägt fehl
+
+**Frontend:** Nach Erfolg `logout()` aufrufen + zur Startseite navigieren.
+Immer mit Bestätigungsdialog absichern (PrimeReact `ConfirmDialog`).
+
+---
+
+### #56 / #57 — Datenschutz & Datensicherheit (NFR)
+
+Diese nicht-funktionalen Anforderungen werden durch die Architektur erfüllt:
+
+| Anforderung | Umsetzung |
+|-------------|-----------|
+| Passwörter nicht im Klartext | BCrypt-Hashing im Backend, nie im Frontend gespeichert |
+| Token sicher übertragen | JWT im `Authorization: Bearer`-Header, nie in der URL |
+| Seiten vor unbefugtem Zugriff schützen | `<ProtectedRoute>` in App.jsx wrappen |
+| Token nach Logout ungültig | Backend-Blacklist via `POST /api/auth/logout` |
+
+---
+
+## Frontend-Patterns für Milestone 1
+
+### Alle Auth-API-Funktionen
+
+```js
+import { login, logout, register, getMe, updatePassword, updateEmail, deleteAccount } from '../api/auth';
+```
+
+### Login-Flow
+
+```jsx
+import { useAuth } from '../context/AuthContext';
+import { useNavigate } from 'react-router-dom';
+
+const { login } = useAuth();
+const navigate = useNavigate();
+
+try {
+  await login(username, password); // speichert Token + setzt user-State
+  navigate('/');
+} catch (err) {
+  setError(err.message.includes('401') ? 'Zugangsdaten falsch.' : err.message);
+}
+```
+
+### Seite schützen
+
+```jsx
+// In App.jsx:
+import ProtectedRoute from './components/auth/ProtectedRoute';
+
+<Route path="/profile" element={
+  <ProtectedRoute><ProfilePage /></ProtectedRoute>
+} />
+```
+
+### Role-Check auf einer Seite
+
+```jsx
+const { user } = useAuth();
+
+// Redirect wenn falsche Rolle
+useEffect(() => {
+  if (user && user.role !== 'CUSTOMER') navigate('/');
+}, [user]);
+```

--- a/docs/milestone-2-produktkatalog.md
+++ b/docs/milestone-2-produktkatalog.md
@@ -1,0 +1,311 @@
+# Milestone 2: Produktkatalog
+
+> Vollständiges Rollenkonzept & Berechtigungsmatrix: [ROLLEN.md](./ROLLEN.md)
+
+**Issues:** #8, #10, #13, #14, #15, #16, #17, #18, #20, #23, #25, #26, #28, #31, #46, #47
+
+---
+
+## Beteiligte Rollen
+
+| Rolle | Was sie im Produktkatalog darf |
+|-------|-------------------------------|
+| (kein Login) | Öffentliche Produktliste + Einzelansicht lesen |
+| `CUSTOMER` | Öffentliche Produktliste + kundenspezifischen Preis abrufen |
+| `EMPLOYEE` | Alle Produkte sehen + Artikel anlegen/löschen/kaufbar setzen/Beschreibung+Bild bearbeiten |
+| `SALES_EMPLOYEE` | Alles was EMPLOYEE darf + UVP bearbeiten + Promoted setzen + Verkaufsstatistiken |
+| `ADMIN` | Alle Rechte wie SALES_EMPLOYEE |
+
+---
+
+## User Stories → Endpunkte
+
+---
+
+### #8 — Gesamtes kaufbares Sortiment sehen (Kunde)
+### #46 — Sortiment nach Suchbegriffen filtern
+### #47 — Sortiment nach Kategorien filtern
+
+**Endpunkt:** `GET /api/products`
+**Berechtigung:** Public
+
+**Query-Parameter:**
+
+| Parameter | Typ | Beschreibung |
+|-----------|-----|--------------|
+| `purchasable` | boolean | `true` = nur kaufbare Artikel (für Kunden), `false` oder leer = alle |
+| `search` | string | Freitextsuche in Name + Beschreibung |
+| `category` | string | Exakte Kategorie (z.B. `Electronics`, `Furniture`) |
+
+**Beispiele:**
+```
+GET /api/products?purchasable=true                        → Nur kaufbare Artikel
+GET /api/products?purchasable=true&search=laptop          → Suche nach "laptop"
+GET /api/products?purchasable=true&category=Electronics   → Kategorie Electronics
+GET /api/products                                         → Alle (auch nicht-kaufbare)
+```
+
+**Response `200 OK`:**
+```json
+[
+  {
+    "id": 1,
+    "name": "Laptop Pro 15",
+    "description": "High-performance laptop with 15\" display",
+    "imageUrl": "https://placehold.co/400x300?text=Laptop",
+    "recommendedRetailPrice": 1299.99,
+    "category": "Electronics",
+    "purchasable": true,
+    "promoted": true,
+    "createdAt": "2026-04-01T10:00:00Z"
+  }
+]
+```
+
+**Frontend-Tipp:** Für die Kundenansicht immer `?purchasable=true` setzen.
+Für Mitarbeiteransicht (#10, #20) ohne den Parameter aufrufen.
+
+---
+
+### #23 — Produktbeschreibung sehen
+### #25 — Produktbild sehen
+### #28 — UVP sehen
+
+**Endpunkt:** `GET /api/products/{id}`
+**Berechtigung:** Public
+
+**Response `200 OK`:** Identisch mit dem einzelnen Objekt aus der Listenabfrage (alle Felder enthalten).
+
+```json
+{
+  "id": 1,
+  "name": "Laptop Pro 15",
+  "description": "High-performance laptop with 15\" display",
+  "imageUrl": "https://placehold.co/400x300?text=Laptop",
+  "recommendedRetailPrice": 1299.99,
+  "category": "Electronics",
+  "purchasable": true,
+  "promoted": false,
+  "createdAt": "2026-04-01T10:00:00Z"
+}
+```
+
+---
+
+### #31 — Preis mit Rabatten sehen (Kunde)
+
+**Endpunkt:** `GET /api/products/{id}/price-for-customer`
+**Berechtigung:** CUSTOMER
+
+**Response `200 OK`:**
+```json
+{
+  "productId": 2,
+  "recommendedRetailPrice": 29.99,
+  "effectivePrice": 26.99,
+  "discountPercent": 10.00
+}
+```
+
+**Was das Backend macht:**
+- Sucht alle aktiven Rabatte für diesen Kunden auf dieses Produkt
+- Berechnet den günstigsten Preis
+- Wenn kein Rabatt: `effectivePrice == recommendedRetailPrice`, `discountPercent == 0`
+
+**Frontend-Tipp:** Diesen Endpunkt auf der Produktdetailseite aufrufen wenn der User eingeloggt ist
+und die Rolle `CUSTOMER` hat. Für nicht eingeloggte User die UVP aus `GET /api/products/{id}` anzeigen.
+
+---
+
+### #13 — Artikel zum Sortiment hinzufügen (EMPLOYEE+)
+
+**Endpunkt:** `POST /api/products`
+**Berechtigung:** EMPLOYEE, SALES_EMPLOYEE, ADMIN
+
+**Request:**
+```json
+{
+  "name": "Neues Produkt",
+  "description": "Produktbeschreibung",
+  "imageUrl": "https://example.com/bild.jpg",
+  "recommendedRetailPrice": 49.99,
+  "category": "Electronics"
+}
+```
+
+Pflichtfelder: `name`, `recommendedRetailPrice` (mind. 0.01). Alle anderen optional.
+
+**Response `201 Created`:** Vollständiges Produkt-Objekt
+
+---
+
+### #14 — Artikel vom Sortiment entfernen (EMPLOYEE+)
+
+**Endpunkt:** `DELETE /api/products/{id}`
+**Berechtigung:** EMPLOYEE, SALES_EMPLOYEE, ADMIN
+
+**Response `204 No Content`**
+
+---
+
+### #15 — Artikel kaufbar markieren (EMPLOYEE+)
+
+**Endpunkt:** `PUT /api/products/{id}/purchasable`
+**Berechtigung:** EMPLOYEE, SALES_EMPLOYEE, ADMIN
+
+**Request:**
+```json
+{ "value": true }
+```
+
+**Response `200 OK`:** Aktualisiertes Produkt-Objekt
+
+---
+
+### #16 — Beschreibung bearbeiten (EMPLOYEE+)
+
+**Endpunkt:** `PUT /api/products/{id}/description`
+**Berechtigung:** EMPLOYEE, SALES_EMPLOYEE, ADMIN
+
+**Request:**
+```json
+{ "description": "Neue ausführliche Beschreibung des Produkts." }
+```
+
+**Response `200 OK`:** Aktualisiertes Produkt-Objekt
+
+---
+
+### #17 — Bild bearbeiten (EMPLOYEE+)
+
+**Endpunkt:** `PUT /api/products/{id}/image`
+**Berechtigung:** EMPLOYEE, SALES_EMPLOYEE, ADMIN
+
+**Request:**
+```json
+{ "imageUrl": "https://example.com/neues-bild.jpg" }
+```
+
+**Response `200 OK`:** Aktualisiertes Produkt-Objekt
+
+> Das Backend speichert nur die URL — kein Datei-Upload. Die Bild-URL muss extern gehostet sein.
+
+---
+
+### #18 — UVP bearbeiten (SALES_EMPLOYEE+)
+
+**Endpunkt:** `PUT /api/products/{id}/price`
+**Berechtigung:** SALES_EMPLOYEE, ADMIN
+
+**Request:**
+```json
+{ "recommendedRetailPrice": 59.99 }
+```
+
+**Response `200 OK`:** Aktualisiertes Produkt-Objekt
+
+---
+
+### #26 — Artikel promoten (SALES_EMPLOYEE+)
+
+**Endpunkt:** `PUT /api/products/{id}/promoted`
+**Berechtigung:** SALES_EMPLOYEE, ADMIN
+
+**Request:**
+```json
+{ "value": true }
+```
+
+**Response `200 OK`:** Aktualisiertes Produkt-Objekt
+
+**Frontend-Tipp:** Promoted-Artikel auf der Startseite/Landingpage hervorheben.
+Im Response-Objekt steht `"promoted": true/false`.
+
+---
+
+### #34 — Artikel-Verkaufsstatistiken (SALES_EMPLOYEE+)
+
+**Endpunkt:** `GET /api/products/{id}/statistics?from=YYYY-MM-DD&to=YYYY-MM-DD`
+**Berechtigung:** SALES_EMPLOYEE, ADMIN
+
+**Beispiel:**
+```
+GET /api/products/1/statistics?from=2026-01-01&to=2026-04-12
+```
+
+**Response `200 OK`:**
+```json
+{
+  "productId": 1,
+  "from": "2026-01-01",
+  "to": "2026-04-12",
+  "unitsSold": 47,
+  "totalRevenue": 61099.53
+}
+```
+
+---
+
+### #10, #20 — Sortiment als Mitarbeiter einsehen (inkl. nicht-kaufbarer Artikel)
+
+Kein eigener Endpunkt — `GET /api/products` ohne `purchasable`-Parameter aufrufen.
+Das gibt alle Produkte zurück, inklusive derer mit `"purchasable": false`.
+
+---
+
+## Frontend-Patterns für Milestone 2
+
+### Produktliste laden
+
+```jsx
+import { useState, useEffect } from 'react';
+import { apiFetch } from '../api/client';
+
+function ProductListPage() {
+  const [products, setProducts] = useState([]);
+  const { user } = useAuth();
+
+  useEffect(() => {
+    // Kunden sehen nur kaufbare, Mitarbeiter alle
+    const isStaff = ['EMPLOYEE', 'SALES_EMPLOYEE', 'ADMIN'].includes(user?.role);
+    const url = isStaff ? '/api/products' : '/api/products?purchasable=true';
+    apiFetch(url).then(setProducts).catch(console.error);
+  }, [user]);
+}
+```
+
+### Kundenpreis abrufen
+
+```jsx
+const { user } = useAuth();
+
+useEffect(() => {
+  if (user?.role === 'CUSTOMER') {
+    apiFetch(`/api/products/${productId}/price-for-customer`)
+      .then(setPriceInfo)
+      .catch(console.error);
+  }
+}, [productId, user]);
+```
+
+### Bearbeitungs-Buttons nur für Staff
+
+```jsx
+const isStaff = ['EMPLOYEE', 'SALES_EMPLOYEE', 'ADMIN'].includes(user?.role);
+const isSalesOrAdmin = ['SALES_EMPLOYEE', 'ADMIN'].includes(user?.role);
+
+{isStaff && (
+  <>
+    <Button label="Beschreibung bearbeiten" onClick={handleEditDescription} />
+    <Button label="Bild ändern" onClick={handleEditImage} />
+    <Button label="Kaufbar" onClick={() => togglePurchasable(product.id)} />
+  </>
+)}
+
+{isSalesOrAdmin && (
+  <>
+    <Button label="UVP bearbeiten" onClick={handleEditPrice} />
+    <Button label="Promoten" onClick={() => togglePromoted(product.id)} />
+  </>
+)}
+```

--- a/docs/milestone-3-warenkorb-checkout.md
+++ b/docs/milestone-3-warenkorb-checkout.md
@@ -1,0 +1,250 @@
+# Milestone 3: Warenkorb & Checkout
+
+> Vollständiges Rollenkonzept & Berechtigungsmatrix: [ROLLEN.md](./ROLLEN.md)
+
+**Issues:** #39, #40, #41, #42, #44, #45
+
+---
+
+## Beteiligte Rollen
+
+| Rolle | Relevanz |
+|-------|----------|
+| `CUSTOMER` | Alle Warenkorb- und Checkout-Funktionen |
+| `EMPLOYEE`, `SALES_EMPLOYEE`, `ADMIN` | Warenkorb-Verwaltung für Kunden → siehe [Milestone 8](./milestone-8-kundenservice.md) |
+
+---
+
+## User Stories → Endpunkte
+
+---
+
+### #41 — Warenkorbübersicht (Preis, Steuern, Versand)
+
+**Endpunkt:** `GET /api/cart`
+**Berechtigung:** CUSTOMER
+
+**Response `200 OK`:**
+```json
+{
+  "items": [
+    {
+      "cartItemId": 1,
+      "productId": 2,
+      "productName": "Wireless Mouse",
+      "imageUrl": "https://placehold.co/400x300?text=Mouse",
+      "unitPrice": 26.99,
+      "quantity": 2,
+      "lineTotal": 53.98,
+      "addedAt": "2026-04-10T14:30:00Z"
+    }
+  ],
+  "subtotal": 53.98,
+  "tax": 8.64,
+  "shippingCost": 0.00,
+  "total": 62.62
+}
+```
+
+**Was das Backend macht:**
+- `unitPrice` enthält bereits den kundenspezifischen Preis (nach Rabatten)
+- Steuern und Versandkosten werden serverseitig berechnet
+
+---
+
+### #39 — Artikel in Warenkorb legen
+
+**Endpunkt:** `POST /api/cart/items`
+**Berechtigung:** CUSTOMER
+
+**Request:**
+```json
+{
+  "productId": 2,
+  "quantity": 1
+}
+```
+
+Validierung: `quantity` mind. 1
+
+**Response `200 OK`:** Aktualisierter Warenkorb (CartResponse — identisch mit GET /api/cart)
+
+**Was das Backend macht:**
+- Wenn der Artikel bereits im Warenkorb: Menge wird addiert
+- Nur kaufbare Produkte (`purchasable = true`) können hinzugefügt werden
+
+---
+
+### #40 — Artikel aus Warenkorb entfernen
+
+**Endpunkt:** `DELETE /api/cart/items/{productId}`
+**Berechtigung:** CUSTOMER
+
+**Response `200 OK`:** Aktualisierter Warenkorb
+
+> Der Pfad-Parameter ist die **Produkt-ID**, nicht die `cartItemId`.
+
+---
+
+### #42 — Warenkorb bestellen
+
+**Endpunkt:** `POST /api/orders`
+**Berechtigung:** CUSTOMER
+
+**Request (optional):**
+```json
+{
+  "couponCode": "WELCOME10"
+}
+```
+
+Body kann auch leer sein (kein Coupon):
+```json
+{}
+```
+
+**Response `201 Created`:**
+```json
+{
+  "id": 42,
+  "status": "PROCESSING",
+  "totalPrice": 56.21,
+  "taxAmount": 7.78,
+  "shippingCost": 0.00,
+  "couponCode": "WELCOME10",
+  "createdAt": "2026-04-12T09:15:00Z",
+  "items": [
+    {
+      "orderItemId": 1,
+      "productId": 2,
+      "productName": "Wireless Mouse",
+      "productPurchasable": true,
+      "quantity": 2,
+      "priceAtOrderTime": 26.99,
+      "lineTotal": 53.98
+    }
+  ]
+}
+```
+
+**Was das Backend macht:**
+- Übernimmt alle Artikel aus dem Warenkorb
+- Wendet Coupon-Rabatt an (wenn gültig)
+- Speichert `priceAtOrderTime` (Preis zum Zeitpunkt der Bestellung — ändert sich nie mehr)
+- Leert den Warenkorb nach erfolgreicher Bestellung
+
+**Mögliche Fehler:**
+- `400 Bad Request`: Warenkorb leer
+- `400 Bad Request`: Coupon ungültig oder bereits verwendet
+- `400 Bad Request`: Ein Artikel ist nicht mehr kaufbar
+
+---
+
+### #44 — Zahlungsart sicher speichern/auswählen
+
+**Endpunkt:** `PUT /api/users/me/payment-method`
+**Berechtigung:** Authenticated
+
+**Request:**
+```json
+{
+  "methodType": "SEPA_DIRECT_DEBIT",
+  "maskedDetails": "DE89****4321"
+}
+```
+
+Verfügbare `methodType`-Werte: `SEPA_DIRECT_DEBIT`, `CREDIT_CARD`, `PAYPAL`
+*(genaue Liste → `PaymentMethodType`-Enum im Backend)*
+
+**Response `204 No Content`**
+
+**Was das Backend macht:**
+- Speichert immer nur die **maskierten** Zahlungsdaten (keine echten Kartennummern)
+- Ersetzt eine eventuell vorhandene Zahlungsart (1 Zahlungsart pro User)
+
+> Das Backend speichert bewusst nur maskierte Details — echte Zahlungsabwicklung
+> würde einen Payment-Provider (Stripe, etc.) erfordern, der hier nicht integriert ist.
+
+---
+
+### #45 — Lieferadresse sicher speichern/auswählen
+
+**Endpunkt:** `PUT /api/users/me/delivery-address`
+**Berechtigung:** Authenticated
+
+**Request:**
+```json
+{
+  "street": "Hauptstraße 1",
+  "city": "Bielefeld",
+  "postalCode": "33602",
+  "country": "Germany"
+}
+```
+
+**Response `204 No Content`**
+
+**Was das Backend macht:**
+- Ersetzt eine eventuell vorhandene Lieferadresse (1 Adresse pro User)
+
+---
+
+## Frontend-Patterns für Milestone 3
+
+### Warenkorb laden und anzeigen
+
+```jsx
+import { useEffect, useState } from 'react';
+import { apiFetch } from '../api/client';
+
+function CartPage() {
+  const [cart, setCart] = useState(null);
+
+  useEffect(() => {
+    apiFetch('/api/cart').then(setCart).catch(console.error);
+  }, []);
+
+  async function handleRemove(productId) {
+    const updated = await apiFetch(`/api/cart/items/${productId}`, { method: 'DELETE' });
+    setCart(updated);
+  }
+
+  async function handleOrder(couponCode) {
+    const body = couponCode ? { couponCode } : {};
+    const order = await apiFetch('/api/orders', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+    // Weiterleitung zu Bestellbestätigung
+    navigate(`/orders/${order.id}`);
+  }
+}
+```
+
+### Artikel zum Warenkorb hinzufügen (von Produktseite)
+
+```jsx
+async function handleAddToCart(productId) {
+  try {
+    await apiFetch('/api/cart/items', {
+      method: 'POST',
+      body: JSON.stringify({ productId, quantity: 1 }),
+    });
+    // Erfolgs-Feedback (Toast o.ä.)
+  } catch (err) {
+    setError(err.message);
+  }
+}
+```
+
+### Zahlungsart speichern
+
+```jsx
+await apiFetch('/api/users/me/payment-method', {
+  method: 'PUT',
+  body: JSON.stringify({
+    methodType: 'SEPA_DIRECT_DEBIT',
+    maskedDetails: 'DE89****4321',
+  }),
+});
+```

--- a/docs/milestone-4-bestellhistorie.md
+++ b/docs/milestone-4-bestellhistorie.md
@@ -1,0 +1,214 @@
+# Milestone 4: Bestellhistorie & Daueraufträge
+
+> Vollständiges Rollenkonzept & Berechtigungsmatrix: [ROLLEN.md](./ROLLEN.md)
+
+**Issues:** #48, #49, #50, #51, #52, #53, #55
+
+---
+
+## Beteiligte Rollen
+
+| Rolle | Relevanz |
+|-------|----------|
+| `CUSTOMER` | Eigene Bestellhistorie + Daueraufträge verwalten |
+| `SALES_EMPLOYEE`, `ADMIN` | Bestellhistorie von Kunden einsehen → [Milestone 5](./milestone-5-crm-vertrieb.md) |
+
+---
+
+## User Stories → Endpunkte
+
+---
+
+### #48 — Frühere Bestellungen einsehen
+
+**Endpunkt:** `GET /api/orders`
+**Berechtigung:** CUSTOMER
+
+**Response `200 OK`:**
+```json
+[
+  {
+    "id": 42,
+    "status": "DELIVERED",
+    "totalPrice": 35.69,
+    "taxAmount": 5.70,
+    "shippingCost": 0.00,
+    "couponCode": null,
+    "createdAt": "2026-03-15T08:30:00Z",
+    "items": [
+      {
+        "orderItemId": 1,
+        "productId": 2,
+        "productName": "Wireless Mouse",
+        "productPurchasable": true,
+        "quantity": 1,
+        "priceAtOrderTime": 29.99,
+        "lineTotal": 29.99
+      }
+    ]
+  }
+]
+```
+
+Mögliche `status`-Werte: `PROCESSING`, `SHIPPED`, `DELIVERED`, `CANCELLED`
+
+---
+
+### #49 — Kaufbare Artikel in alten Bestellungen erkennen
+
+**Endpunkt:** `GET /api/orders/{id}`
+**Berechtigung:** CUSTOMER
+
+**Response:** Identisch mit einem Element aus der Listabfrage.
+
+**Was das Backend macht:**
+- Das Feld `productPurchasable` zeigt den **aktuellen** Kaufbar-Status des Artikels
+- Wenn `productPurchasable: false` → Artikel kann nicht erneut bestellt werden
+
+**Frontend-Tipp:** Den "Erneut bestellen"-Button nur anzeigen wenn alle Artikel
+in der Bestellung `productPurchasable: true` haben (oder item-by-item prüfen).
+
+---
+
+### #50 — Artikel aus alter Bestellung erneut in Warenkorb legen
+
+**Endpunkt:** `POST /api/cart/reorder/{orderId}`
+**Berechtigung:** CUSTOMER
+
+**Request:** Kein Body
+
+**Response `200 OK`:** Aktualisierter Warenkorb (CartResponse)
+
+**Was das Backend macht:**
+- Fügt alle Artikel aus der Bestellung, die noch **kaufbar** sind, in den Warenkorb
+- Nicht mehr kaufbare Artikel werden übersprungen (kein Fehler)
+- Existierende Warenkorb-Artikel werden nicht überschrieben (Menge wird addiert)
+
+---
+
+### #51 — Dauerauftrag erstellen
+
+**Endpunkt:** `POST /api/standing-orders`
+**Berechtigung:** CUSTOMER
+
+**Request:**
+```json
+{
+  "intervalDays": 30,
+  "firstExecutionDate": "2026-05-01",
+  "items": [
+    { "productId": 2, "quantity": 3 },
+    { "productId": 4, "quantity": 1 }
+  ]
+}
+```
+
+Validierung: `intervalDays` mind. 1, `items` nicht leer, `quantity` mind. 1
+
+**Response `201 Created`:**
+```json
+{
+  "id": 5,
+  "intervalDays": 30,
+  "nextExecutionDate": "2026-05-01",
+  "active": true,
+  "createdAt": "2026-04-12T10:00:00Z",
+  "items": [
+    { "id": 1, "productId": 2, "productName": "Wireless Mouse", "quantity": 3 },
+    { "id": 2, "productId": 4, "productName": "USB-C Hub", "quantity": 1 }
+  ]
+}
+```
+
+---
+
+### #52 — Dauerauftrag stornieren
+
+**Endpunkt:** `DELETE /api/standing-orders/{id}`
+**Berechtigung:** CUSTOMER
+
+**Response `204 No Content`**
+
+---
+
+### #53 — Dauerauftrag ändern
+
+**Endpunkt:** `PUT /api/standing-orders/{id}`
+**Berechtigung:** CUSTOMER
+
+**Request:**
+```json
+{
+  "intervalDays": 14,
+  "items": [
+    { "productId": 2, "quantity": 5 }
+  ]
+}
+```
+
+**Response `200 OK`:** Aktualisierter Dauerauftrag (StandingOrderResponse)
+
+---
+
+### #55 — Benachrichtigung bei nicht mehr verfügbarem Dauerauftrag-Artikel
+
+**Kein Frontend-Endpunkt nötig.** Das Backend versendet automatisch eine E-Mail
+wenn ein Artikel in einem aktiven Dauerauftrag auf `purchasable = false` gesetzt wird.
+
+**Frontend-Hinweis:** Beim Laden der Daueraufträge kann `GET /api/standing-orders` verwendet
+werden — in der Response steht `"active": false` wenn der Dauerauftrag deaktiviert wurde.
+
+---
+
+### Daueraufträge auflisten
+
+**Endpunkt:** `GET /api/standing-orders`
+**Berechtigung:** CUSTOMER
+
+**Response `200 OK`:** Array von StandingOrderResponse-Objekten (Struktur wie bei POST-Response)
+
+---
+
+## Frontend-Patterns für Milestone 4
+
+### Bestellhistorie laden
+
+```jsx
+useEffect(() => {
+  apiFetch('/api/orders').then(setOrders).catch(console.error);
+}, []);
+```
+
+### Erneut bestellen
+
+```jsx
+async function handleReorder(orderId) {
+  try {
+    const cart = await apiFetch(`/api/cart/reorder/${orderId}`, { method: 'POST' });
+    // Erfolg: zum Warenkorb navigieren
+    navigate('/cart');
+  } catch (err) {
+    setError(err.message);
+  }
+}
+```
+
+### Daueraufträge verwalten
+
+```jsx
+// Laden
+const standingOrders = await apiFetch('/api/standing-orders');
+
+// Erstellen
+const newOrder = await apiFetch('/api/standing-orders', {
+  method: 'POST',
+  body: JSON.stringify({
+    intervalDays: 30,
+    firstExecutionDate: '2026-05-01',
+    items: [{ productId: 2, quantity: 3 }],
+  }),
+});
+
+// Löschen
+await apiFetch(`/api/standing-orders/${id}`, { method: 'DELETE' });
+```

--- a/docs/milestone-5-crm-vertrieb.md
+++ b/docs/milestone-5-crm-vertrieb.md
@@ -1,0 +1,271 @@
+# Milestone 5: CRM & Vertrieb
+
+> Vollständiges Rollenkonzept & Berechtigungsmatrix: [ROLLEN.md](./ROLLEN.md)
+
+**Issues:** #24, #26, #27, #29, #33, #34, #35, #36, #37, #38, #43, #54
+
+---
+
+## Beteiligte Rollen
+
+| Rolle | Relevanz |
+|-------|----------|
+| `CUSTOMER` | Sieht seinen eigenen (rabattierten) Preis via `GET /api/products/{id}/price-for-customer` |
+| `SALES_EMPLOYEE` | Vollzugriff auf alle CRM-Funktionen |
+| `ADMIN` | Identische Rechte wie SALES_EMPLOYEE |
+
+---
+
+## User Stories → Endpunkte
+
+---
+
+### #27 — Bestellungen eines Kunden einsehen (Analyse)
+
+**Endpunkt:** `GET /api/customers/{id}/orders`
+**Berechtigung:** SALES_EMPLOYEE, ADMIN
+
+**Beispiel:** `GET /api/customers/1/orders`
+
+**Response `200 OK`:** Array von OrderResponse-Objekten (identisch mit Kunden-Endpunkt, inkl. Items, Preise, Status)
+
+```json
+[
+  {
+    "id": 42,
+    "status": "DELIVERED",
+    "totalPrice": 35.69,
+    "taxAmount": 5.70,
+    "shippingCost": 0.00,
+    "couponCode": null,
+    "createdAt": "2026-03-15T08:30:00Z",
+    "items": [ ... ]
+  }
+]
+```
+
+---
+
+### #29 — Umsatzstatistiken pro Kunde (Zeitraum)
+
+**Endpunkt:** `GET /api/customers/{id}/revenue?from=YYYY-MM-DD&to=YYYY-MM-DD`
+**Berechtigung:** SALES_EMPLOYEE, ADMIN
+
+**Beispiel:** `GET /api/customers/1/revenue?from=2026-01-01&to=2026-04-12`
+
+**Response `200 OK`:**
+```json
+{
+  "customerId": 1,
+  "from": "2026-01-01",
+  "to": "2026-04-12",
+  "orderCount": 5,
+  "totalRevenue": 349.95
+}
+```
+
+---
+
+### #33, #54 — Rabatte vergeben (befristet / unbefristet)
+
+**Endpunkt:** `POST /api/customers/{id}/discounts`
+**Berechtigung:** SALES_EMPLOYEE, ADMIN
+
+**Request für befristeten Rabatt (#33):**
+```json
+{
+  "productId": 1,
+  "discountPercent": 15.00,
+  "validFrom": "2026-04-15",
+  "validUntil": "2026-05-15"
+}
+```
+
+**Request für unbefristeten Rabatt (#54):**
+```json
+{
+  "productId": 2,
+  "discountPercent": 10.00,
+  "validFrom": "2026-04-15",
+  "validUntil": null
+}
+```
+
+Validierung: `discountPercent` zwischen 0.01 und 100.00
+
+**Response `201 Created`:**
+```json
+{
+  "id": 7,
+  "customerId": 1,
+  "productId": 2,
+  "discountPercent": 10.00,
+  "validFrom": "2026-04-15",
+  "validUntil": null
+}
+```
+
+**Was das Backend macht:**
+- Der Rabatt gilt automatisch beim nächsten `GET /api/products/{id}/price-for-customer` des Kunden
+- Und beim Hinzufügen zum Warenkorb
+
+---
+
+### #24 — Coupons vergeben
+
+**Endpunkt:** `POST /api/customers/{id}/coupons`
+**Berechtigung:** SALES_EMPLOYEE, ADMIN
+
+**Request:**
+```json
+{
+  "code": "SOMMER20",
+  "discountPercent": 20.00,
+  "validUntil": "2026-08-31"
+}
+```
+
+`validUntil` ist optional (null = kein Ablaufdatum).
+
+**Response `201 Created`** (kein Body)
+
+**Wie der Kunde den Coupon einlöst:** Beim Checkout `POST /api/orders` mit `couponCode`-Feld.
+
+---
+
+### #43 — Unternehmenskunden-Daten einsehen
+
+**Endpunkt:** `GET /api/customers/{id}/business-info`
+**Berechtigung:** SALES_EMPLOYEE, ADMIN
+
+**Response `200 OK`:**
+```json
+{
+  "id": 1,
+  "companyName": "Bob Corp GmbH",
+  "industry": "Technology",
+  "companySize": "10-50"
+}
+```
+
+**Fehler:** `404 Not Found` wenn der Kunde kein Unternehmenskunde ist (kein Business-Info-Datensatz).
+
+**Frontend-Tipp:** Zuerst `user.userType === 'BUSINESS'` prüfen bevor dieser Endpunkt aufgerufen wird.
+
+---
+
+### #37 — E-Mail an Kunden senden
+
+**Endpunkt:** `POST /api/customers/{id}/email`
+**Berechtigung:** SALES_EMPLOYEE, ADMIN
+
+**Request:**
+```json
+{
+  "subject": "Ihr persönliches Angebot",
+  "body": "Sehr geehrte/r alice,\n\nwir haben ein besonderes Angebot für Sie..."
+}
+```
+
+**Response `204 No Content`**
+
+**Was das Backend macht:** Versendet die E-Mail via Mail-Service (lokal: Mailpit auf Port 1025).
+
+---
+
+### #34 — Artikel-Verkaufsstatistiken (Zeitraum)
+
+**Endpunkt:** `GET /api/products/{id}/statistics?from=YYYY-MM-DD&to=YYYY-MM-DD`
+**Berechtigung:** SALES_EMPLOYEE, ADMIN
+
+**Response `200 OK`:**
+```json
+{
+  "productId": 1,
+  "from": "2026-01-01",
+  "to": "2026-04-12",
+  "unitsSold": 47,
+  "totalRevenue": 61099.53
+}
+```
+
+---
+
+### #26 — Artikel promoten
+
+Siehe [Milestone 2 — #26](./milestone-2-produktkatalog.md#26----artikel-promoten-sales_employee).
+
+---
+
+### #38 — Privatkunde und Unternehmenskunde unterscheiden
+
+Kein eigener Endpunkt. Das User-Objekt enthält `userType`:
+
+```js
+user.userType // "PRIVATE" | "BUSINESS"
+```
+
+Für Unternehmenskunden-Details: `GET /api/customers/{id}/business-info`
+
+**Frontend-Tipp:** In der Kundenliste (`GET /api/customers`) ist `userType` im Response enthalten:
+```json
+{ "id": 2, "username": "bob", "userType": "BUSINESS", ... }
+```
+
+---
+
+### #35, #36 — Benachrichtigungen bei Absatzänderungen
+
+Diese User Stories werden **vollständig vom Backend** verarbeitet:
+
+- **#35**: Bei >20% Absatzänderung → automatische E-Mail an SALES_EMPLOYEE-Nutzer
+- **#36**: Bei 0 Verkäufen eines Artikels über einen definierten Zeitraum → automatische E-Mail
+
+**Kein Frontend-Endpunkt nötig.** Das Backend prüft dies regelmäßig und sendet E-Mails direkt.
+
+---
+
+## Frontend-Patterns für Milestone 5
+
+### Kundendetails laden (Vertriebs-Dashboard)
+
+```jsx
+// Bestellhistorie
+const orders = await apiFetch(`/api/customers/${customerId}/orders`);
+
+// Umsatzstatistik
+const revenue = await apiFetch(
+  `/api/customers/${customerId}/revenue?from=2026-01-01&to=2026-04-12`
+);
+
+// Business-Info (nur für BUSINESS-Kunden)
+if (customer.userType === 'BUSINESS') {
+  const businessInfo = await apiFetch(`/api/customers/${customerId}/business-info`);
+}
+```
+
+### Rabatt vergeben
+
+```jsx
+await apiFetch(`/api/customers/${customerId}/discounts`, {
+  method: 'POST',
+  body: JSON.stringify({
+    productId: selectedProductId,
+    discountPercent: 15.00,
+    validFrom: '2026-04-15',
+    validUntil: isLimited ? endDate : null,  // null = unbefristet (#54)
+  }),
+});
+```
+
+### Role-Guard für Vertriebs-Seiten
+
+```jsx
+const { user } = useAuth();
+const isSalesOrAdmin = ['SALES_EMPLOYEE', 'ADMIN'].includes(user?.role);
+
+// In einer Seite: redirect wenn keine Berechtigung
+useEffect(() => {
+  if (user && !isSalesOrAdmin) navigate('/');
+}, [user]);
+```

--- a/docs/milestone-6-administration-audit.md
+++ b/docs/milestone-6-administration-audit.md
@@ -1,0 +1,216 @@
+# Milestone 6: Administration & Audit
+
+> Vollständiges Rollenkonzept & Berechtigungsmatrix: [ROLLEN.md](./ROLLEN.md)
+
+**Issues:** #19, #58, #59, #60, #61, #62
+
+---
+
+## Beteiligte Rollen
+
+| Rolle | Relevanz |
+|-------|----------|
+| `ADMIN` | Alle Endpunkte in diesem Milestone — exklusiv |
+
+> Alle Admin-Endpunkte (`/api/admin/*`) sind mit `@PreAuthorize("hasRole('ADMIN')")` auf
+> Klassen-Ebene geschützt. Jeder andere Aufruf führt zu `403 Forbidden`.
+
+---
+
+## User Stories → Endpunkte
+
+---
+
+### #59, #60 — Alle Benutzer anzeigen + nach Suchbegriffen filtern
+
+**Endpunkt:** `GET /api/admin/users`
+**Berechtigung:** ADMIN
+
+**Query-Parameter:**
+
+| Parameter | Beschreibung |
+|-----------|--------------|
+| `search` | Optional — Freitextsuche in Username und E-Mail |
+
+**Beispiele:**
+```
+GET /api/admin/users               → Alle User
+GET /api/admin/users?search=alice  → Suche nach "alice"
+```
+
+**Response `200 OK`:**
+```json
+[
+  {
+    "id": 1,
+    "username": "alice",
+    "email": "alice@example.com",
+    "role": "CUSTOMER",
+    "userType": "PRIVATE",
+    "customerNumber": "100001"
+  },
+  {
+    "id": 5,
+    "username": "admin",
+    "email": "admin@example.com",
+    "role": "ADMIN",
+    "userType": "PRIVATE",
+    "customerNumber": null
+  }
+]
+```
+
+> Unterschied zu `GET /api/customers`: dieser Endpunkt gibt **alle** User zurück
+> (CUSTOMER, EMPLOYEE, SALES_EMPLOYEE, ADMIN), nicht nur Kunden.
+
+---
+
+### #61 — Benutzer deregistrieren (Admin)
+
+**Endpunkt:** `DELETE /api/admin/users/{id}`
+**Berechtigung:** ADMIN
+
+**Response `204 No Content`**
+
+**Was das Backend macht:**
+- Setzt `active = false` (Soft-Delete — Daten bleiben erhalten)
+- Schreibt einen Eintrag ins Audit-Log: `DEACTIVATE_USER` mit `initiator = ADMIN`
+- Der deaktivierte User kann sich nicht mehr einloggen
+
+---
+
+### #19 — Admin kann jede Rolle wählen / Impersonation
+
+**Endpunkt:** `POST /api/admin/impersonate/{userId}`
+**Berechtigung:** ADMIN
+
+**Beispiel:** `POST /api/admin/impersonate/1`
+
+**Request:** Kein Body
+
+**Response `200 OK`:** AuthResponse-Objekt mit Token des Ziel-Users:
+```json
+{
+  "token": "eyJhbGciOiJIUzI1NiJ9...",
+  "userId": 1,
+  "username": "alice",
+  "email": "alice@example.com",
+  "role": "CUSTOMER",
+  "userType": "PRIVATE",
+  "customerNumber": "100001"
+}
+```
+
+**Was das Backend macht:**
+- Stellt einen vollwertigen JWT für den Ziel-User aus
+- Schreibt `IMPERSONATE_USER`-Eintrag ins Audit-Log mit `initiator = ADMIN`
+- Mit diesem Token kann der Admin im Namen des Kunden alle Aktionen ausführen
+
+**Frontend-Nutzung:**
+```js
+const response = await apiFetch(`/api/admin/impersonate/${targetUserId}`, { method: 'POST' });
+// response.token im localStorage speichern → jetzt verhält sich die App wie der Ziel-User
+localStorage.setItem('auth_token', response.token);
+window.location.reload(); // AuthContext neu laden
+```
+
+---
+
+### #58 — System-Transaktionen einsehen (Audit-Log)
+
+**Endpunkt:** `GET /api/admin/audit-log`
+**Berechtigung:** ADMIN
+
+**Response `200 OK`:**
+```json
+[
+  {
+    "id": 1,
+    "actorUsername": "admin",
+    "action": "IMPERSONATE_USER",
+    "entityType": "User",
+    "entityId": 1,
+    "initiator": "ADMIN",
+    "description": "Admin impersonated user: alice",
+    "timestamp": "2026-04-12T10:30:00Z"
+  },
+  {
+    "id": 2,
+    "actorUsername": "admin",
+    "action": "DEACTIVATE_USER",
+    "entityType": "User",
+    "entityId": 3,
+    "initiator": "ADMIN",
+    "description": "Admin deactivated user: carol",
+    "timestamp": "2026-04-12T11:00:00Z"
+  }
+]
+```
+
+Sortierung: neueste zuerst (`ORDER BY timestamp DESC`)
+
+---
+
+### #62 — Admin-Änderungen von Systemänderungen unterscheiden (NFR)
+
+Das Audit-Log enthält das Feld `initiator`:
+
+| Wert | Bedeutung |
+|------|-----------|
+| `ADMIN` | Eine Person mit Admin-Rolle hat die Aktion ausgelöst |
+| `SYSTEM` | Das Backend hat die Aktion automatisch ausgelöst (z.B. Dauerauftrag-Ausführung) |
+
+**Frontend:** Im Audit-Log-Table das `initiator`-Feld als Badge darstellen:
+```jsx
+<Tag
+  value={log.initiator}
+  severity={log.initiator === 'ADMIN' ? 'warning' : 'info'}
+/>
+```
+
+---
+
+## Frontend-Patterns für Milestone 6
+
+### Admin-Bereich absichern
+
+```jsx
+// AdminPage.jsx
+const { user } = useAuth();
+
+useEffect(() => {
+  if (user && user.role !== 'ADMIN') navigate('/');
+}, [user]);
+```
+
+### Benutzerliste mit Suche
+
+```jsx
+const [search, setSearch] = useState('');
+const [users, setUsers] = useState([]);
+
+useEffect(() => {
+  const url = search
+    ? `/api/admin/users?search=${encodeURIComponent(search)}`
+    : '/api/admin/users';
+  apiFetch(url).then(setUsers).catch(console.error);
+}, [search]);
+```
+
+### Audit-Log laden
+
+```jsx
+useEffect(() => {
+  apiFetch('/api/admin/audit-log').then(setAuditLogs).catch(console.error);
+}, []);
+```
+
+### Impersonation
+
+```jsx
+async function handleImpersonate(userId) {
+  const response = await apiFetch(`/api/admin/impersonate/${userId}`, { method: 'POST' });
+  localStorage.setItem('auth_token', response.token);
+  window.location.href = '/'; // vollständiger Reload, damit AuthContext neu lädt
+}
+```

--- a/docs/milestone-8-kundenservice.md
+++ b/docs/milestone-8-kundenservice.md
@@ -1,0 +1,198 @@
+# Milestone 8: Kundenservice (Mitarbeiter)
+
+> Vollständiges Rollenkonzept & Berechtigungsmatrix: [ROLLEN.md](./ROLLEN.md)
+
+**Issues:** #11, #12, #21, #22, #30, #32
+
+---
+
+## Beteiligte Rollen
+
+| Rolle | Relevanz |
+|-------|----------|
+| `EMPLOYEE` | Vollzugriff auf alle Endpunkte in diesem Milestone |
+| `SALES_EMPLOYEE` | Identische Rechte wie EMPLOYEE für Kundenservice-Funktionen |
+| `ADMIN` | Identische Rechte wie EMPLOYEE |
+
+> Diese Endpunkte ermöglichen es Mitarbeitern, **telefonisch** im Namen des Kunden zu handeln:
+> Warenkorb einsehen, Artikel hinzufügen/entfernen, Kunden suchen und Kundennummern nachschlagen.
+
+---
+
+## User Stories → Endpunkte
+
+---
+
+### #30 — Alle Kunden anzeigen (Mitarbeiter)
+### #32 — Kunden nach Suchbegriffen filtern
+
+**Endpunkt:** `GET /api/customers`
+**Berechtigung:** EMPLOYEE, SALES_EMPLOYEE, ADMIN
+
+**Query-Parameter:**
+
+| Parameter | Beschreibung |
+|-----------|--------------|
+| `search` | Optional — Freitextsuche in Username und E-Mail |
+
+**Beispiele:**
+```
+GET /api/customers                 → Alle Kunden
+GET /api/customers?search=alice    → Kunden mit "alice" in Name oder E-Mail
+```
+
+**Response `200 OK`:**
+```json
+[
+  {
+    "id": 1,
+    "username": "alice",
+    "email": "alice@example.com",
+    "role": "CUSTOMER",
+    "userType": "PRIVATE",
+    "customerNumber": "100001"
+  },
+  {
+    "id": 2,
+    "username": "bob",
+    "email": "bob@example.com",
+    "role": "CUSTOMER",
+    "userType": "BUSINESS",
+    "customerNumber": "100002"
+  }
+]
+```
+
+> Dieser Endpunkt gibt **nur Kunden** zurück (`role = CUSTOMER`).
+> Für alle User-Typen → `GET /api/admin/users` (nur ADMIN).
+
+---
+
+### #12 — Kundennummer einsehen (Mitarbeiter)
+
+**Endpunkt:** `GET /api/customers/{id}`
+**Berechtigung:** EMPLOYEE, SALES_EMPLOYEE, ADMIN
+
+**Response `200 OK`:** Identisch mit einem Element aus der Kundenliste (inkl. `customerNumber`).
+
+```json
+{
+  "id": 1,
+  "username": "alice",
+  "email": "alice@example.com",
+  "role": "CUSTOMER",
+  "userType": "PRIVATE",
+  "customerNumber": "100001"
+}
+```
+
+---
+
+### #11 — Warenkorb von Kunden einsehen
+
+**Endpunkt:** `GET /api/customers/{id}/cart`
+**Berechtigung:** EMPLOYEE, SALES_EMPLOYEE, ADMIN
+
+**Response `200 OK`:** Identisch mit `GET /api/cart` des Kunden (CartResponse):
+```json
+{
+  "items": [
+    {
+      "cartItemId": 3,
+      "productId": 2,
+      "productName": "Wireless Mouse",
+      "imageUrl": "https://placehold.co/400x300?text=Mouse",
+      "unitPrice": 26.99,
+      "quantity": 2,
+      "lineTotal": 53.98,
+      "addedAt": "2026-04-10T14:30:00Z"
+    }
+  ],
+  "subtotal": 53.98,
+  "tax": 8.64,
+  "shippingCost": 0.00,
+  "total": 62.62
+}
+```
+
+---
+
+### #21 — Artikel für Kunden in Warenkorb legen
+
+**Endpunkt:** `POST /api/customers/{id}/cart/items`
+**Berechtigung:** EMPLOYEE, SALES_EMPLOYEE, ADMIN
+
+**Request:**
+```json
+{
+  "productId": 1,
+  "quantity": 1
+}
+```
+
+**Response `200 OK`:** Aktualisierter Warenkorb des Kunden (CartResponse)
+
+**Was das Backend macht:** Identisch mit dem Kunden-Endpunkt `POST /api/cart/items`,
+aber für den Kunden mit der angegebenen ID — nicht für den eingeloggten Mitarbeiter.
+
+---
+
+### #22 — Artikel aus Warenkorb des Kunden entfernen
+
+**Endpunkt:** `DELETE /api/customers/{id}/cart/items/{productId}`
+**Berechtigung:** EMPLOYEE, SALES_EMPLOYEE, ADMIN
+
+**Response `200 OK`:** Aktualisierter Warenkorb des Kunden
+
+> Der zweite Pfad-Parameter ist die **Produkt-ID** des zu entfernenden Artikels.
+
+---
+
+## Frontend-Patterns für Milestone 8
+
+### Kundenservice-Seite absichern
+
+```jsx
+const { user } = useAuth();
+const isStaff = ['EMPLOYEE', 'SALES_EMPLOYEE', 'ADMIN'].includes(user?.role);
+
+useEffect(() => {
+  if (user && !isStaff) navigate('/');
+}, [user]);
+```
+
+### Kundensuche mit Debounce
+
+```jsx
+const [search, setSearch] = useState('');
+const [customers, setCustomers] = useState([]);
+
+useEffect(() => {
+  const timeout = setTimeout(() => {
+    const url = search
+      ? `/api/customers?search=${encodeURIComponent(search)}`
+      : '/api/customers';
+    apiFetch(url).then(setCustomers).catch(console.error);
+  }, 300); // 300ms Debounce
+  return () => clearTimeout(timeout);
+}, [search]);
+```
+
+### Warenkorb eines Kunden verwalten
+
+```jsx
+// Warenkorb laden
+const cart = await apiFetch(`/api/customers/${customerId}/cart`);
+
+// Artikel hinzufügen
+const updatedCart = await apiFetch(`/api/customers/${customerId}/cart/items`, {
+  method: 'POST',
+  body: JSON.stringify({ productId: selectedProduct.id, quantity: 1 }),
+});
+
+// Artikel entfernen
+const updatedCart = await apiFetch(
+  `/api/customers/${customerId}/cart/items/${productId}`,
+  { method: 'DELETE' }
+);
+```


### PR DESCRIPTION
## Summary
- Adds `docs/` folder with 8 Markdown files covering all 62 frontend user stories
- `docs/ROLLEN.md`: canonical role/permission reference (roles, userType, full endpoint matrix, frontend code examples, seed users)
- One file per frontend milestone with exact endpoints, request/response formats, role requirements, and frontend code examples:
  - `milestone-1-auth-benutzerverwaltung.md` (Issues #1–#7, #9, #56, #57)
  - `milestone-2-produktkatalog.md` (Issues #8, #10, #13–#18, #20, #23, #25, #26, #28, #31, #34, #46, #47)
  - `milestone-3-warenkorb-checkout.md` (Issues #39–#42, #44, #45)
  - `milestone-4-bestellhistorie.md` (Issues #48–#53, #55)
  - `milestone-5-crm-vertrieb.md` (Issues #24, #26, #27, #29, #33–#38, #43, #54)
  - `milestone-6-administration-audit.md` (Issues #19, #58–#62)
  - `milestone-8-kundenservice.md` (Issues #11, #12, #21, #22, #30, #32)

## Purpose
Bridges the communication gap between backend and frontend teams: every frontend developer can look up the exact endpoint, request/response format, and required role for their user story without reading the source code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)