### PR TITLE
Resolves #87 rabatt-und-promotionsmanagement

### DIFF
--- a/src/main/java/de/fhdw/webshop/customer/CustomerController.java
+++ b/src/main/java/de/fhdw/webshop/customer/CustomerController.java
@@ -4,6 +4,7 @@ import de.fhdw.webshop.cart.CartService;
 import de.fhdw.webshop.cart.dto.AddToCartRequest;
 import de.fhdw.webshop.cart.dto.CartResponse;
 import de.fhdw.webshop.discount.DiscountService;
+import de.fhdw.webshop.discount.dto.CouponResponse;
 import de.fhdw.webshop.discount.dto.CreateCouponRequest;
 import de.fhdw.webshop.discount.dto.CreateDiscountRequest;
 import de.fhdw.webshop.discount.dto.DiscountResponse;
@@ -27,7 +28,12 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/customers")
@@ -108,14 +114,48 @@ public class CustomerController {
                 .body(discountService.createDiscount(id, createDiscountRequest, currentUser));
     }
 
+    /** List all discounts for a customer. */
+    @GetMapping("/{id}/discounts")
+    @PreAuthorize("hasAnyRole('SALES_EMPLOYEE', 'ADMIN')")
+    public ResponseEntity<List<DiscountResponse>> listDiscounts(@PathVariable Long id) {
+        return ResponseEntity.ok(discountService.listDiscountsForCustomer(id));
+    }
+
+    /** Delete a specific discount for a customer. */
+    @DeleteMapping("/{id}/discounts/{discountId}")
+    @PreAuthorize("hasAnyRole('SALES_EMPLOYEE', 'ADMIN')")
+    public ResponseEntity<Void> deleteDiscount(@PathVariable Long id,
+                                               @PathVariable Long discountId,
+                                               @AuthenticationPrincipal User currentUser) {
+        discountService.deleteDiscount(discountId, id, currentUser);
+        return ResponseEntity.noContent().build();
+    }
+
     /** US #24 — Assign a coupon to a customer. */
     @PostMapping("/{id}/coupons")
     @PreAuthorize("hasAnyRole('SALES_EMPLOYEE', 'ADMIN')")
-    public ResponseEntity<Void> createCoupon(@PathVariable Long id,
-                                             @Valid @RequestBody CreateCouponRequest createCouponRequest,
+    public ResponseEntity<CouponResponse> createCoupon(@PathVariable Long id,
+                                                       @Valid @RequestBody CreateCouponRequest createCouponRequest,
+                                                       @AuthenticationPrincipal User currentUser) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(discountService.createCoupon(id, createCouponRequest, currentUser));
+    }
+
+    /** List all coupons for a customer. */
+    @GetMapping("/{id}/coupons")
+    @PreAuthorize("hasAnyRole('SALES_EMPLOYEE', 'ADMIN')")
+    public ResponseEntity<List<CouponResponse>> listCoupons(@PathVariable Long id) {
+        return ResponseEntity.ok(discountService.listCouponsForCustomer(id));
+    }
+
+    /** Delete a specific coupon for a customer. */
+    @DeleteMapping("/{id}/coupons/{couponId}")
+    @PreAuthorize("hasAnyRole('SALES_EMPLOYEE', 'ADMIN')")
+    public ResponseEntity<Void> deleteCoupon(@PathVariable Long id,
+                                             @PathVariable Long couponId,
                                              @AuthenticationPrincipal User currentUser) {
-        discountService.createCoupon(id, createCouponRequest, currentUser);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        discountService.deleteCoupon(couponId, id, currentUser);
+        return ResponseEntity.noContent().build();
     }
 
     /** US #29 — Revenue statistics for a customer over a date range. */
