### PR TITLE
feat(#16): Shoppi KI-Assistent — Ollama-Integration, GPU-Support, dev.sh & dev.ps1

### DIFF
--- a/README-Linux.md
+++ b/README-Linux.md
@@ -123,6 +123,14 @@ Das Modell `gemma4:e4b` wird einmalig gezogen (einmalig, ~3 GB):
 docker exec webshop-ollama ollama pull gemma4:e4b
 ```
 
+**GPU-Beschleunigung:** `dev.ps1` erkennt beim Start automatisch die verbaute GPU:
+
+| GPU | Verhalten |
+|---|---|
+| NVIDIA | `docker-compose.gpu-nvidia.yml` wird automatisch eingebunden |
+| AMD | `docker-compose.gpu-amd.yml` wird eingebunden (ROCm, funktioniert auf Linux) |
+| Intel / Keine | CPU-Modus mit Info-Meldung |
+
 **Shoppi** ist der KI-Assistent des Webshops (`POST /api/chat/message`, öffentlich, auth-aware).
 
 ---

--- a/README-Linux.md
+++ b/README-Linux.md
@@ -213,6 +213,14 @@ docker exec webshop-ollama ollama pull gemma4:e4b
 ```
 Dieser Download (~3 GB) ist nur einmalig nötig. Das Modell wird im Docker-Volume `ollama_data` gecacht.
 
+> **Fehler: „pull model manifest: 412 — requires a newer version of Ollama"?**
+> Das lokale Ollama-Image ist veraltet (z.B. von einer früheren Installation). Image updaten und Container neu starten:
+> ```bash
+> docker pull ollama/ollama:latest
+> docker compose up -d --no-deps ollama
+> docker exec webshop-ollama ollama pull gemma4:e4b
+> ```
+
 ### Schritt 4 — Testdaten einspielen (einmalig)
 ```bash
 docker exec -i webshop-postgres psql -U webshop -d webshop \

--- a/README-Linux.md
+++ b/README-Linux.md
@@ -211,10 +211,10 @@ Das Backend ist dann erreichbar unter: `http://localhost:8080`
 ```bash
 docker exec webshop-ollama ollama pull gemma4:e4b
 ```
-Dieser Download (~3 GB) ist nur einmalig nötig. Das Modell wird im Docker-Volume `ollama_data` gecacht.
+Dieser Download (~10 GB) ist nur einmalig nötig. Das Modell wird im Docker-Volume `ollama_data` gecacht.
 
 > **Fehler: „pull model manifest: 412 — requires a newer version of Ollama"?**
-> Das lokale Ollama-Image ist veraltet (z.B. von einer früheren Installation). Image updaten und Container neu starten:
+> Das lokale Ollama-Image ist veraltet (z.B. von einer früheren Installation). Image updaten (~4 GB) und Container neu starten:
 > ```bash
 > docker pull ollama/ollama:latest
 > docker compose up -d --no-deps ollama

--- a/README-Linux.md
+++ b/README-Linux.md
@@ -33,7 +33,8 @@ Spring Boot Backend für den Webshop. Stellt eine REST API bereit, die vom React
 Browser
   └── Frontend (React + Vite, Port 5173)
         └──[HTTP / REST API / JSON]──► Backend (Spring Boot, Port 8080)
-                                            └──[JPA / SQL]──► PostgreSQL (Port 5432)
+                                            ├──[JPA / SQL]──► PostgreSQL (Port 5432)
+                                            └──[REST]──────► Ollama (Port 11434, lokal)
 ```
 
 Das Frontend schickt HTTP-Anfragen an das Backend (z.B. `GET /api/products`).
@@ -54,6 +55,7 @@ Jede Anfrage wird über einen JWT-Token authentifiziert (außer Login/Register).
 | JWT (jjwt) | Authentifizierung | 0.12.6 |
 | springdoc-openapi | OpenAPI Spec generieren | 2.8.6 |
 | Docker + Compose | Lokale Entwicklungsumgebung | - |
+| Ollama | Lokale KI-Laufzeitumgebung für Shoppi | latest |
 | NGINX | Reverse Proxy + HTTPS (Produktion) | - |
 | GitHub Actions | CI/CD-Pipelines | - |
 
@@ -111,6 +113,19 @@ Docker Compose startet zwei Container: **PostgreSQL** (Datenbank) und **Spring B
 
 ### springdoc-openapi — API-Beschreibung
 Liest den Spring Boot Code und generiert automatisch eine maschinenlesbare Beschreibung aller Endpunkte (`/v3/api-docs`). Das Frontend-Team kann daraus ablesen wie ein API-Call aussehen muss, ohne beim Backend-Team nachzufragen.
+
+### Ollama — lokale KI-Laufzeitumgebung
+
+Ollama führt KI-Sprachmodelle lokal auf dem Server aus. Keine Daten verlassen den Server — kein Drittanbieter wie OpenAI oder Google Cloud. Das Backend kommuniziert intern über `http://ollama:11434`.
+
+Das Modell `gemma4:e4b` wird einmalig gezogen (einmalig, ~3 GB):
+```bash
+docker exec webshop-ollama ollama pull gemma4:e4b
+```
+
+**Shoppi** ist der KI-Assistent des Webshops (`POST /api/chat/message`, öffentlich, auth-aware).
+
+---
 
 ### GitHub Actions — CI/CD
 Zwei Pipelines:
@@ -192,13 +207,19 @@ Das Backend ist dann erreichbar unter: `http://localhost:8080`
 > aus einem anderen Grund neu gebaut werden muss. `rebuild` übergibt `--force-recreate`
 > und `--no-cache` an Docker Compose.
 
-### Schritt 3 — Testdaten einspielen (einmalig)
+### Schritt 3 — Ollama-Modell ziehen (einmalig, nur für Shoppi KI-Assistent)
+```bash
+docker exec webshop-ollama ollama pull gemma4:e4b
+```
+Dieser Download (~3 GB) ist nur einmalig nötig. Das Modell wird im Docker-Volume `ollama_data` gecacht.
+
+### Schritt 4 — Testdaten einspielen (einmalig)
 ```bash
 docker exec -i webshop-postgres psql -U webshop -d webshop \
   < src/main/resources/db/dev-seed.sql
 ```
 
-### Schritt 4 — Verifizieren
+### Schritt 5 — Verifizieren
 ```bash
 curl http://localhost:8080/api/health
 # Erwartet: {"status":"UP"}
@@ -237,6 +258,11 @@ src/
     │   ├── customer/                       ← Kundenübersicht (Mitarbeiter-Sicht)
     │   ├── standingorder/                  ← Daueraufträge
     │   ├── notification/                   ← E-Mail-Versand, Scheduler
+    │   ├── chat/                           ← Shoppi KI-Assistent (Ollama)
+    │   │   ├── ChatController.java         ← POST /api/chat/message
+    │   │   ├── ChatService.java
+    │   │   ├── OllamaClient.java
+    │   │   └── dto/
     │   └── admin/                          ← Admin-Endpunkte, Audit-Log
     │
     └── resources/
@@ -316,6 +342,8 @@ Alle Variablen können in einer `.env`-Datei im Root-Verzeichnis gesetzt werden 
 | `MAIL_PORT` | `587` | SMTP-Port |
 | `MAIL_USERNAME` | — | SMTP-Benutzername |
 | `MAIL_PASSWORD` | — | SMTP-Passwort / App-Passwort |
+| `OLLAMA_BASE_URL` | `http://ollama:11434` | Ollama API URL (intern im Docker-Netzwerk) |
+| `OLLAMA_MODEL` | `gemma4:e4b` | KI-Modell für Shoppi |
 
 ---
 
@@ -442,6 +470,20 @@ curl -X POST http://localhost:8080/api/customers/1/discounts \
 # Umsatzstatistik
 curl "http://localhost:8080/api/customers/1/revenue?from=2026-01-01&to=2026-12-31" \
   -H "Authorization: Bearer $SALES_TOKEN"
+```
+
+### Shoppi KI-Assistent
+```bash
+# Unauthentifiziert (nur Produktkatalog-Kontext)
+curl -s -X POST http://localhost:8080/api/chat/message \
+  -H "Content-Type: application/json" \
+  -d '{"message":"Welche Produkte habt ihr?","history":[]}' | python3 -m json.tool
+
+# Als eingeloggter Kunde (mit persönlichem Kontext)
+curl -s -X POST http://localhost:8080/api/chat/message \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"message":"Was habe ich im Warenkorb?","history":[]}' | python3 -m json.tool
 ```
 
 ### Admin-Endpunkte

--- a/README-Mac.md
+++ b/README-Mac.md
@@ -1,11 +1,11 @@
-# Webshop Backend — Linux (bash)
+# Webshop Backend — macOS (bash / zsh)
 
 > **Windows-Nutzer:** → [README.md](README.md)
-> **macOS-Nutzer:** → [README-Mac.md](README-Mac.md)
+> **Linux-Nutzer:** → [README-Linux.md](README-Linux.md)
 
 Spring Boot Backend für den Webshop. Stellt eine REST API bereit, die vom React-Frontend unter [SEPBFWS124A/Webshop](https://github.com/SEPBFWS124A/Webshop) verwendet wird.
 
-> Alle Befehle in diesem Dokument sind für **bash / zsh** geschrieben.
+> Alle Befehle in diesem Dokument sind für **bash / zsh** auf macOS geschrieben.
 
 ---
 
@@ -124,13 +124,9 @@ Das Modell `gemma4:e4b` wird einmalig gezogen (einmalig, ~3 GB):
 docker exec webshop-ollama ollama pull gemma4:e4b
 ```
 
-**GPU-Beschleunigung:** `dev.sh` erkennt beim Start automatisch die verbaute GPU:
+**GPU-Beschleunigung:** Docker auf macOS läuft in einer Linux-VM — GPU-Passthrough (NVIDIA, AMD, Apple Metal) ist **nicht** unterstützt. Ollama läuft daher immer auf CPU, unabhängig vom verbauten Chip (Intel, AMD oder Apple Silicon M1/M2/M3).
 
-| GPU | Verhalten |
-|---|---|
-| NVIDIA | `docker-compose.gpu-nvidia.yml` wird automatisch eingebunden |
-| AMD | `docker-compose.gpu-amd.yml` wird eingebunden (ROCm, funktioniert auf Linux) |
-| Intel / Keine | CPU-Modus mit Info-Meldung |
+> Wer Ollama nativ auf dem Mac mit Metal-Beschleunigung nutzen möchte, kann es separat über `brew install ollama` installieren und lokal starten. Das liegt aber außerhalb dieser Docker-Entwicklungsumgebung.
 
 **Shoppi** ist der KI-Assistent des Webshops (`POST /api/chat/message`, öffentlich, auth-aware).
 
@@ -152,20 +148,25 @@ https://domain.de/api/   → Backend (Spring Boot, intern Port 8080)
 
 ## 4. Voraussetzungen
 
-Folgendes muss auf deinem Rechner installiert sein:
-
-### Docker
+### Docker Desktop
 Wird für PostgreSQL **und** das Spring Boot Backend benötigt. Kein Java oder Maven lokal nötig.
 ```bash
 docker --version
 docker compose version
 ```
-Installation: https://www.docker.com/products/docker-desktop  
-Oder via Paketmanager: `sudo apt install docker.io docker-compose-plugin` (Ubuntu/Debian)
+Download: https://www.docker.com/products/docker-desktop
 
-### python3 (optional)
-Nur für die automatische Rebuild-Erkennung (`./dev.sh start`) benötigt. Auf den meisten Linux-Distributionen vorinstalliert.
+> Auf Apple Silicon (M1/M2/M3) läuft Docker Desktop nativ — kein Rosetta nötig.
+
+### python3
+Nur für die automatische Rebuild-Erkennung (`./dev.sh start`) benötigt. Auf macOS über Xcode Command Line Tools oder Homebrew verfügbar.
 ```bash
+# Xcode Command Line Tools (empfohlen, falls noch nicht installiert):
+xcode-select --install
+
+# Oder via Homebrew:
+brew install python3
+
 python3 --version
 ```
 
@@ -220,27 +221,27 @@ Das Backend ist dann erreichbar unter: `http://localhost:8080`
 | `./dev.sh rebuild` | Docker-Image neu bauen + starten (kein Layer-Cache) |
 | `./dev.sh rebuild --keep-db` | Rebuild ohne PostgreSQL-Neustart |
 
-### Schritt 3 — Ollama-Modell ziehen (einmalig, nur für Shoppi KI-Assistent)
+### Schritt 4 — Ollama-Modell ziehen (einmalig, nur für Shoppi KI-Assistent)
 ```bash
 docker exec webshop-ollama ollama pull gemma4:e4b
 ```
 Dieser Download (~10 GB) ist nur einmalig nötig. Das Modell wird im Docker-Volume `ollama_data` gecacht.
 
 > **Fehler: „pull model manifest: 412 — requires a newer version of Ollama"?**
-> Das lokale Ollama-Image ist veraltet (z.B. von einer früheren Installation). Image updaten (~4 GB) und Container neu starten:
+> Das lokale Ollama-Image ist veraltet. Image updaten und Container neu starten:
 > ```bash
 > docker pull ollama/ollama:latest
 > docker compose up -d --no-deps ollama
 > docker exec webshop-ollama ollama pull gemma4:e4b
 > ```
 
-### Schritt 4 — Testdaten einspielen (einmalig)
+### Schritt 5 — Testdaten einspielen (einmalig)
 ```bash
 docker exec -i webshop-postgres psql -U webshop -d webshop \
   < src/main/resources/db/dev-seed.sql
 ```
 
-### Schritt 5 — Verifizieren
+### Schritt 6 — Verifizieren
 ```bash
 curl http://localhost:8080/api/health
 # Erwartet: {"status":"UP"}
@@ -289,7 +290,7 @@ src/
     └── resources/
         ├── application.properties          ← Konfiguration (DB, JWT, Mail)
         └── db/
-            ├── migration/                  ← Flyway SQL-Migrations (V1–V9)
+            ├── migration/                  ← Flyway SQL-Migrations (V1-V9)
             └── dev-seed.sql                ← Testdaten für lokale Entwicklung
 ```
 
@@ -301,7 +302,6 @@ Flyway führt beim Start automatisch alle noch nicht angewendeten Migrations aus
 
 **Neue Migration anlegen:**
 ```bash
-# Dateiname-Schema: V<nummer>__<beschreibung>.sql
 touch src/main/resources/db/migration/V10__add_column_xyz.sql
 ```
 
@@ -327,15 +327,13 @@ Im `docs/`-Ordner dieses Repos liegt eine ausführliche Dokumentation für jedes
 | Datei | Inhalt |
 |-------|--------|
 | [`docs/ROLLEN.md`](docs/ROLLEN.md) | Rollenkonzept, vollständige Berechtigungsmatrix, Frontend-Patterns |
-| [`docs/milestone-1-auth-benutzerverwaltung.md`](docs/milestone-1-auth-benutzerverwaltung.md) | Issues #1–#7, #9, #56, #57 |
-| [`docs/milestone-2-produktkatalog.md`](docs/milestone-2-produktkatalog.md) | Issues #8, #10, #13–#18, #20, #23–#26, #28, #31, #34, #46, #47 |
-| [`docs/milestone-3-warenkorb-checkout.md`](docs/milestone-3-warenkorb-checkout.md) | Issues #39–#42, #44, #45 |
-| [`docs/milestone-4-bestellhistorie.md`](docs/milestone-4-bestellhistorie.md) | Issues #48–#53, #55 |
-| [`docs/milestone-5-crm-vertrieb.md`](docs/milestone-5-crm-vertrieb.md) | Issues #24, #26–#27, #29, #33–#38, #43, #54 |
-| [`docs/milestone-6-administration-audit.md`](docs/milestone-6-administration-audit.md) | Issues #19, #58–#62 |
+| [`docs/milestone-1-auth-benutzerverwaltung.md`](docs/milestone-1-auth-benutzerverwaltung.md) | Issues #1-#7, #9, #56, #57 |
+| [`docs/milestone-2-produktkatalog.md`](docs/milestone-2-produktkatalog.md) | Issues #8, #10, #13-#18, #20, #23-#26, #28, #31, #34, #46, #47 |
+| [`docs/milestone-3-warenkorb-checkout.md`](docs/milestone-3-warenkorb-checkout.md) | Issues #39-#42, #44, #45 |
+| [`docs/milestone-4-bestellhistorie.md`](docs/milestone-4-bestellhistorie.md) | Issues #48-#53, #55 |
+| [`docs/milestone-5-crm-vertrieb.md`](docs/milestone-5-crm-vertrieb.md) | Issues #24, #26-#27, #29, #33-#38, #43, #54 |
+| [`docs/milestone-6-administration-audit.md`](docs/milestone-6-administration-audit.md) | Issues #19, #58-#62 |
 | [`docs/milestone-8-kundenservice.md`](docs/milestone-8-kundenservice.md) | Issues #11, #12, #21, #22, #30, #32 |
-
-Jede Datei enthält: exakte Endpunkte, Request/Response-Felder, benötigte Rolle und Frontend-Codebeispiele.
 
 ---
 
@@ -361,8 +359,8 @@ Alle Variablen können in einer `.env`-Datei im Root-Verzeichnis gesetzt werden 
 | `CORS_ALLOWED_ORIGINS` | `http://localhost:5173` | Erlaubte Frontend-Origins (kommagetrennt) |
 | `MAIL_HOST` | `smtp.gmail.com` | SMTP-Server |
 | `MAIL_PORT` | `587` | SMTP-Port |
-| `MAIL_USERNAME` | — | SMTP-Benutzername |
-| `MAIL_PASSWORD` | — | SMTP-Passwort / App-Passwort |
+| `MAIL_USERNAME` | - | SMTP-Benutzername |
+| `MAIL_PASSWORD` | - | SMTP-Passwort / App-Passwort |
 | `OLLAMA_BASE_URL` | `http://ollama:11434` | Ollama API URL (intern im Docker-Netzwerk) |
 | `OLLAMA_MODEL` | `gemma4:e4b` | KI-Modell für Shoppi |
 
@@ -401,7 +399,8 @@ Alle Befehle setzen voraus, dass das Backend auf `http://localhost:8080` läuft 
 
 Testdaten einspielen (einmalig):
 ```bash
-docker exec -i webshop-postgres psql -U webshop -d webshop < src/main/resources/db/dev-seed.sql
+docker exec -i webshop-postgres psql -U webshop -d webshop \
+  < src/main/resources/db/dev-seed.sql
 ```
 
 Seeded-Accounts (Passwort überall: `Password1!`):
@@ -410,9 +409,9 @@ Seeded-Accounts (Passwort überall: `Password1!`):
 |---|---|---|
 | alice | CUSTOMER | Privat |
 | bob | CUSTOMER | Business |
-| carol | EMPLOYEE | — |
-| dave | SALES_EMPLOYEE | — |
-| admin | ADMIN | — |
+| carol | EMPLOYEE | - |
+| dave | SALES_EMPLOYEE | - |
+| admin | ADMIN | - |
 
 ---
 
@@ -461,38 +460,6 @@ curl -X POST http://localhost:8080/api/orders \
 curl http://localhost:8080/api/orders -H "Authorization: Bearer $TOKEN"
 ```
 
-### Mitarbeiter-Endpunkte
-```bash
-EMPLOYEE_TOKEN=$(curl -s -X POST http://localhost:8080/api/auth/login \
-  -H "Content-Type: application/json" \
-  -d '{"username":"carol","password":"Password1!"}' \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
-
-SALES_TOKEN=$(curl -s -X POST http://localhost:8080/api/auth/login \
-  -H "Content-Type: application/json" \
-  -d '{"username":"dave","password":"Password1!"}' \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
-
-# Kundenliste
-curl "http://localhost:8080/api/customers" -H "Authorization: Bearer $EMPLOYEE_TOKEN"
-
-# Rabatt anlegen (befristet)
-curl -X POST http://localhost:8080/api/customers/1/discounts \
-  -H "Authorization: Bearer $SALES_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"productId":1,"discountPercent":10,"validFrom":"2026-01-01","validUntil":"2026-12-31"}'
-
-# Unbefristeter Rabatt (validUntil = null)
-curl -X POST http://localhost:8080/api/customers/1/discounts \
-  -H "Authorization: Bearer $SALES_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"productId":1,"discountPercent":5,"validFrom":"2026-01-01","validUntil":null}'
-
-# Umsatzstatistik
-curl "http://localhost:8080/api/customers/1/revenue?from=2026-01-01&to=2026-12-31" \
-  -H "Authorization: Bearer $SALES_TOKEN"
-```
-
 ### Shoppi KI-Assistent
 ```bash
 # Unauthentifiziert (nur Produktkatalog-Kontext)
@@ -500,7 +467,7 @@ curl -s -X POST http://localhost:8080/api/chat/message \
   -H "Content-Type: application/json" \
   -d '{"message":"Welche Produkte habt ihr?","history":[]}' | python3 -m json.tool
 
-# Als eingeloggter Kunde (mit persönlichem Kontext)
+# Als eingeloggter Kunde (mit persoenlichem Kontext)
 curl -s -X POST http://localhost:8080/api/chat/message \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
@@ -517,7 +484,7 @@ ADMIN_TOKEN=$(curl -s -X POST http://localhost:8080/api/auth/login \
 # Alle Benutzer
 curl http://localhost:8080/api/admin/users -H "Authorization: Bearer $ADMIN_TOKEN"
 
-# Identität annehmen (gibt Token zurück, der als alice funktioniert)
+# Identitaet annehmen (gibt Token zurueck, der als alice funktioniert)
 curl -X POST http://localhost:8080/api/admin/impersonate/1 -H "Authorization: Bearer $ADMIN_TOKEN"
 
 # Audit-Log
@@ -528,15 +495,15 @@ curl http://localhost:8080/api/admin/audit-log -H "Authorization: Bearer $ADMIN_
 
 ## 13. User Story Abdeckung
 
-Alle 62 User Stories sind implementiert. Übersicht:
+Alle 62 User Stories sind implementiert. Uebersicht:
 
 | US | Beschreibung | Endpunkt / Mechanismus | Rolle |
 |---|---|---|---|
 | 1 | Login | `POST /api/auth/login` | Public |
 | 2 | Registrieren | `POST /api/auth/register` | Public |
 | 3 | Rolle bei Registrierung | Automatisch: Default `CUSTOMER`; EMPLOYEE/ADMIN werden von ADMIN gesetzt | System |
-| 4 | Passwort ändern | `PUT /api/users/me/password` | AUTHENTICATED |
-| 5 | E-Mail ändern | `PUT /api/users/me/email` | AUTHENTICATED |
+| 4 | Passwort aendern | `PUT /api/users/me/password` | AUTHENTICATED |
+| 5 | E-Mail aendern | `PUT /api/users/me/email` | AUTHENTICATED |
 | 6 | Logout | `POST /api/auth/logout` (Token-Blacklist) | AUTHENTICATED |
 | 7 | Deregistrieren | `DELETE /api/users/me` | AUTHENTICATED |
 | 8 | Kaufbares Sortiment (Kunde) | `GET /api/products?purchasable=true` | CUSTOMER |
@@ -544,56 +511,56 @@ Alle 62 User Stories sind implementiert. Übersicht:
 | 10 | Volles Sortiment (Mitarbeiter) | `GET /api/products` (ohne purchasable-Filter) | EMPLOYEE |
 | 11 | Warenkorb eines Kunden | `GET /api/customers/{id}/cart` | EMPLOYEE |
 | 12 | Kundennummer eines Kunden | `GET /api/customers/{id}` → Feld `customerNumber` | EMPLOYEE |
-| 13 | Artikel hinzufügen | `POST /api/products` | EMPLOYEE |
+| 13 | Artikel hinzufuegen | `POST /api/products` | EMPLOYEE |
 | 14 | Artikel entfernen | `DELETE /api/products/{id}` | EMPLOYEE |
 | 15 | Artikel als kaufbar markieren | `PUT /api/products/{id}/purchasable` | EMPLOYEE |
 | 16 | Beschreibung bearbeiten | `PUT /api/products/{id}/description` | EMPLOYEE |
 | 17 | Bild bearbeiten | `PUT /api/products/{id}/image` | EMPLOYEE |
 | 18 | UVP bearbeiten | `PUT /api/products/{id}/price` | SALES_EMPLOYEE |
-| 19 | Identität annehmen | `POST /api/admin/impersonate/{userId}` | ADMIN |
-| 20 | Artikeldaten wie Kunde sieht | `GET /api/products` + `GET /api/products/{id}/price-for-customer` mit Kunden-ID | EMPLOYEE |
+| 19 | Identitaet annehmen | `POST /api/admin/impersonate/{userId}` | ADMIN |
+| 20 | Artikeldaten wie Kunde sieht | `GET /api/products` + `GET /api/products/{id}/price-for-customer` | EMPLOYEE |
 | 21 | Artikel in Kunden-Warenkorb | `POST /api/customers/{id}/cart/items` | EMPLOYEE |
 | 22 | Artikel aus Kunden-Warenkorb | `DELETE /api/customers/{id}/cart/items/{productId}` | EMPLOYEE |
 | 23 | Artikelbeschreibung sehen | `GET /api/products/{id}` → Feld `description` | CUSTOMER |
 | 24 | Artikelbild sehen | `GET /api/products/{id}` → Feld `imageUrl` | CUSTOMER |
 | 25 | UVP sehen | `GET /api/products/{id}` → Feld `recommendedRetailPrice` | CUSTOMER |
-| 26 | Persönlicher Preis (inkl. Rabatte + Steuern) | `GET /api/products/{id}/price-for-customer` | CUSTOMER |
+| 26 | Persoenlicher Preis (inkl. Rabatte + Steuern) | `GET /api/products/{id}/price-for-customer` | CUSTOMER |
 | 27 | Befristeter Rabatt | `POST /api/customers/{id}/discounts` mit `validUntil` gesetzt | SALES_EMPLOYEE |
-| 28 | Privat- vs. Unternehmenskunde unterscheiden | Feld `userType` (PRIVATE/BUSINESS) in Profil + Kundenliste | SALES_EMPLOYEE |
-| 29 | Branche & Unternehmensgröße | `GET /api/customers/{id}/business-info` | SALES_EMPLOYEE |
+| 28 | Privat- vs. Unternehmenskunde | Feld `userType` (PRIVATE/BUSINESS) in Profil + Kundenliste | SALES_EMPLOYEE |
+| 29 | Branche & Unternehmensgroesse | `GET /api/customers/{id}/business-info` | SALES_EMPLOYEE |
 | 30 | Unbefristeter Rabatt | `POST /api/customers/{id}/discounts` mit `validUntil: null` | SALES_EMPLOYEE |
-| 31 | Coupons gewähren | `POST /api/customers/{id}/coupons` | SALES_EMPLOYEE |
+| 31 | Coupons gewaehren | `POST /api/customers/{id}/coupons` | SALES_EMPLOYEE |
 | 32 | Artikel promoten | `PUT /api/products/{id}/promoted` | SALES_EMPLOYEE |
 | 33 | Bestellungen eines Kunden | `GET /api/customers/{id}/orders` | SALES_EMPLOYEE |
 | 34 | Umsatzstatistik eines Kunden | `GET /api/customers/{id}/revenue?from=&to=` | SALES_EMPLOYEE |
-| 35 | Kundenübersicht | `GET /api/customers` | EMPLOYEE |
+| 35 | Kundenuebersicht | `GET /api/customers` | EMPLOYEE |
 | 36 | Kunden filtern | `GET /api/customers?search={term}` | EMPLOYEE |
 | 37 | Artikel-Statistik (Absatz, Preise) | `GET /api/products/{id}/statistics?from=&to=` | SALES_EMPLOYEE |
-| 38 | Benachrichtigung >20% Absatzrückgang | `NotificationScheduler` — läuft jeden Montag 07:00, loggt Warnungen | System |
-| 39 | Benachrichtigung 0 Absatz | `NotificationScheduler` — läuft jeden Montag 07:00, loggt Warnungen | System |
+| 38 | Benachrichtigung >20% Absatzrueckgang | `NotificationScheduler` — laeuft jeden Montag 07:00 | System |
+| 39 | Benachrichtigung 0 Absatz | `NotificationScheduler` — laeuft jeden Montag 07:00 | System |
 | 40 | E-Mail an Kunden senden | `POST /api/customers/{id}/email` | SALES_EMPLOYEE |
 | 41 | Artikel in Warenkorb | `POST /api/cart/items` | CUSTOMER |
 | 42 | Artikel aus Warenkorb | `DELETE /api/cart/items/{productId}` | CUSTOMER |
-| 43 | Warenkorbübersicht (Summe, Steuern, Versand) | `GET /api/cart` — enthält subtotal, tax, shippingCost, total | CUSTOMER |
+| 43 | Warenkorbübersicht (Summe, Steuern, Versand) | `GET /api/cart` | CUSTOMER |
 | 44 | Bestellen | `POST /api/orders` | CUSTOMER |
 | 45 | Zahlungsart festlegen | `PUT /api/users/me/payment-method` | CUSTOMER |
 | 46 | Lieferadresse festlegen | `PUT /api/users/me/delivery-address` | CUSTOMER |
 | 47 | Sortiment nach Suchbegriffen filtern | `GET /api/products?search={term}` | CUSTOMER |
 | 48 | Sortiment nach Kategorie filtern | `GET /api/products?category={cat}` | CUSTOMER |
 | 49 | Bestellhistorie | `GET /api/orders` | CUSTOMER |
-| 50 | Kaufbare Artikel in alter Bestellung | `GET /api/orders/{id}` → Feld `items[].purchasable` zeigt Verfügbarkeit | CUSTOMER |
+| 50 | Kaufbare Artikel in alter Bestellung | `GET /api/orders/{id}` → Feld `items[].purchasable` | CUSTOMER |
 | 51 | Nachbestellung (Reorder) | `POST /api/cart/reorder/{orderId}` | CUSTOMER |
 | 52 | Dauerauftrag erstellen | `POST /api/standing-orders` | CUSTOMER |
 | 53 | Dauerauftrag stornieren | `DELETE /api/standing-orders/{id}` | CUSTOMER |
-| 54 | Dauerauftrag ändern | `PUT /api/standing-orders/{id}` | CUSTOMER |
-| 55 | Benachrichtigung Dauerauftrag (nicht mehr kaufbar) | `StandingOrderScheduler` — täglich 06:00, loggt Warnungen | System |
-| 56 | Personenbezogene Daten schützen | Spring Security: rollenbasierter Zugriff, JWT, keine Datenlecks über API-Grenzen | NFR |
-| 57 | Unternehmensdaten schützen | Spring Security: EMPLOYEE/SALES_EMPLOYEE-Endpunkte nur mit gültiger Rolle erreichbar | NFR |
+| 54 | Dauerauftrag aendern | `PUT /api/standing-orders/{id}` | CUSTOMER |
+| 55 | Benachrichtigung Dauerauftrag (nicht mehr kaufbar) | `StandingOrderScheduler` — taeglich 06:00 | System |
+| 56 | Personenbezogene Daten schuetzen | Spring Security: rollenbasierter Zugriff, JWT | NFR |
+| 57 | Unternehmensdaten schuetzen | Spring Security: EMPLOYEE/SALES_EMPLOYEE-Endpunkte geschuetzt | NFR |
 | 58 | System-Transaktionen einsehen | `GET /api/admin/audit-log` | ADMIN |
-| 59 | Benutzerübersicht | `GET /api/admin/users` | ADMIN |
+| 59 | Benutzuebersicht | `GET /api/admin/users` | ADMIN |
 | 60 | Benutzer filtern | `GET /api/admin/users?search={term}` | ADMIN |
 | 61 | Benutzer deregistrieren | `DELETE /api/admin/users/{id}` | ADMIN |
-| 62 | Admin- vs. System-Änderungen unterscheiden | `audit_log.initiated_by` = `USER` / `ADMIN` / `SYSTEM` | NFR |
+| 62 | Admin- vs. System-Aenderungen unterscheiden | `audit_log.initiated_by` = `USER` / `ADMIN` / `SYSTEM` | NFR |
 
 **Ergebnis: 62 von 62 User Stories abgedeckt.**
 
@@ -643,6 +610,6 @@ usermod -aG sudo deploy
 # Lokal: Key generieren (falls noch keiner existiert)
 ssh-keygen -t ed25519 -C "github-actions"
 
-# Öffentlichen Key auf den Server kopieren
+# Oeffentlichen Key auf den Server kopieren
 ssh-copy-id deploy@DEINE-IP
 ```

--- a/README.md
+++ b/README.md
@@ -123,6 +123,15 @@ Das verwendete Modell `gemma4:e4b` (Google DeepMind) wird beim ersten Start manu
 docker exec webshop-ollama ollama pull gemma4:e4b
 ```
 
+**GPU-Beschleunigung:** `dev.ps1` erkennt beim Start automatisch die verbaute GPU und lädt das passende Docker-Compose-Override:
+
+| GPU | Verhalten |
+|---|---|
+| NVIDIA | `docker-compose.gpu-nvidia.yml` wird automatisch eingebunden (NVIDIA Container Toolkit nötig) |
+| AMD | Info-Meldung — ROCm funktioniert nur unter Linux, auf Windows läuft Ollama auf CPU |
+| Intel | Info-Meldung — kein GPU-Support im Docker-Container auf Windows, CPU-Fallback |
+| Keine | CPU-Modus |
+
 **Shoppi** ist der KI-Assistent des Webshops. Der Endpunkt `POST /api/chat/message` ist öffentlich, aber auth-aware: eingeloggte Kunden erhalten einen personalisierten Kontext (Warenkorb, Bestellhistorie, Profil) im System-Prompt.
 
 ---
@@ -334,6 +343,11 @@ src/
         └── db/
             ├── migration/                  ← Flyway SQL-Migrations (V1–V9)
             └── dev-seed.sql                ← Testdaten für lokale Entwicklung
+
+docker-compose.yml                          ← Basis: PostgreSQL + Ollama (CPU) + Backend
+docker-compose.gpu-nvidia.yml              ← Override: NVIDIA GPU für Ollama (auto-geladen)
+docker-compose.gpu-amd.yml                 ← Override: AMD GPU / ROCm für Ollama (Linux, auto-geladen)
+dev.ps1                                     ← Dev-Script: erkennt GPU automatisch und wählt Override
 ```
 
 ### Wie ein Package aufgebaut ist

--- a/README.md
+++ b/README.md
@@ -207,10 +207,10 @@ Das Backend ist dann erreichbar unter: `http://localhost:8080`
 ```bash
 docker exec webshop-ollama ollama pull gemma4:e4b
 ```
-Dieser Download (~3 GB) ist nur einmalig nötig. Das Modell wird im Docker-Volume `ollama_data` gecacht.
+Dieser Download (~10 GB) ist nur einmalig nötig. Das Modell wird im Docker-Volume `ollama_data` gecacht.
 
 > **Fehler: „pull model manifest: 412 — requires a newer version of Ollama"?**
-> Das lokale Ollama-Image ist veraltet (z.B. von einer früheren Installation). Image updaten und Container neu starten:
+> Das lokale Ollama-Image ist veraltet (z.B. von einer früheren Installation). Image updaten (~4 GB) und Container neu starten:
 > ```bash
 > docker pull ollama/ollama:latest
 > docker compose up -d --no-deps ollama

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Spring Boot Backend für den Webshop. Stellt eine REST API bereit, die vom React
 Browser
   └── Frontend (React + Vite, Port 5173)
         └──[HTTP / REST API / JSON]──► Backend (Spring Boot, Port 8080)
-                                            └──[JPA / SQL]──► PostgreSQL (Port 5432)
+                                            ├──[JPA / SQL]──► PostgreSQL (Port 5432)
+                                            └──[REST]──────► Ollama (Port 11434, lokal)
 ```
 
 Das Frontend schickt HTTP-Anfragen an das Backend (z.B. `GET /api/products`).
@@ -54,6 +55,7 @@ Jede Anfrage wird über einen JWT-Token authentifiziert (außer Login/Register).
 | JWT (jjwt) | Authentifizierung | 0.12.6 |
 | springdoc-openapi | OpenAPI Spec generieren | 2.8.6 |
 | Docker + Compose | Lokale Entwicklungsumgebung | - |
+| Ollama | Lokale KI-Laufzeitumgebung für Shoppi | latest |
 | NGINX | Reverse Proxy + HTTPS (Produktion) | - |
 | GitHub Actions | CI/CD-Pipelines | - |
 
@@ -112,6 +114,19 @@ Docker lässt PostgreSQL in einem isolierten Container laufen — kein manuelles
 ### springdoc-openapi — API-Beschreibung
 Liest den Spring Boot Code und generiert automatisch eine maschinenlesbare Beschreibung aller Endpunkte (`/v3/api-docs`). Das Frontend-Team kann daraus ablesen wie ein API-Call aussehen muss, ohne beim Backend-Team nachzufragen.
 
+### Ollama — lokale KI-Laufzeitumgebung
+
+Ollama führt KI-Sprachmodelle lokal auf dem Server aus. Dadurch werden keine Daten an Drittanbieter wie OpenAI oder Google Cloud gesendet. Das Backend kommuniziert intern über `http://ollama:11434` mit dem Ollama-Container.
+
+Das verwendete Modell `gemma4:e4b` (Google DeepMind) wird beim ersten Start manuell gezogen (einmalig, ~3 GB):
+```bash
+docker exec webshop-ollama ollama pull gemma4:e4b
+```
+
+**Shoppi** ist der KI-Assistent des Webshops. Der Endpunkt `POST /api/chat/message` ist öffentlich, aber auth-aware: eingeloggte Kunden erhalten einen personalisierten Kontext (Warenkorb, Bestellhistorie, Profil) im System-Prompt.
+
+---
+
 ### GitHub Actions — CI/CD
 Zwei Pipelines:
 - **CI**: Bei jedem Pull Request wird automatisch `mvn test` ausgeführt.
@@ -162,8 +177,9 @@ cd Webshop-Backend
 
 Das Script baut und startet alle Container automatisch:
 1. PostgreSQL-Container starten (wartet bis er `healthy` ist)
-2. Spring Boot-Image bauen (Maven läuft im Container — kein Java lokal nötig)
-3. Backend-Container starten und auf `/api/health` warten
+2. Ollama-Container starten
+3. Spring Boot-Image bauen (Maven läuft im Container — kein Java lokal nötig)
+4. Backend-Container starten und auf `/api/health` warten
 
 Das Backend ist dann erreichbar unter: `http://localhost:8080`
 
@@ -187,12 +203,18 @@ Das Backend ist dann erreichbar unter: `http://localhost:8080`
 > Nach Änderungen am `Dockerfile` oder wenn der Layer-Cache einen veralteten Stand hat.
 > Für normale Code-Änderungen reicht `restart`.
 
-### Schritt 3 — Testdaten einspielen (einmalig)
+### Schritt 3 — Ollama-Modell ziehen (einmalig, nur für Shoppi KI-Assistent)
+```bash
+docker exec webshop-ollama ollama pull gemma4:e4b
+```
+Dieser Download (~3 GB) ist nur einmalig nötig. Das Modell wird im Docker-Volume `ollama_data` gecacht.
+
+### Schritt 4 — Testdaten einspielen (einmalig)
 ```bat
 docker exec -i webshop-postgres psql -U webshop -d webshop < src/main/resources/db/dev-seed.sql
 ```
 
-### Schritt 4 — Verifizieren
+### Schritt 5 — Verifizieren
 ```bash
 curl http://localhost:8080/api/health
 # Erwartet: {"status":"UP"}
@@ -283,6 +305,15 @@ src/
     │   │   ├── EmailService.java
     │   │   ├── NotificationScheduler.java  ← @Scheduled (montags 07:00)
     │   │   └── dto/
+    │   │
+    │   ├── chat/                           ← Shoppi KI-Assistent
+    │   │   ├── ChatController.java         ← POST /api/chat/message (public, auth-aware)
+    │   │   ├── ChatService.java            ← System-Prompt bauen + Ollama aufrufen
+    │   │   ├── OllamaClient.java           ← HTTP-Client für Ollama REST API
+    │   │   └── dto/
+    │   │       ├── ChatMessageRequest.java
+    │   │       ├── ChatMessageResponse.java
+    │   │       └── ConversationEntry.java
     │   │
     │   └── admin/                          ← Admin-Endpunkte & Audit-Log
     │       ├── AuditLog.java
@@ -622,6 +653,47 @@ Rabatt-Body:
 
 ---
 
+#### Shoppi KI-Assistent (`/api/chat`)
+
+| Aktion | Methode | URL | Body | Auth |
+|---|---|---|---|---|
+| Nachricht senden | POST | `/api/chat/message` | `{message, history[]}` | Optional (JWT für Kontext) |
+
+Request-Body:
+```json
+{
+  "message": "Was habe ich im Warenkorb?",
+  "history": [
+    { "role": "user", "content": "Hallo" },
+    { "role": "assistant", "content": "Hallo! Ich bin Shoppi..." }
+  ]
+}
+```
+
+Antwort:
+```json
+{ "reply": "Du hast aktuell 2 Artikel im Warenkorb: ..." }
+```
+
+- **Ohne JWT:** Shoppi kennt nur den öffentlichen Produktkatalog.
+- **Mit JWT (CUSTOMER-Rolle):** Shoppi erhält zusätzlich Profil, Warenkorb und letzte 5 Bestellungen im System-Prompt.
+- Das Modell läuft lokal via Ollama — keine Daten verlassen den Server.
+
+```powershell
+# Unauthentifiziert
+Invoke-RestMethod -Method Post http://localhost:8080/api/chat/message `
+  -ContentType "application/json" `
+  -Body '{"message":"Welche Produkte habt ihr?","history":[]}'
+
+# Als eingeloggter Kunde
+Invoke-RestMethod -Method Post http://localhost:8080/api/chat/message `
+  -Headers @{Authorization="Bearer $TOKEN"} `
+  -ContentType "application/json" `
+  -Body '{"message":"Was habe ich im Warenkorb?","history":[]}'
+```
+
+---
+
 #### Admin-Endpunkte (`/api/admin`)
 
 | Aktion | Methode | URL | Rolle |
@@ -703,6 +775,10 @@ CORS_ALLOWED_ORIGINS=http://localhost:5173
 # Mail (für Benachrichtigungen)
 MAIL_HOST=localhost
 MAIL_PORT=1025
+
+# Shoppi KI-Assistent (Ollama)
+OLLAMA_BASE_URL=http://ollama:11434
+OLLAMA_MODEL=gemma4:e4b
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Dieser Download (~10 GB) ist nur einmalig nötig. Das Modell wird im Docker-Volu
 
 ### Schritt 4 — Testdaten einspielen (einmalig)
 ```bat
-docker exec -i webshop-postgres psql -U webshop -d webshop < src/main/resources/db/dev-seed.sql
+Get-Content src/main/resources/db/dev-seed.sql | docker exec -i webshop-postgres psql -U webshop -d webshop
 ```
 
 ### Schritt 5 — Verifizieren
@@ -700,6 +700,7 @@ Antwort:
 - **Ohne JWT:** Shoppi kennt nur den öffentlichen Produktkatalog.
 - **Mit JWT (CUSTOMER-Rolle):** Shoppi erhält zusätzlich Profil, Warenkorb und letzte 5 Bestellungen im System-Prompt.
 - Das Modell läuft lokal via Ollama — keine Daten verlassen den Server.
+- **Markdown:** Der System-Prompt informiert das Modell, dass es Markdown verwenden kann (Fettdruck, Listen, Überschriften). Das Frontend rendert Bot-Antworten als Markdown. Der System-Prompt ist in `ChatService.java` (`buildSystemPrompt()`) konfigurierbar.
 
 ```powershell
 # Unauthentifiziert

--- a/README.md
+++ b/README.md
@@ -209,6 +209,14 @@ docker exec webshop-ollama ollama pull gemma4:e4b
 ```
 Dieser Download (~3 GB) ist nur einmalig nötig. Das Modell wird im Docker-Volume `ollama_data` gecacht.
 
+> **Fehler: „pull model manifest: 412 — requires a newer version of Ollama"?**
+> Das lokale Ollama-Image ist veraltet (z.B. von einer früheren Installation). Image updaten und Container neu starten:
+> ```bash
+> docker pull ollama/ollama:latest
+> docker compose up -d --no-deps ollama
+> docker exec webshop-ollama ollama pull gemma4:e4b
+> ```
+
 ### Schritt 4 — Testdaten einspielen (einmalig)
 ```bat
 docker exec -i webshop-postgres psql -U webshop -d webshop < src/main/resources/db/dev-seed.sql

--- a/dev.ps1
+++ b/dev.ps1
@@ -55,17 +55,17 @@ function Get-OllamaComposeFiles {
 
     switch ($gpuVendor) {
         "nvidia" {
-            Write-Host "GPU detected: NVIDIA — enabling GPU acceleration for Ollama."
+            Write-Host "GPU detected: NVIDIA - enabling GPU acceleration for Ollama."
             $composeFiles += "`"$RootPath\docker-compose.gpu-nvidia.yml`""
         }
         "amd" {
-            Write-Host "GPU detected: AMD — GPU acceleration requires ROCm (Linux only). Running Ollama on CPU."
+            Write-Host "GPU detected: AMD - GPU acceleration requires ROCm (Linux only). Running Ollama on CPU."
         }
         "intel" {
-            Write-Host "GPU detected: Intel — GPU acceleration for Ollama in Docker is not supported on Windows. Running on CPU."
+            Write-Host "GPU detected: Intel - GPU acceleration for Ollama in Docker is not supported on Windows. Running on CPU."
         }
         default {
-            Write-Host "No dedicated GPU detected — Ollama will run on CPU."
+            Write-Host "No dedicated GPU detected - Ollama will run on CPU."
         }
     }
 
@@ -215,7 +215,7 @@ function Start-Backend {
     if (-not (Test-DockerRunning)) { return }
 
     if (Test-RebuildNeeded) {
-        Write-Host "Source changes detected since last build — rebuilding automatically."
+        Write-Host "Source changes detected since last build - rebuilding automatically."
         Write-Host "-------------------------------------------------------------------------------"
         Rebuild-Backend
         return

--- a/dev.ps1
+++ b/dev.ps1
@@ -26,6 +26,50 @@ $HealthUrl = "http://localhost:$Port/api/health"
 
 # --- helpers -----------------------------------------------------------------
 
+function Get-GpuVendor {
+    # Fastest check: nvidia-smi is available if NVIDIA drivers are installed
+    if (Get-Command nvidia-smi -ErrorAction SilentlyContinue) {
+        return "nvidia"
+    }
+    # Fallback: query WMI for video controllers
+    try {
+        $gpuControllers = Get-WmiObject Win32_VideoController |
+            Where-Object { $_.Name -notmatch "Virtual|Remote|Basic" -and $_.AdapterCompatibility -notmatch "Microsoft" }
+        foreach ($gpuController in $gpuControllers) {
+            $gpuInfo = "$($gpuController.Name) $($gpuController.AdapterCompatibility)"
+            if ($gpuInfo -match "NVIDIA")                          { return "nvidia" }
+            if ($gpuInfo -match "AMD|Radeon|Advanced Micro Devices") { return "amd" }
+            if ($gpuInfo -match "Intel")                           { return "intel" }
+        }
+    } catch {}
+    return "none"
+}
+
+function Get-OllamaComposeFiles {
+    param([string]$RootPath)
+
+    $gpuVendor = Get-GpuVendor
+    $composeFiles = @("`"$RootPath\docker-compose.yml`"")
+
+    switch ($gpuVendor) {
+        "nvidia" {
+            Write-Host "GPU detected: NVIDIA — enabling GPU acceleration for Ollama."
+            $composeFiles += "`"$RootPath\docker-compose.gpu-nvidia.yml`""
+        }
+        "amd" {
+            Write-Host "GPU detected: AMD — GPU acceleration requires ROCm (Linux only). Running Ollama on CPU."
+        }
+        "intel" {
+            Write-Host "GPU detected: Intel — GPU acceleration for Ollama in Docker is not supported on Windows. Running on CPU."
+        }
+        default {
+            Write-Host "No dedicated GPU detected — Ollama will run on CPU."
+        }
+    }
+
+    return ($composeFiles -join " -f ")
+}
+
 function Test-DockerRunning {
     docker info 2>$null | Out-Null
     if ($LASTEXITCODE -ne 0) {
@@ -58,11 +102,14 @@ function Wait-ForBackend {
 function Show-SeedHint {
     Write-Host ""
     Write-Host "--- Seed data (optional, run once) ---"
-    Write-Host "  docker exec -i webshop-postgres psql -U webshop -d webshop < src/main/resources/db/dev-seed.sql"
+    Write-Host "  Windows (PowerShell):"
+    Write-Host "    Get-Content src/main/resources/db/dev-seed.sql | docker exec -i webshop-postgres psql -U webshop -d webshop"
+    Write-Host "  Linux / macOS (bash):"
+    Write-Host "    docker exec -i webshop-postgres psql -U webshop -d webshop < src/main/resources/db/dev-seed.sql"
     Write-Host ""
     Write-Host "--- Shoppi KI-Assistent (Ollama model, run once) ---"
     Write-Host "  docker exec webshop-ollama ollama pull gemma4:e4b"
-    Write-Host "  (This downloads ~3 GB on first run. The model is cached in the ollama_data volume.)"
+    Write-Host "  (This downloads ~10 GB on first run. The model is cached in the ollama_data volume.)"
     Write-Host ""
 }
 
@@ -88,11 +135,12 @@ function Start-Backend {
     Write-Host "(First run: Maven downloads dependencies inside the container - may take a few minutes)"
     Write-Host "-------------------------------------------------------------------------------"
 
+    $composeFiles = Get-OllamaComposeFiles -RootPath $Root
+
     if ($KeepDb) {
-        # PostgreSQL is already running - only start/rebuild the backend service
-        docker compose -f "$Root\docker-compose.yml" up -d --build backend
+        Invoke-Expression "docker compose -f $composeFiles up -d --build backend"
     } else {
-        docker compose -f "$Root\docker-compose.yml" up -d --build
+        Invoke-Expression "docker compose -f $composeFiles up -d --build"
     }
 
     if ($LASTEXITCODE -ne 0) {
@@ -115,11 +163,13 @@ function Rebuild-Backend {
     Write-Host "Forcing full rebuild (no layer cache)..."
     if (-not (Test-DockerRunning)) { return }
 
+    $composeFiles = Get-OllamaComposeFiles -RootPath $Root
+
     if ($KeepDb) {
-        docker compose -f "$Root\docker-compose.yml" up -d --build --force-recreate backend
+        Invoke-Expression "docker compose -f $composeFiles up -d --build --force-recreate backend"
     } else {
-        docker compose -f "$Root\docker-compose.yml" down
-        docker compose -f "$Root\docker-compose.yml" up -d --build --force-recreate
+        Invoke-Expression "docker compose -f $composeFiles down"
+        Invoke-Expression "docker compose -f $composeFiles up -d --build --force-recreate"
     }
 
     if ($LASTEXITCODE -ne 0) {

--- a/dev.ps1
+++ b/dev.ps1
@@ -60,6 +60,10 @@ function Show-SeedHint {
     Write-Host "--- Seed data (optional, run once) ---"
     Write-Host "  docker exec -i webshop-postgres psql -U webshop -d webshop < src/main/resources/db/dev-seed.sql"
     Write-Host ""
+    Write-Host "--- Shoppi KI-Assistent (Ollama model, run once) ---"
+    Write-Host "  docker exec webshop-ollama ollama pull gemma4:e4b"
+    Write-Host "  (This downloads ~3 GB on first run. The model is cached in the ollama_data volume.)"
+    Write-Host ""
 }
 
 # --- stop --------------------------------------------------------------------

--- a/dev.ps1
+++ b/dev.ps1
@@ -3,11 +3,14 @@
 #         ./dev.bat stop    --keep-db   (stop backend container, keep PostgreSQL running)
 #         ./dev.bat restart --keep-db
 #         ./dev.bat rebuild --keep-db
+#         ./dev.bat         (no argument: shows help and prompts interactively)
 #
 # Requirements: Docker Desktop (no Java or Maven needed locally)
 #
 # How it works:
 #   start   -> docker compose up -d --build
+#              Auto-detects source changes (src/, pom.xml, Dockerfile) and switches
+#              to a full rebuild automatically if any file is newer than the last image.
 #              (first run: Maven downloads ~200 MB of dependencies inside the container)
 #              Polls /api/health until the app responds, then prints the ready message.
 #   stop    -> docker compose down  (or stop only backend with --keep-db)
@@ -15,8 +18,7 @@
 #   rebuild -> docker compose up -d --build --force-recreate
 
 param(
-    [Parameter(Mandatory)][ValidateSet("start","stop","restart","rebuild")]
-    [string]$Command,
+    [string]$Command = "",
     [switch]$KeepDb
 )
 
@@ -79,6 +81,88 @@ function Test-DockerRunning {
     return $true
 }
 
+function Show-Usage {
+    Write-Host ""
+    Write-Host "Usage:  ./dev.bat <command> [--keep-db]"
+    Write-Host ""
+    Write-Host "Commands:"
+    Write-Host "  start    Start all containers (auto-detects if rebuild is needed)"
+    Write-Host "  stop     Stop all containers"
+    Write-Host "  restart  Stop backend, then start backend"
+    Write-Host "  rebuild  Force full rebuild (recreates containers, no layer cache)"
+    Write-Host ""
+    Write-Host "Options:"
+    Write-Host "  --keep-db   Keep PostgreSQL running (combine with stop/restart/rebuild)"
+    Write-Host ""
+}
+
+function Read-CommandInteractive {
+    Show-Usage
+    $inputCommand = (Read-Host "Enter command (start/stop/restart/rebuild)").Trim().ToLower()
+
+    if ($inputCommand -notin @("start", "stop", "restart", "rebuild")) {
+        Write-Host "ERROR: Unknown command '$inputCommand'."
+        exit 1
+    }
+
+    $keepDbAnswer = (Read-Host "Keep PostgreSQL running? [y/N]").Trim().ToLower()
+    if ($keepDbAnswer -in @("y", "j")) {
+        $script:KeepDb = $true
+    }
+
+    return $inputCommand
+}
+
+function Get-BackendImageCreated {
+    $imageId = docker inspect webshop-backend --format "{{.Image}}" 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $imageId) { return $null }
+
+    $createdString = docker inspect $imageId --format "{{.Created}}" 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $createdString) { return $null }
+
+    try {
+        return [datetime]::Parse(
+            $createdString,
+            $null,
+            [System.Globalization.DateTimeStyles]::RoundtripKind
+        )
+    } catch {
+        return $null
+    }
+}
+
+function Test-RebuildNeeded {
+    $imageCreated = Get-BackendImageCreated
+    if ($null -eq $imageCreated) { return $false }
+
+    $trackedPaths = @(
+        (Join-Path $Root "src"),
+        (Join-Path $Root "pom.xml"),
+        (Join-Path $Root "Dockerfile")
+    )
+
+    foreach ($trackedPath in $trackedPaths) {
+        if (-not (Test-Path $trackedPath)) { continue }
+
+        $pathItem = Get-Item $trackedPath
+        $filesToCheck = if ($pathItem.PSIsContainer) {
+            Get-ChildItem -Path $trackedPath -Recurse -File
+        } else {
+            @($pathItem)
+        }
+
+        foreach ($fileItem in $filesToCheck) {
+            if ($fileItem.LastWriteTimeUtc -gt $imageCreated) {
+                $relativePath = $fileItem.FullName.Substring($Root.Length).TrimStart('\', '/')
+                Write-Host "Changed since last build: $relativePath"
+                return $true
+            }
+        }
+    }
+
+    return $false
+}
+
 function Wait-ForBackend {
     Write-Host "Waiting for backend to be ready..." -NoNewline
     for ($i = 0; $i -lt 90; $i++) {
@@ -129,6 +213,13 @@ function Stop-Backend {
 
 function Start-Backend {
     if (-not (Test-DockerRunning)) { return }
+
+    if (Test-RebuildNeeded) {
+        Write-Host "Source changes detected since last build — rebuilding automatically."
+        Write-Host "-------------------------------------------------------------------------------"
+        Rebuild-Backend
+        return
+    }
 
     Write-Host ""
     Write-Host "Building and starting backend..."
@@ -187,6 +278,15 @@ function Rebuild-Backend {
 }
 
 # --- dispatch ----------------------------------------------------------------
+
+if (-not $Command) {
+    $Command = Read-CommandInteractive
+}
+
+if ($Command -notin @("start", "stop", "restart", "rebuild")) {
+    Write-Host "ERROR: Unknown command '$Command'. Run './dev.bat' without arguments for help."
+    exit 1
+}
 
 switch ($Command) {
     "start"   { Start-Backend }

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+# dev.sh - Start, stop, restart or rebuild the Webshop backend via Docker
+# Usage:  ./dev.sh start   | stop | restart | rebuild
+#         ./dev.sh stop    --keep-db   (stop backend container, keep PostgreSQL running)
+#         ./dev.sh restart --keep-db
+#         ./dev.sh rebuild --keep-db
+#         ./dev.sh          (no argument: shows help and prompts interactively)
+#
+# Requirements: Docker Desktop (no Java or Maven needed locally)
+#               python3 (optional - used for auto-rebuild detection)
+#
+# How it works:
+#   start   -> docker compose up -d --build
+#              Auto-detects source changes (src/, pom.xml, Dockerfile) and switches
+#              to a full rebuild automatically if any file is newer than the last image.
+#              (first run: Maven downloads ~200 MB of dependencies inside the container)
+#              Polls /api/health until the app responds, then prints the ready message.
+#   stop    -> docker compose down  (or stop only backend with --keep-db)
+#   restart -> stop backend + start backend
+#   rebuild -> docker compose up -d --build --force-recreate
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PORT=8080
+HEALTH_URL="http://localhost:$PORT/api/health"
+
+COMMAND="${1:-}"
+KEEP_DB=false
+COMPOSE_FILES=()
+
+# Shift past the command arg, then scan remaining args for flags
+[[ $# -gt 0 ]] && shift
+for arg in "$@"; do
+    [[ "$arg" == "--keep-db" ]] && KEEP_DB=true
+done
+
+# --- helpers -----------------------------------------------------------------
+
+get_gpu_vendor() {
+    local os
+    os="$(uname -s)"
+
+    # macOS: Docker runs in a Linux VM - no GPU passthrough support on any Mac hardware
+    if [[ "$os" == "Darwin" ]]; then
+        echo "macos"
+        return
+    fi
+
+    # Linux: nvidia-smi is the fastest check
+    if command -v nvidia-smi &>/dev/null; then
+        echo "nvidia"
+        return
+    fi
+
+    # Linux fallback: query PCI devices
+    if command -v lspci &>/dev/null; then
+        local gpu_info
+        gpu_info="$(lspci 2>/dev/null | grep -iE 'VGA|3D|Display')"
+        if echo "$gpu_info" | grep -qi "NVIDIA"; then
+            echo "nvidia"; return
+        fi
+        if echo "$gpu_info" | grep -qiE "AMD|Radeon|Advanced Micro"; then
+            echo "amd"; return
+        fi
+    fi
+
+    echo "none"
+}
+
+setup_compose_files() {
+    COMPOSE_FILES=("-f" "$ROOT/docker-compose.yml")
+    local gpu_vendor
+    gpu_vendor="$(get_gpu_vendor)"
+
+    case "$gpu_vendor" in
+        nvidia)
+            echo "GPU detected: NVIDIA - enabling GPU acceleration for Ollama."
+            COMPOSE_FILES+=("-f" "$ROOT/docker-compose.gpu-nvidia.yml")
+            ;;
+        amd)
+            echo "GPU detected: AMD - enabling GPU acceleration for Ollama (ROCm)."
+            COMPOSE_FILES+=("-f" "$ROOT/docker-compose.gpu-amd.yml")
+            ;;
+        macos)
+            echo "macOS: GPU passthrough is not supported in Docker. Ollama will run on CPU."
+            ;;
+        *)
+            echo "No dedicated GPU detected - Ollama will run on CPU."
+            ;;
+    esac
+}
+
+test_docker_running() {
+    if ! docker info &>/dev/null; then
+        echo "ERROR: Docker is not running. Start Docker Desktop and retry."
+        return 1
+    fi
+    return 0
+}
+
+test_rebuild_needed() {
+    # Compares the creation timestamp of the last built webshop-backend image against
+    # tracked source files (src/, pom.xml, Dockerfile).
+    # Returns 0 (rebuild needed) and prints the triggering filename.
+    # Returns 1 (no rebuild needed or check skipped).
+    # Requires python3 for cross-platform ISO 8601 timestamp parsing.
+
+    command -v python3 &>/dev/null || return 1
+
+    local image_id
+    image_id="$(docker inspect webshop-backend --format '{{.Image}}' 2>/dev/null)" || return 1
+    [[ -z "$image_id" ]] && return 1
+
+    local created_str
+    created_str="$(docker inspect "$image_id" --format '{{.Created}}' 2>/dev/null)" || return 1
+    [[ -z "$created_str" ]] && return 1
+
+    # Create a temp file whose mtime equals the image creation time (UTC epoch).
+    # Use find -newer for a cross-platform file-age comparison.
+    local tmp_file
+    tmp_file="$(mktemp)"
+
+    python3 - "$created_str" "$tmp_file" <<'PYEOF'
+import sys, re, os, calendar
+from datetime import datetime
+
+ts  = sys.argv[1]
+tmp = sys.argv[2]
+
+# Truncate nanoseconds to microseconds
+ts = re.sub(r'(\.\d{6})\d*', r'\1', ts)
+# Strip timezone suffix - Docker timestamps are always UTC
+ts = re.sub(r'(Z|[+-]\d{2}:\d{2})$', '', ts)
+
+try:
+    dt = datetime.strptime(ts, '%Y-%m-%dT%H:%M:%S.%f')
+except ValueError:
+    try:
+        dt = datetime.strptime(ts, '%Y-%m-%dT%H:%M:%S')
+    except ValueError:
+        sys.exit(1)
+
+# calendar.timegm interprets the struct_time as UTC (no DST conversion)
+epoch = float(calendar.timegm(dt.timetuple()))
+os.utime(tmp, (epoch, epoch))
+PYEOF
+
+    if [[ $? -ne 0 ]]; then
+        rm -f "$tmp_file"
+        return 1
+    fi
+
+    # Collect tracked paths that actually exist
+    local tracked_paths=()
+    for path in "$ROOT/src" "$ROOT/pom.xml" "$ROOT/Dockerfile"; do
+        [[ -e "$path" ]] && tracked_paths+=("$path")
+    done
+
+    local changed_file
+    changed_file="$(find "${tracked_paths[@]}" -newer "$tmp_file" ! -type d 2>/dev/null | head -1)"
+    rm -f "$tmp_file"
+
+    if [[ -n "$changed_file" ]]; then
+        echo "Changed since last build: ${changed_file#"$ROOT/"}"
+        return 0
+    fi
+
+    return 1
+}
+
+wait_for_backend() {
+    printf "Waiting for backend to be ready..."
+    local i
+    for i in $(seq 1 90); do
+        if curl -sf "$HEALTH_URL" &>/dev/null; then
+            echo " ready."
+            return 0
+        fi
+        printf "."
+        sleep 2
+    done
+    echo " timed out!"
+    echo "Check container logs: docker logs webshop-backend"
+    return 1
+}
+
+show_seed_hint() {
+    echo ""
+    echo "--- Seed data (optional, run once) ---"
+    echo "  docker exec -i webshop-postgres psql -U webshop -d webshop \\"
+    echo "    < src/main/resources/db/dev-seed.sql"
+    echo ""
+    echo "--- Shoppi KI-Assistent (Ollama model, run once) ---"
+    echo "  docker exec webshop-ollama ollama pull gemma4:e4b"
+    echo "  (This downloads ~10 GB on first run. Model is cached in the ollama_data volume.)"
+    echo ""
+}
+
+show_usage() {
+    echo ""
+    echo "Usage:  ./dev.sh <command> [--keep-db]"
+    echo ""
+    echo "Commands:"
+    echo "  start    Start all containers (auto-detects if rebuild is needed)"
+    echo "  stop     Stop all containers"
+    echo "  restart  Stop backend, then start backend"
+    echo "  rebuild  Force full rebuild (recreates containers)"
+    echo ""
+    echo "Options:"
+    echo "  --keep-db   Keep PostgreSQL running (combine with stop/restart/rebuild)"
+    echo ""
+}
+
+read_command_interactive() {
+    show_usage
+    printf "Enter command (start/stop/restart/rebuild): "
+    read -r input_command
+    input_command="$(echo "$input_command" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+
+    case "$input_command" in
+        start|stop|restart|rebuild) ;;
+        *)
+            echo "ERROR: Unknown command '$input_command'."
+            exit 1
+            ;;
+    esac
+
+    printf "Keep PostgreSQL running? [y/N]: "
+    read -r keep_db_answer
+    keep_db_answer="$(echo "$keep_db_answer" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+    if [[ "$keep_db_answer" == "y" || "$keep_db_answer" == "j" ]]; then
+        KEEP_DB=true
+    fi
+
+    COMMAND="$input_command"
+}
+
+# --- stop --------------------------------------------------------------------
+
+stop_backend() {
+    if [[ "$KEEP_DB" == "true" ]]; then
+        echo "Stopping backend container (keeping PostgreSQL running)..."
+        docker compose -f "$ROOT/docker-compose.yml" stop backend
+    else
+        echo "Stopping all containers..."
+        docker compose -f "$ROOT/docker-compose.yml" down
+    fi
+}
+
+# --- start -------------------------------------------------------------------
+
+start_backend() {
+    test_docker_running || return 1
+
+    local rebuild_output
+    if rebuild_output="$(test_rebuild_needed 2>&1)"; then
+        [[ -n "$rebuild_output" ]] && echo "$rebuild_output"
+        echo "Source changes detected since last build - rebuilding automatically."
+        echo "-------------------------------------------------------------------------------"
+        rebuild_backend
+        return
+    fi
+
+    echo ""
+    echo "Building and starting backend..."
+    echo "(First run: Maven downloads dependencies inside the container - may take a few minutes)"
+    echo "-------------------------------------------------------------------------------"
+
+    setup_compose_files
+
+    if [[ "$KEEP_DB" == "true" ]]; then
+        docker compose "${COMPOSE_FILES[@]}" up -d --build backend
+    else
+        docker compose "${COMPOSE_FILES[@]}" up -d --build
+    fi
+
+    if [[ $? -ne 0 ]]; then
+        echo "ERROR: docker compose up failed."
+        return 1
+    fi
+
+    if wait_for_backend; then
+        echo "-------------------------------------------------------------------------------"
+        echo "Backend is up at     http://localhost:$PORT"
+        echo "Swagger UI:          http://localhost:$PORT/swagger-ui/index.html"
+        show_seed_hint
+        echo "Run './dev.sh stop' to shut down."
+    fi
+}
+
+# --- rebuild -----------------------------------------------------------------
+
+rebuild_backend() {
+    echo "Forcing full rebuild (no layer cache)..."
+    test_docker_running || return 1
+
+    setup_compose_files
+
+    if [[ "$KEEP_DB" == "true" ]]; then
+        docker compose "${COMPOSE_FILES[@]}" up -d --build --force-recreate backend
+    else
+        docker compose "${COMPOSE_FILES[@]}" down
+        docker compose "${COMPOSE_FILES[@]}" up -d --build --force-recreate
+    fi
+
+    if [[ $? -ne 0 ]]; then
+        echo "ERROR: docker compose rebuild failed."
+        return 1
+    fi
+
+    if wait_for_backend; then
+        echo "-------------------------------------------------------------------------------"
+        echo "Backend is up at     http://localhost:$PORT"
+        echo "Swagger UI:          http://localhost:$PORT/swagger-ui/index.html"
+        show_seed_hint
+        echo "Run './dev.sh stop' to shut down."
+    fi
+}
+
+# --- dispatch ----------------------------------------------------------------
+
+if [[ -z "$COMMAND" ]]; then
+    read_command_interactive
+fi
+
+case "$COMMAND" in
+    start)
+        start_backend
+        ;;
+    stop)
+        stop_backend
+        ;;
+    restart)
+        stop_backend
+        sleep 1
+        start_backend
+        ;;
+    rebuild)
+        rebuild_backend
+        ;;
+    *)
+        echo "ERROR: Unknown command '$COMMAND'. Run './dev.sh' without arguments for help."
+        exit 1
+        ;;
+esac

--- a/docker-compose.gpu-amd.yml
+++ b/docker-compose.gpu-amd.yml
@@ -1,0 +1,7 @@
+services:
+  ollama:
+    devices:
+      - /dev/kfd
+      - /dev/dri
+    group_add:
+      - video

--- a/docker-compose.gpu-nvidia.yml
+++ b/docker-compose.gpu-nvidia.yml
@@ -1,0 +1,9 @@
+services:
+  ollama:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,15 @@ services:
       timeout: 5s
       retries: 5
 
+  ollama:
+    image: ollama/ollama:latest
+    container_name: webshop-ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    restart: unless-stopped
+
   backend:
     build: .
     container_name: webshop-backend
@@ -29,6 +38,7 @@ services:
       APP_CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-http://localhost:5173}
       SPRING_MAIL_HOST: ${MAIL_HOST:-localhost}
       SPRING_MAIL_PORT: ${MAIL_PORT:-1025}
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-http://ollama:11434}
     depends_on:
       postgres:
         condition: service_healthy
@@ -36,3 +46,4 @@ services:
 
 volumes:
   postgres_data:
+  ollama_data:

--- a/src/main/java/de/fhdw/webshop/chat/ChatController.java
+++ b/src/main/java/de/fhdw/webshop/chat/ChatController.java
@@ -1,0 +1,32 @@
+package de.fhdw.webshop.chat;
+
+import de.fhdw.webshop.chat.dto.ChatMessageRequest;
+import de.fhdw.webshop.chat.dto.ChatMessageResponse;
+import de.fhdw.webshop.user.User;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/chat")
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final ChatService chatService;
+
+    /**
+     * Public endpoint — works for both anonymous and authenticated users.
+     * Authenticated users receive personal context (cart, orders, profile) in the bot's response.
+     */
+    @PostMapping("/message")
+    public ResponseEntity<ChatMessageResponse> sendMessage(
+            @AuthenticationPrincipal User currentUser,
+            @Valid @RequestBody ChatMessageRequest request) {
+        return ResponseEntity.ok(chatService.processMessage(currentUser, request));
+    }
+}

--- a/src/main/java/de/fhdw/webshop/chat/ChatService.java
+++ b/src/main/java/de/fhdw/webshop/chat/ChatService.java
@@ -72,6 +72,11 @@ public class ChatService {
     private void appendProductCatalogContext(StringBuilder builder) {
         try {
             List<ProductResponse> allProducts = productService.listProducts(null, null, null);
+            if (allProducts.isEmpty()) {
+                builder.append("[PRODUKTKATALOG]: Derzeit sind keine Produkte im Katalog vorhanden. " +
+                        "Weise den Nutzer darauf hin, falls er nach Produkten fragt.\n\n");
+                return;
+            }
             builder.append("[PRODUKTKATALOG - alle ").append(allProducts.size()).append(" Artikel]:\n");
             for (ProductResponse product : allProducts) {
                 builder.append("- ")

--- a/src/main/java/de/fhdw/webshop/chat/ChatService.java
+++ b/src/main/java/de/fhdw/webshop/chat/ChatService.java
@@ -1,0 +1,155 @@
+package de.fhdw.webshop.chat;
+
+import de.fhdw.webshop.cart.CartService;
+import de.fhdw.webshop.cart.dto.CartResponse;
+import de.fhdw.webshop.chat.dto.ChatMessageRequest;
+import de.fhdw.webshop.chat.dto.ChatMessageResponse;
+import de.fhdw.webshop.order.OrderService;
+import de.fhdw.webshop.order.dto.OrderResponse;
+import de.fhdw.webshop.product.ProductService;
+import de.fhdw.webshop.product.dto.ProductResponse;
+import de.fhdw.webshop.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final OllamaClient ollamaClient;
+    private final ProductService productService;
+    private final CartService cartService;
+    private final OrderService orderService;
+
+    public ChatMessageResponse processMessage(User currentUser, ChatMessageRequest request) {
+        String systemPrompt = buildSystemPrompt(currentUser);
+        List<de.fhdw.webshop.chat.dto.ConversationEntry> historyWithCurrentMessage =
+                buildHistoryWithCurrentMessage(request);
+
+        String reply = ollamaClient.chat(systemPrompt, historyWithCurrentMessage);
+        return new ChatMessageResponse(reply);
+    }
+
+    private String buildSystemPrompt(User currentUser) {
+        StringBuilder systemPromptBuilder = new StringBuilder();
+
+        systemPromptBuilder.append("""
+                Du bist Shoppi, der freundliche KI-Assistent dieses Webshops.
+                Antworte immer auf Deutsch, präzise, freundlich und hilfsbereit.
+
+                Was du tust:
+                - Du hilfst Kunden bei Produktfragen, Preisinfos und der Suche nach Artikeln.
+                - Du erklärst Bestellhistorie, Warenkorb und Daueraufträge (nur für eingeloggte Nutzer).
+                - Du gibst allgemeine Infos zum Shop.
+
+                Was du NICHT tust:
+                - Du änderst KEINE Daten (keine Bestellungen, kein Warenkorb, keine Profiledaten).
+                - Du gibst KEINE Daten anderer Nutzer preis.
+                - Du antwortest NICHT zu Admin- oder Mitarbeiterthemen.
+                - Du nennst NIEMALS Passwörter, vollständige Zahlungsdaten oder interne System-IDs.
+                - Du führst KEINE Aktionen außerhalb des Webshops aus.
+
+                Wenn du etwas nicht weißt, sage es ehrlich.
+
+                """);
+
+        appendProductCatalogContext(systemPromptBuilder);
+
+        if (currentUser != null) {
+            appendUserContext(systemPromptBuilder, currentUser);
+        } else {
+            systemPromptBuilder.append("""
+                    [NUTZERSTATUS]: Nicht eingeloggt.
+                    Für personalisierte Infos (Warenkorb, Bestellhistorie, Rabatte) muss sich der Nutzer einloggen.
+                    """);
+        }
+
+        return systemPromptBuilder.toString();
+    }
+
+    private void appendProductCatalogContext(StringBuilder builder) {
+        try {
+            List<ProductResponse> allProducts = productService.listProducts(null, null, null);
+            builder.append("[PRODUKTKATALOG - alle ").append(allProducts.size()).append(" Artikel]:\n");
+            for (ProductResponse product : allProducts) {
+                builder.append("- ")
+                        .append(product.name())
+                        .append(" | Kategorie: ").append(product.category())
+                        .append(" | Preis: ").append(product.recommendedRetailPrice()).append(" EUR")
+                        .append(" | Beschreibung: ").append(truncate(product.description(), 120))
+                        .append(" | Kaufbar: ").append(product.purchasable() ? "Ja" : "Nein")
+                        .append("\n");
+            }
+            builder.append("\n");
+        } catch (Exception exception) {
+            builder.append("[PRODUKTKATALOG]: Konnte nicht geladen werden.\n\n");
+        }
+    }
+
+    private void appendUserContext(StringBuilder builder, User currentUser) {
+        builder.append("[NUTZERPROFIL]:\n")
+                .append("- Benutzername: ").append(currentUser.getUsername()).append("\n")
+                .append("- Kundennummer: ").append(currentUser.getCustomerNumber()).append("\n")
+                .append("- Kundentyp: ").append(currentUser.getUserType() == de.fhdw.webshop.user.UserType.BUSINESS
+                        ? "Unternehmenskunde" : "Privatkunde")
+                .append("\n\n");
+
+        appendCartContext(builder, currentUser);
+        appendOrderHistoryContext(builder, currentUser);
+    }
+
+    private void appendCartContext(StringBuilder builder, User currentUser) {
+        try {
+            CartResponse cart = cartService.getCart(currentUser.getId());
+            if (cart.items().isEmpty()) {
+                builder.append("[WARENKORB]: Leer.\n\n");
+            } else {
+                builder.append("[WARENKORB] (").append(cart.items().size()).append(" Artikel):\n");
+                cart.items().forEach(item ->
+                        builder.append("- ").append(item.productName())
+                                .append(" x").append(item.quantity())
+                                .append(" = ").append(item.lineTotal()).append(" EUR\n")
+                );
+                builder.append("Gesamtbetrag: ").append(cart.total()).append(" EUR\n\n");
+            }
+        } catch (Exception exception) {
+            builder.append("[WARENKORB]: Konnte nicht geladen werden.\n\n");
+        }
+    }
+
+    private void appendOrderHistoryContext(StringBuilder builder, User currentUser) {
+        try {
+            List<OrderResponse> recentOrders = orderService.listOrdersForCustomer(currentUser.getId())
+                    .stream().limit(5).toList();
+            if (recentOrders.isEmpty()) {
+                builder.append("[BESTELLHISTORIE]: Keine Bestellungen vorhanden.\n\n");
+            } else {
+                builder.append("[BESTELLHISTORIE] (letzte ").append(recentOrders.size()).append(" Bestellungen):\n");
+                recentOrders.forEach(order ->
+                        builder.append("- Bestellung #").append(order.id())
+                                .append(" | Status: ").append(order.status())
+                                .append(" | Betrag: ").append(order.totalPrice()).append(" EUR")
+                                .append(" | Datum: ").append(order.createdAt()).append("\n")
+                );
+                builder.append("\n");
+            }
+        } catch (Exception exception) {
+            builder.append("[BESTELLHISTORIE]: Konnte nicht geladen werden.\n\n");
+        }
+    }
+
+    private List<de.fhdw.webshop.chat.dto.ConversationEntry> buildHistoryWithCurrentMessage(
+            ChatMessageRequest request) {
+        List<de.fhdw.webshop.chat.dto.ConversationEntry> history =
+                request.history() != null ? new java.util.ArrayList<>(request.history()) : new java.util.ArrayList<>();
+        history.add(new de.fhdw.webshop.chat.dto.ConversationEntry("user", request.message()));
+        return history;
+    }
+
+    private String truncate(String text, int maxLength) {
+        if (text == null) return "";
+        return text.length() <= maxLength ? text : text.substring(0, maxLength) + "...";
+    }
+}

--- a/src/main/java/de/fhdw/webshop/chat/ChatService.java
+++ b/src/main/java/de/fhdw/webshop/chat/ChatService.java
@@ -53,6 +53,9 @@ public class ChatService {
 
                 Wenn du etwas nicht weißt, sage es ehrlich.
 
+                Du kannst Markdown-Formatierung verwenden (z. B. **Fettdruck**, Listen mit `-`, Überschriften mit `##`),
+                um Antworten übersichtlicher zu gestalten. Setze Markdown gezielt ein, nicht übermäßig.
+
                 """);
 
         appendProductCatalogContext(systemPromptBuilder);

--- a/src/main/java/de/fhdw/webshop/chat/OllamaClient.java
+++ b/src/main/java/de/fhdw/webshop/chat/OllamaClient.java
@@ -1,0 +1,72 @@
+package de.fhdw.webshop.chat;
+
+import de.fhdw.webshop.chat.dto.ConversationEntry;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+@Slf4j
+public class OllamaClient {
+
+    private final RestClient restClient;
+    private final String modelName;
+
+    public OllamaClient(
+            @Value("${ollama.base-url}") String ollamaBaseUrl,
+            @Value("${ollama.model}") String modelName) {
+        this.restClient = RestClient.builder()
+                .baseUrl(ollamaBaseUrl)
+                .build();
+        this.modelName = modelName;
+    }
+
+    /**
+     * Sends a chat request to the Ollama API and returns the assistant's reply.
+     * The systemPrompt is always prepended as the first message with role "system".
+     */
+    public String chat(String systemPrompt, List<ConversationEntry> conversationHistory) {
+        List<Map<String, String>> messages = buildMessageList(systemPrompt, conversationHistory);
+
+        Map<String, Object> requestBody = Map.of(
+                "model", modelName,
+                "messages", messages,
+                "stream", false
+        );
+
+        try {
+            OllamaResponse response = restClient.post()
+                    .uri("/api/chat")
+                    .body(requestBody)
+                    .retrieve()
+                    .body(OllamaResponse.class);
+
+            if (response == null || response.message() == null) {
+                return "Entschuldigung, ich konnte keine Antwort generieren. Bitte versuche es erneut.";
+            }
+            return response.message().content();
+        } catch (Exception exception) {
+            log.error("Ollama request failed: {}", exception.getMessage());
+            return "Entschuldigung, der KI-Assistent ist gerade nicht erreichbar. Bitte versuche es später erneut.";
+        }
+    }
+
+    private List<Map<String, String>> buildMessageList(String systemPrompt, List<ConversationEntry> history) {
+        List<Map<String, String>> messages = new java.util.ArrayList<>();
+        messages.add(Map.of("role", "system", "content", systemPrompt));
+
+        if (history != null) {
+            for (ConversationEntry entry : history) {
+                messages.add(Map.of("role", entry.role(), "content", entry.content()));
+            }
+        }
+        return messages;
+    }
+
+    private record OllamaResponse(OllamaMessage message) {}
+    private record OllamaMessage(String role, String content) {}
+}

--- a/src/main/java/de/fhdw/webshop/chat/dto/ChatMessageRequest.java
+++ b/src/main/java/de/fhdw/webshop/chat/dto/ChatMessageRequest.java
@@ -1,0 +1,9 @@
+package de.fhdw.webshop.chat.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+
+public record ChatMessageRequest(
+        @NotBlank String message,
+        List<ConversationEntry> history
+) {}

--- a/src/main/java/de/fhdw/webshop/chat/dto/ChatMessageResponse.java
+++ b/src/main/java/de/fhdw/webshop/chat/dto/ChatMessageResponse.java
@@ -1,0 +1,3 @@
+package de.fhdw.webshop.chat.dto;
+
+public record ChatMessageResponse(String reply) {}

--- a/src/main/java/de/fhdw/webshop/chat/dto/ConversationEntry.java
+++ b/src/main/java/de/fhdw/webshop/chat/dto/ConversationEntry.java
@@ -1,0 +1,3 @@
+package de.fhdw.webshop.chat.dto;
+
+public record ConversationEntry(String role, String content) {}

--- a/src/main/java/de/fhdw/webshop/config/SecurityConfig.java
+++ b/src/main/java/de/fhdw/webshop/config/SecurityConfig.java
@@ -50,6 +50,8 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-ui.html").permitAll()
                         // Health check
                         .requestMatchers("/api/health").permitAll()
+                        // Shoppi chatbot — public, auth-aware (personal context only when authenticated)
+                        .requestMatchers(HttpMethod.POST, "/api/chat/message").permitAll()
                         // All other endpoints require authentication
                         .anyRequest().authenticated()
                 )

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,6 +35,10 @@ spring.mail.password=${MAIL_PASSWORD:}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 
+# ── Ollama ──────────────────────────────────────────────────────────────────
+ollama.base-url=${OLLAMA_BASE_URL:http://localhost:11434}
+ollama.model=${OLLAMA_MODEL:gemma4:e4b}
+
 # ── OpenAPI ─────────────────────────────────────────────────────────────────
 springdoc.swagger-ui.enabled=true
 springdoc.api-docs.enabled=true


### PR DESCRIPTION
## Zusammenfassung

Implementiert den Shoppi KI-Assistenten im Backend (Ollama-Integration,
System-Prompt, GPU-Support) und verbessert das Entwicklerskript für alle
Plattformen (Windows, Linux, macOS).

## Änderungen

### Neue Dateien (Backend-Code)
- `src/.../chat/ChatController.java` — `POST /api/chat/message` (öffentlich, auth-aware)
- `src/.../chat/ChatService.java` — System-Prompt-Builder: Produktkatalog,
  Warenkorb, Bestellhistorie, Nutzerprofil, Markdown-Hinweis; leerer Katalog
  wird explizit kommuniziert
- `src/.../chat/OllamaClient.java` — HTTP-Client für Ollama REST API
- `src/.../chat/dto/` — `ChatMessageRequest`, `ChatMessageResponse`, `ConversationEntry`
- `docker-compose.gpu-nvidia.yml` — NVIDIA GPU-Override für Ollama
- `docker-compose.gpu-amd.yml` — AMD GPU-Override für Ollama (Linux/ROCm)

### Neue Dateien (Dev-Scripts & Doku)
- `dev.sh` — Bash-Script für Linux und macOS mit vollständiger Feature-Parität zu
  `dev.ps1`: GPU-Erkennung (nvidia-smi / lspci / macOS-Fallback), Auto-Rebuild-
  Erkennung via python3 + find -newer, interaktiver Modus ohne Parameter
- `README-Mac.md` — macOS-spezifisches Setup-Guide (Docker Desktop, python3 via
  Xcode CLT oder Homebrew, GPU-Einschränkung in Docker erläutert)

### Geänderte Dateien
- `docker-compose.yml` — Ollama-Service ergänzt
- `src/.../config/SecurityConfig.java` — `/api/chat/**` öffentlich
- `src/main/resources/application.properties` — `OLLAMA_BASE_URL` + `OLLAMA_MODEL`
- `dev.ps1` — GPU-Erkennung (NVIDIA/AMD/Intel/CPU), Auto-Rebuild-Erkennung
  (`start` prüft Timestamps von src/, pom.xml, Dockerfile gegen letztes Image),
  interaktiver Modus ohne Parameter; Bugfix: em-dash-Zeichen durch ASCII-Bindestrich
  ersetzt (UTF-8/Windows-1252-Encoding-Konflikt verursachte Parser-Fehler)
- `README.md` — Shoppi-Abschnitt, GPU-Tabelle, dev.ps1-Befehle, Troubleshooting
- `README-Linux.md` — Auf dev.sh umgestellt, PowerShell-Abhängigkeit entfernt,
  Auto-Rebuild und interaktiver Modus dokumentiert, Verweis auf README-Mac.md

## Endpunkt

| Methode | URL | Auth | Beschreibung |
|---|---|---|---|
| POST | `/api/chat/message` | Optional (JWT) | Shoppi-Nachricht; mit JWT = personalisierter Kontext |

## Einmalige Einrichtung nach Merge

```bash
# Linux / macOS
chmod +x dev.sh
./dev.sh start
docker exec webshop-ollama ollama pull gemma4:e4b   # ~10 GB, einmalig

# Windows
./dev.bat start
docker exec webshop-ollama ollama pull gemma4:e4b