@@ -146,5 +186,117 @@ public class CustomerController {
         BusinessInfo businessInfo = businessInfoRepository.findByUserId(id)
                 .orElseThrow(() -> new EntityNotFoundException("No business info found for customer: " + id));
         return ResponseEntity.ok(businessInfo);
+    }
+
+    /**
+     * 360°-Dashboard combining customer profile, cart, orders, discounts, coupons and revenue.
+     * canViewSalesData / canManageSalesActions are true for SALES_EMPLOYEE and ADMIN.
+     */
+    @GetMapping("/{id}/dashboard")
+    @PreAuthorize("hasAnyRole('EMPLOYEE', 'SALES_EMPLOYEE', 'ADMIN')")
+    public ResponseEntity<CustomerDashboardResponse> getCustomerDashboard(
+            @PathVariable Long id,
+            @RequestParam(required = false) LocalDate from,
+            @RequestParam(required = false) LocalDate to,
+            @AuthenticationPrincipal User currentUser) {
+
+        User customer = userService.loadById(id);
+        String role = currentUser.getRole().name();
+        boolean canViewSalesData = "SALES_EMPLOYEE".equals(role) || "ADMIN".equals(role);
+        boolean canManageSalesActions = canViewSalesData;
+
+        UserProfileResponse customerProfile = new UserProfileResponse(
+                customer.getId(), customer.getUsername(), customer.getEmail(),
+                customer.getRole(), customer.getUserType(), customer.getCustomerNumber());
+
+        Optional<BusinessInfo> businessInfoOpt = businessInfoRepository.findByUserId(id);
+        Map<String, Object> businessInfoMap = businessInfoOpt.map(bi -> Map.<String, Object>of(
+                "companyName", bi.getCompanyName() != null ? bi.getCompanyName() : "",
+                "industry", bi.getIndustry() != null ? bi.getIndustry() : "",
+                "companySize", bi.getCompanySize() != null ? bi.getCompanySize() : ""
+        )).orElse(null);
+
+        CartResponse cart = cartService.getCart(id);
+
+        LocalDate effectiveFrom = from != null ? from : LocalDate.now().minusDays(90);
+        LocalDate effectiveTo = to != null ? to : LocalDate.now();
+
+        RevenueStatisticsResponse revenue = canViewSalesData
+                ? statisticsService.getCustomerRevenue(id, effectiveFrom, effectiveTo)
+                : null;
+
+        List<OrderResponse> allOrders = orderService.listOrdersForCustomer(id);
+        List<OrderResponse> recentOrders = allOrders.stream().limit(5).toList();
+        long totalOrderCount = allOrders.size();
+
+        Instant latestOrderAt = allOrders.stream()
+                .map(OrderResponse::createdAt)
+                .max(Instant::compareTo)
+                .orElse(null);
+
+        List<DiscountResponse> discounts = canViewSalesData
+                ? discountService.listDiscountsForCustomer(id)
+                : List.of();
+
+        List<CouponResponse> coupons = canViewSalesData
+                ? discountService.listCouponsForCustomer(id)
+                : List.of();
+
+        List<String> alerts = buildAlerts(allOrders, totalOrderCount);
+        String behaviorSummary = buildBehaviorSummary(totalOrderCount, latestOrderAt, revenue);
+
+        CustomerDashboardResponse dashboard = new CustomerDashboardResponse(
+                customerProfile,
+                businessInfoMap,
+                businessInfoOpt.isPresent(),
+                cart,
+                recentOrders,
+                totalOrderCount,
+                latestOrderAt,
+                discounts,
+                coupons,
+                revenue,
+                effectiveFrom,
+                effectiveTo,
+                canViewSalesData,
+                canManageSalesActions,
+                alerts,
+                behaviorSummary
+        );
+
+        return ResponseEntity.ok(dashboard);
+    }
+
+    private List<String> buildAlerts(List<OrderResponse> orders, long totalOrderCount) {
+        List<String> alerts = new ArrayList<>();
+        if (totalOrderCount == 0) {
+            alerts.add("Noch keine Bestellungen – Kunde ist neu oder inaktiv.");
+        }
+        long activeCoupons = orders.stream()
+                .filter(o -> o.couponCode() != null && !o.couponCode().isBlank())
+                .count();
+        if (activeCoupons > 0) {
+            alerts.add("Kunde hat bereits " + activeCoupons + " Coupon(s) eingelöst.");
+        }
+        return alerts;
+    }
+
+    private String buildBehaviorSummary(long totalOrderCount, Instant latestOrderAt,
+                                        RevenueStatisticsResponse revenue) {
+        if (totalOrderCount == 0) {
+            return "Dieser Kunde hat noch keine Bestellungen aufgegeben.";
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append("Der Kunde hat bisher ").append(totalOrderCount).append(" Bestellung(en) aufgegeben");
+        if (revenue != null && revenue.totalRevenue() != null) {
+            sb.append(" mit einem Gesamtumsatz von ")
+              .append(String.format("%.2f", revenue.totalRevenue())).append(" EUR im gewählten Zeitraum");
+        }
+        if (latestOrderAt != null) {
+            LocalDate lastOrderDate = latestOrderAt.atZone(ZoneOffset.UTC).toLocalDate();
+            long daysSince = java.time.temporal.ChronoUnit.DAYS.between(lastOrderDate, LocalDate.now());
+            sb.append(". Letzter Kauf vor ").append(daysSince).append(" Tag(en).");
+        }
+        return sb.toString();
     }
 }

--- a/src/main/java/de/fhdw/webshop/customer/CustomerDashboardResponse.java
+++ b/src/main/java/de/fhdw/webshop/customer/CustomerDashboardResponse.java
@@ -1,0 +1,31 @@
+package de.fhdw.webshop.customer;
+
+import de.fhdw.webshop.cart.dto.CartResponse;
+import de.fhdw.webshop.discount.dto.CouponResponse;
+import de.fhdw.webshop.discount.dto.DiscountResponse;
+import de.fhdw.webshop.order.dto.OrderResponse;
+import de.fhdw.webshop.user.dto.UserProfileResponse;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+public record CustomerDashboardResponse(
+        UserProfileResponse customer,
+        Map<String, Object> businessInfo,
+        boolean businessCustomer,
+        CartResponse cart,
+        List<OrderResponse> recentOrders,
+        long totalOrderCount,
+        Instant latestOrderAt,
+        List<DiscountResponse> discounts,
+        List<CouponResponse> coupons,
+        RevenueStatisticsResponse revenue,
+        LocalDate revenueFrom,
+        LocalDate revenueTo,
+        boolean canViewSalesData,
+        boolean canManageSalesActions,
+        List<String> alerts,
+        String behaviorSummary
+) {}

--- a/src/main/java/de/fhdw/webshop/discount/DiscountService.java
+++ b/src/main/java/de/fhdw/webshop/discount/DiscountService.java
@@ -1,5 +1,8 @@
 package de.fhdw.webshop.discount;
 
+import de.fhdw.webshop.admin.AuditInitiator;
+import de.fhdw.webshop.admin.AuditLogService;
+import de.fhdw.webshop.discount.dto.CouponResponse;
 import de.fhdw.webshop.discount.dto.CreateCouponRequest;
 import de.fhdw.webshop.discount.dto.CreateDiscountRequest;
 import de.fhdw.webshop.discount.dto.DiscountResponse;
@@ -23,6 +26,7 @@ public class DiscountService implements ProductService.DiscountLookupPort {
     private final CouponRepository couponRepository;
     private final UserRepository userRepository;
     private final ProductService productService;
+    private final AuditLogService auditLogService;
 
     /** Implementation of DiscountLookupPort — returns the best active discount percent for a product. */
     @Override
@@ -34,49 +38,93 @@ public class DiscountService implements ProductService.DiscountLookupPort {
                 .orElse(BigDecimal.ZERO);
     }
 
-    /** US #33, #54 — Create a time-limited or unlimited discount for a customer. */
+    /** US #33, #54 — Create or update a time-limited or unlimited discount for a customer. */
     @Transactional
-    public DiscountResponse createDiscount(Long customerId, CreateDiscountRequest createDiscountRequest, User salesEmployee) {
+    public DiscountResponse createDiscount(Long customerId, CreateDiscountRequest req, User salesEmployee) {
         User customer = loadCustomer(customerId);
 
         Discount discount = discountRepository
-                .findByCustomerIdAndProductId(customerId, createDiscountRequest.productId())
+                .findByCustomerIdAndProductId(customerId, req.productId())
                 .orElseGet(() -> {
-                    Discount newDiscount = new Discount();
-                    newDiscount.setCustomer(customer);
-                    newDiscount.setProduct(productService.loadProduct(createDiscountRequest.productId()));
-                    return newDiscount;
+                    Discount d = new Discount();
+                    d.setCustomer(customer);
+                    d.setProduct(productService.loadProduct(req.productId()));
+                    return d;
                 });
 
-        discount.setDiscountPercent(createDiscountRequest.discountPercent());
-        discount.setValidFrom(createDiscountRequest.validFrom());
-        discount.setValidUntil(createDiscountRequest.validUntil());
+        discount.setDiscountPercent(req.discountPercent());
+        discount.setValidFrom(req.validFrom());
+        discount.setValidUntil(req.validUntil());
         discount.setCreatedByUser(salesEmployee);
 
-        return toDiscountResponse(discountRepository.save(discount));
+        Discount saved = discountRepository.save(discount);
+        auditLogService.record(salesEmployee, "CREATE_DISCOUNT", "Discount", saved.getId(),
+                AuditInitiator.USER,
+                "customerId=" + customerId + ", productId=" + req.productId() + ", percent=" + req.discountPercent());
+        return toDiscountResponse(saved);
     }
 
     /** US #24 — Assign a coupon to a specific customer. */
     @Transactional
-    public Coupon createCoupon(Long customerId, CreateCouponRequest createCouponRequest, User salesEmployee) {
-        if (couponRepository.findByCode(createCouponRequest.code()).isPresent()) {
-            throw new IllegalArgumentException("Coupon code already exists: " + createCouponRequest.code());
+    public CouponResponse createCoupon(Long customerId, CreateCouponRequest req, User salesEmployee) {
+        if (couponRepository.findByCode(req.code()).isPresent()) {
+            throw new IllegalArgumentException("Coupon code already exists: " + req.code());
         }
         User customer = loadCustomer(customerId);
 
         Coupon coupon = new Coupon();
         coupon.setCustomer(customer);
-        coupon.setCode(createCouponRequest.code());
-        coupon.setDiscountPercent(createCouponRequest.discountPercent());
-        coupon.setValidUntil(createCouponRequest.validUntil());
+        coupon.setCode(req.code());
+        coupon.setDiscountPercent(req.discountPercent());
+        coupon.setValidUntil(req.validUntil());
         coupon.setCreatedByUser(salesEmployee);
-        return couponRepository.save(coupon);
+
+        Coupon saved = couponRepository.save(coupon);
+        auditLogService.record(salesEmployee, "CREATE_COUPON", "Coupon", saved.getId(),
+                AuditInitiator.USER,
+                "code=" + req.code() + ", customerId=" + customerId + ", percent=" + req.discountPercent());
+        return toCouponResponse(saved);
+    }
+
+    /** Delete a discount — only allowed for the owning customer's discounts. */
+    @Transactional
+    public void deleteDiscount(Long discountId, Long customerId, User salesEmployee) {
+        Discount discount = discountRepository.findById(discountId)
+                .orElseThrow(() -> new EntityNotFoundException("Discount not found: " + discountId));
+        if (!discount.getCustomer().getId().equals(customerId)) {
+            throw new IllegalArgumentException("Discount does not belong to customer: " + customerId);
+        }
+        discountRepository.delete(discount);
+        auditLogService.record(salesEmployee, "DELETE_DISCOUNT", "Discount", discountId,
+                AuditInitiator.USER,
+                "customerId=" + customerId + ", productId=" + discount.getProduct().getId());
+    }
+
+    /** Delete a coupon — only allowed for the owning customer's coupons. */
+    @Transactional
+    public void deleteCoupon(Long couponId, Long customerId, User salesEmployee) {
+        Coupon coupon = couponRepository.findById(couponId)
+                .orElseThrow(() -> new EntityNotFoundException("Coupon not found: " + couponId));
+        if (!coupon.getCustomer().getId().equals(customerId)) {
+            throw new IllegalArgumentException("Coupon does not belong to customer: " + customerId);
+        }
+        couponRepository.delete(coupon);
+        auditLogService.record(salesEmployee, "DELETE_COUPON", "Coupon", couponId,
+                AuditInitiator.USER,
+                "code=" + coupon.getCode() + ", customerId=" + customerId);
     }
 
     public List<DiscountResponse> listDiscountsForCustomer(Long customerId) {
         return discountRepository.findByCustomerId(customerId)
                 .stream()
                 .map(this::toDiscountResponse)
+                .toList();
+    }
+
+    public List<CouponResponse> listCouponsForCustomer(Long customerId) {
+        return couponRepository.findByCustomerId(customerId)
+                .stream()
+                .map(this::toCouponResponse)
                 .toList();
     }
 
@@ -90,9 +138,22 @@ public class DiscountService implements ProductService.DiscountLookupPort {
                 discount.getId(),
                 discount.getCustomer().getId(),
                 discount.getProduct().getId(),
+                discount.getProduct().getName(),
                 discount.getDiscountPercent(),
                 discount.getValidFrom(),
                 discount.getValidUntil()
+        );
+    }
+
+    private CouponResponse toCouponResponse(Coupon coupon) {
+        return new CouponResponse(
+                coupon.getId(),
+                coupon.getCustomer().getId(),
+                coupon.getCode(),
+                coupon.getDiscountPercent(),
+                coupon.getValidUntil(),
+                coupon.isUsed(),
+                coupon.getUsedAt()
         );
     }
 }

--- a/src/main/java/de/fhdw/webshop/discount/dto/CouponResponse.java
+++ b/src/main/java/de/fhdw/webshop/discount/dto/CouponResponse.java
@@ -1,14 +1,15 @@
 package de.fhdw.webshop.discount.dto;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 
-public record DiscountResponse(
+public record CouponResponse(
         Long id,
         Long customerId,
-        Long productId,
-        String productName,
+        String code,
         BigDecimal discountPercent,
-        LocalDate validFrom,
-        LocalDate validUntil
+        LocalDate validUntil,
+        boolean used,
+        Instant usedAt
 ) {}

--- a/src/main/java/de/fhdw/webshop/order/OrderService.java
+++ b/src/main/java/de/fhdw/webshop/order/OrderService.java
@@ -1,7 +1,11 @@
 package de.fhdw.webshop.order;
 
+import de.fhdw.webshop.admin.AuditInitiator;
+import de.fhdw.webshop.admin.AuditLogService;
 import de.fhdw.webshop.cart.CartItem;
 import de.fhdw.webshop.cart.CartRepository;
+import de.fhdw.webshop.discount.Coupon;
+import de.fhdw.webshop.discount.CouponRepository;
 import de.fhdw.webshop.order.dto.OrderItemResponse;
 import de.fhdw.webshop.order.dto.OrderResponse;
 import de.fhdw.webshop.order.dto.PlaceOrderRequest;
@@ -14,6 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -24,7 +30,9 @@ public class OrderService {
 
     private final OrderRepository orderRepository;
     private final CartRepository cartRepository;
+    private final CouponRepository couponRepository;
     private final ProductService.DiscountLookupPort discountLookupPort;
+    private final AuditLogService auditLogService;
 
     public List<OrderResponse> listOrdersForCustomer(Long customerId) {
         return orderRepository.findByCustomerIdOrderByCreatedAtDesc(customerId)
@@ -39,7 +47,7 @@ public class OrderService {
         return toResponse(order);
     }
 
-    /** US #42 — Convert the current cart into a confirmed order. */
+    /** US #42 — Convert the current cart into a confirmed order. Coupon reduces the order subtotal. */
     @Transactional
     public OrderResponse placeOrder(User customer, PlaceOrderRequest placeOrderRequest) {
         List<CartItem> cartItems = cartRepository.findByUserId(customer.getId());
@@ -47,9 +55,12 @@ public class OrderService {
             throw new IllegalArgumentException("Cannot place an order with an empty cart");
         }
 
+        String couponCode = placeOrderRequest != null ? placeOrderRequest.couponCode() : null;
+        Coupon coupon = resolveCoupon(couponCode, customer);
+
         Order order = new Order();
         order.setCustomer(customer);
-        order.setCouponCode(placeOrderRequest != null ? placeOrderRequest.couponCode() : null);
+        order.setCouponCode(couponCode);
 
         BigDecimal subtotal = BigDecimal.ZERO;
         for (CartItem cartItem : cartItems) {
@@ -67,6 +78,11 @@ public class OrderService {
             subtotal = subtotal.add(unitPrice.multiply(BigDecimal.valueOf(cartItem.getQuantity())));
         }
 
+        // Apply coupon discount to the subtotal (after item-level discounts)
+        if (coupon != null) {
+            subtotal = applyDiscount(subtotal, coupon.getDiscountPercent());
+        }
+
         BigDecimal taxAmount = subtotal.multiply(TAX_RATE).setScale(2, RoundingMode.HALF_UP);
         order.setTotalPrice(subtotal.add(taxAmount).setScale(2, RoundingMode.HALF_UP));
         order.setTaxAmount(taxAmount);
@@ -75,7 +91,41 @@ public class OrderService {
 
         Order savedOrder = orderRepository.save(order);
         cartRepository.deleteByUserId(customer.getId());
+
+        if (coupon != null) {
+            coupon.setUsed(true);
+            coupon.setUsedAt(Instant.now());
+            couponRepository.save(coupon);
+            auditLogService.record(customer, "APPLY_COUPON", "Coupon", coupon.getId(),
+                    AuditInitiator.USER,
+                    "code=" + coupon.getCode() + ", orderId=" + savedOrder.getId());
+        }
+
         return toResponse(savedOrder);
+    }
+
+    /**
+     * Looks up and validates a coupon code. Returns null if no code was provided.
+     * Throws IllegalArgumentException if the code is invalid, expired, already used,
+     * or does not belong to the placing customer.
+     */
+    private Coupon resolveCoupon(String couponCode, User customer) {
+        if (couponCode == null || couponCode.isBlank()) {
+            return null;
+        }
+        Coupon coupon = couponRepository.findByCode(couponCode)
+                .orElseThrow(() -> new IllegalArgumentException("Coupon code not found: " + couponCode));
+
+        if (!coupon.getCustomer().getId().equals(customer.getId())) {
+            throw new IllegalArgumentException("Coupon does not belong to this customer");
+        }
+        if (coupon.isUsed()) {
+            throw new IllegalArgumentException("Coupon has already been used: " + couponCode);
+        }
+        if (coupon.getValidUntil() != null && coupon.getValidUntil().isBefore(LocalDate.now())) {
+            throw new IllegalArgumentException("Coupon has expired: " + couponCode);
+        }
+        return coupon;
     }
 
     private BigDecimal applyDiscount(BigDecimal price, BigDecimal discountPercent) {

--- a/src/main/java/de/fhdw/webshop/user/UserController.java
+++ b/src/main/java/de/fhdw/webshop/user/UserController.java
@@ -1,11 +1,17 @@
 package de.fhdw.webshop.user;
 
+import de.fhdw.webshop.discount.DiscountService;
+import de.fhdw.webshop.discount.dto.CouponResponse;
+import de.fhdw.webshop.discount.dto.DiscountResponse;
 import de.fhdw.webshop.user.dto.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/users")
@@ -13,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+    private final DiscountService discountService;
 
     /** US #9 — Return own profile including customer number. */
     @GetMapping("/me")
@@ -57,5 +64,19 @@ public class UserController {
                                                   @Valid @RequestBody PaymentMethodRequest paymentMethodRequest) {
         userService.savePaymentMethod(currentUser, paymentMethodRequest);
         return ResponseEntity.noContent().build();
+    }
+
+    /** Customer views their own active discounts. */
+    @GetMapping("/me/discounts")
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public ResponseEntity<List<DiscountResponse>> getMyDiscounts(@AuthenticationPrincipal User currentUser) {
+        return ResponseEntity.ok(discountService.listDiscountsForCustomer(currentUser.getId()));
+    }
+
+    /** Customer views their own coupons. */
+    @GetMapping("/me/coupons")
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public ResponseEntity<List<CouponResponse>> getMyCoupons(@AuthenticationPrincipal User currentUser) {
+        return ResponseEntity.ok(discountService.listCouponsForCustomer(currentUser.getId()));
     }
 }

--- a/src/main/resources/db/migration/V10__mock_data.sql
+++ b/src/main/resources/db/migration/V10__mock_data.sql
@@ -1,0 +1,113 @@
+-- =============================================================================
+-- V10 – Demo-Daten für Rabatt- und Promotionsmanagement (Issue #87)
+-- Passwort für alle Demo-Accounts: Demo12345!
+-- BCrypt-Hash (cost 10) von "Demo12345!"
+-- =============================================================================
+
+-- Demo-Vertriebsmitarbeiter
+INSERT INTO users (username, email, password_hash, role, user_type, active)
+VALUES (
+    'demo_vertrieb',
+    'vertrieb@demo.de',
+    '$2a$10$8bCh1J0CQV8xLaHMcqEi7eCz5X5RqbVSG2VqTpWZzY5G.5X8P2GqO',
+    'SALES_EMPLOYEE',
+    'PRIVATE',
+    TRUE
+) ON CONFLICT (username) DO NOTHING;
+
+-- Demo-Kunden
+INSERT INTO users (username, email, password_hash, role, user_type, customer_number, active)
+VALUES
+    ('demo_kunde1', 'kunde1@demo.de',
+     '$2a$10$8bCh1J0CQV8xLaHMcqEi7eCz5X5RqbVSG2VqTpWZzY5G.5X8P2GqO',
+     'CUSTOMER', 'PRIVATE',
+     'K-' || to_char(nextval('customer_number_sequence'), 'FM000000'),
+     TRUE),
+    ('demo_kunde2', 'kunde2@demo.de',
+     '$2a$10$8bCh1J0CQV8xLaHMcqEi7eCz5X5RqbVSG2VqTpWZzY5G.5X8P2GqO',
+     'CUSTOMER', 'BUSINESS',
+     'K-' || to_char(nextval('customer_number_sequence'), 'FM000000'),
+     TRUE)
+ON CONFLICT (username) DO NOTHING;
+
+-- Business-Info für Demo-Geschäftskunden
+INSERT INTO business_info (user_id, company_name, industry, company_size)
+SELECT u.id, 'Demo GmbH', 'IT & Software', '10–50'
+FROM users u
+WHERE u.username = 'demo_kunde2'
+  AND NOT EXISTS (SELECT 1 FROM business_info bi WHERE bi.user_id = u.id);
+
+-- Promoted-Flag auf den ersten 3 kaufbaren Produkten setzen
+UPDATE products
+SET promoted = TRUE
+WHERE id IN (
+    SELECT id FROM products WHERE purchasable = TRUE ORDER BY id LIMIT 3
+);
+
+-- Rabatte und Coupons über DO-Block (referenziert User per username)
+DO $$
+DECLARE
+    v_sales    BIGINT;
+    v_cust1    BIGINT;
+    v_cust2    BIGINT;
+    v_prod1    BIGINT;
+    v_prod2    BIGINT;
+    v_prod3    BIGINT;
+BEGIN
+    SELECT id INTO v_sales FROM users WHERE username = 'demo_vertrieb';
+    SELECT id INTO v_cust1  FROM users WHERE username = 'demo_kunde1';
+    SELECT id INTO v_cust2  FROM users WHERE username = 'demo_kunde2';
+    SELECT id INTO v_prod1  FROM products WHERE purchasable = TRUE ORDER BY id LIMIT 1 OFFSET 0;
+    SELECT id INTO v_prod2  FROM products WHERE purchasable = TRUE ORDER BY id LIMIT 1 OFFSET 1;
+    SELECT id INTO v_prod3  FROM products WHERE purchasable = TRUE ORDER BY id LIMIT 1 OFFSET 2;
+
+    -- Befristeter Rabatt: demo_kunde1 auf Produkt 1 (90 Tage)
+    IF v_sales IS NOT NULL AND v_cust1 IS NOT NULL AND v_prod1 IS NOT NULL THEN
+        INSERT INTO discounts (customer_id, product_id, discount_percent, valid_from, valid_until, created_by_user_id)
+        VALUES (v_cust1, v_prod1, 15.00, CURRENT_DATE, CURRENT_DATE + INTERVAL '90 days', v_sales)
+        ON CONFLICT (customer_id, product_id) DO NOTHING;
+    END IF;
+
+    -- Unbefristeter Rabatt: demo_kunde1 auf Produkt 2
+    IF v_sales IS NOT NULL AND v_cust1 IS NOT NULL AND v_prod2 IS NOT NULL THEN
+        INSERT INTO discounts (customer_id, product_id, discount_percent, valid_from, valid_until, created_by_user_id)
+        VALUES (v_cust1, v_prod2, 10.00, CURRENT_DATE, NULL, v_sales)
+        ON CONFLICT (customer_id, product_id) DO NOTHING;
+    END IF;
+
+    -- Befristeter Rabatt: demo_kunde2 auf Produkt 1 (30 Tage)
+    IF v_sales IS NOT NULL AND v_cust2 IS NOT NULL AND v_prod1 IS NOT NULL THEN
+        INSERT INTO discounts (customer_id, product_id, discount_percent, valid_from, valid_until, created_by_user_id)
+        VALUES (v_cust2, v_prod1, 20.00, CURRENT_DATE, CURRENT_DATE + INTERVAL '30 days', v_sales)
+        ON CONFLICT (customer_id, product_id) DO NOTHING;
+    END IF;
+
+    -- Unbefristeter Rabatt: demo_kunde2 auf Produkt 3
+    IF v_sales IS NOT NULL AND v_cust2 IS NOT NULL AND v_prod3 IS NOT NULL THEN
+        INSERT INTO discounts (customer_id, product_id, discount_percent, valid_from, valid_until, created_by_user_id)
+        VALUES (v_cust2, v_prod3, 25.00, CURRENT_DATE, NULL, v_sales)
+        ON CONFLICT (customer_id, product_id) DO NOTHING;
+    END IF;
+
+    -- Coupons für demo_kunde1
+    IF v_sales IS NOT NULL AND v_cust1 IS NOT NULL THEN
+        INSERT INTO coupons (customer_id, code, discount_percent, valid_until, used, created_by_user_id)
+        VALUES (v_cust1, 'WELCOME10', 10.00, CURRENT_DATE + INTERVAL '365 days', FALSE, v_sales)
+        ON CONFLICT (code) DO NOTHING;
+
+        INSERT INTO coupons (customer_id, code, discount_percent, valid_until, used, created_by_user_id)
+        VALUES (v_cust1, 'SUMMER15', 15.00, CURRENT_DATE + INTERVAL '180 days', FALSE, v_sales)
+        ON CONFLICT (code) DO NOTHING;
+    END IF;
+
+    -- Coupons für demo_kunde2
+    IF v_sales IS NOT NULL AND v_cust2 IS NOT NULL THEN
+        INSERT INTO coupons (customer_id, code, discount_percent, valid_until, used, created_by_user_id)
+        VALUES (v_cust2, 'BUSINESS20', 20.00, NULL, FALSE, v_sales)
+        ON CONFLICT (code) DO NOTHING;
+
+        INSERT INTO coupons (customer_id, code, discount_percent, valid_until, used, created_by_user_id)
+        VALUES (v_cust2, 'VIP25', 25.00, CURRENT_DATE + INTERVAL '365 days', FALSE, v_sales)
+        ON CONFLICT (code) DO NOTHING;
+    END IF;
+END $$;


### PR DESCRIPTION
## Summary
- Implementierung von Issue #87: Rabatt- und Promotionsmanagement (Backend)
- `CouponResponse` DTO für strukturierte Coupon-Antworten eingeführt
- `DiscountResponse` um `productName` erweitert (kein separater Produkt-Lookup im Frontend nötig)
- `DiscountService`: neue Methoden `deleteDiscount`, `deleteCoupon`, `listCouponsForCustomer` inkl. AuditLog-Einträge
- `CustomerController`: 360°-Dashboard-Endpunkt sowie GET/DELETE-Endpunkte für Rabatte und Coupons
- `UserController`: `GET /me/discounts` und `GET /me/coupons` für eingeloggte Kunden
- `OrderService`: Coupon-Validierung und -Anwendung auf Gesamtbetrag + AuditLog-Eintrag `APPLY_COUPON`
- `V10__mock_data.sql`: Demo-Nutzer (`demo_vertrieb`, `demo_kunde1`, `demo_kunde2`), Promoted-Produkte, Muster-Rabatte und Coupons

## Kombinationsregel
Coupon wird auf den Gesamtbetrag **nach** Artikel-Rabatten angewendet, danach wird die MwSt. (19 %) berechnet.

## Test plan
- [ ] `POST /api/customers/{id}/discounts` → Rabatt anlegen, AuditLog-Eintrag vorhanden
- [ ] `POST /api/customers/{id}/coupons` → Coupon anlegen, AuditLog-Eintrag vorhanden
- [ ] `DELETE /api/customers/{id}/discounts/{discountId}` → Rabatt gelöscht, AuditLog-Eintrag vorhanden
- [ ] `DELETE /api/customers/{id}/coupons/{couponId}` → Coupon gelöscht, AuditLog-Eintrag vorhanden
- [ ] `GET /api/customers/{id}/dashboard` → vollständiges Dashboard inkl. Rabatte/Coupons
- [ ] `GET /api/users/me/discounts` / `/me/coupons` → nur eigene Daten als CUSTOMER sichtbar
- [ ] `POST /api/orders` mit gültigem `couponCode` → Preis korrekt reduziert, Coupon als `used` markiert, AuditLog-Eintrag `APPLY_COUPON`
- [ ] Demo-Daten via `V10__mock_data.sql` korrekt angelegt (Flyway-Migration läuft durch)