### PR TITLE
Resolves SEPBFWS124A/Webshop#139 statistiken-nach-zeitraum-filtern

### DIFF
--- a/src/main/java/de/fhdw/webshop/admin/statistics/AdminStatisticsService.java
+++ b/src/main/java/de/fhdw/webshop/admin/statistics/AdminStatisticsService.java
@@ -3,8 +3,6 @@ package de.fhdw.webshop.admin.statistics;
 import de.fhdw.webshop.admin.statistics.dto.AdminProductPerformanceResponse;
 import de.fhdw.webshop.admin.statistics.dto.AdminStatisticsDashboardResponse;
 import de.fhdw.webshop.order.OrderStatus;
-import de.fhdw.webshop.user.UserRepository;
-import de.fhdw.webshop.user.UserRole;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,7 +22,6 @@ public class AdminStatisticsService {
     private static final int PRODUCT_PERFORMANCE_LIMIT = 8;
 
     private final EntityManager entityManager;
-    private final UserRepository userRepository;
 
     public AdminStatisticsDashboardResponse getDashboard(LocalDate from, LocalDate to) {
         LocalDate resolvedTo = to != null ? to : LocalDate.now();
@@ -50,7 +47,7 @@ public class AdminStatisticsService {
 
         BigDecimal revenue = toBigDecimal(totals[0]);
         long orderCount = toLong(totals[1]);
-        long activeCustomerCount = userRepository.countActiveCustomers(UserRole.CUSTOMER);
+        long activeCustomerCount = toLong(totals[2]);
         List<AdminProductPerformanceResponse> productPerformance = loadProductPerformance(fromInstant, toExclusive);
 
         return new AdminStatisticsDashboardResponse(

--- a/src/main/java/de/fhdw/webshop/config/GlobalExceptionHandler.java
+++ b/src/main/java/de/fhdw/webshop/config/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.time.Instant;
 import java.util.Map;
@@ -39,6 +40,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<Map<String, Object>> handleMessageNotReadable(HttpMessageNotReadableException exception) {
         return buildErrorResponse(HttpStatus.BAD_REQUEST, "Request body could not be parsed");
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<Map<String, Object>> handleTypeMismatch(MethodArgumentTypeMismatchException exception) {
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "Request parameter could not be parsed");
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)

--- a/src/test/java/de/fhdw/webshop/admin/statistics/AdminStatisticsServiceTest.java
+++ b/src/test/java/de/fhdw/webshop/admin/statistics/AdminStatisticsServiceTest.java
@@ -1,0 +1,65 @@
+package de.fhdw.webshop.admin.statistics;
+
+import de.fhdw.webshop.admin.statistics.dto.AdminStatisticsDashboardResponse;
+import de.fhdw.webshop.order.OrderStatus;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AdminStatisticsServiceTest {
+
+    @Test
+    void usesDateRangeForAllDashboardKpis() {
+        EntityManager entityManager = mock(EntityManager.class);
+        Query totalsQuery = mock(Query.class);
+        Query productPerformanceQuery = mock(Query.class);
+        AdminStatisticsService service = new AdminStatisticsService(entityManager);
+
+        when(entityManager.createQuery(anyString())).thenReturn(totalsQuery);
+        when(entityManager.createNativeQuery(anyString())).thenReturn(productPerformanceQuery);
+        when(totalsQuery.setParameter(anyString(), any())).thenReturn(totalsQuery);
+        when(productPerformanceQuery.setParameter(anyString(), any())).thenReturn(productPerformanceQuery);
+        when(productPerformanceQuery.setMaxResults(anyInt())).thenReturn(productPerformanceQuery);
+        when(totalsQuery.getSingleResult()).thenReturn(new Object[] { new BigDecimal("119.90"), 3L, 2L });
+        when(productPerformanceQuery.getResultList()).thenReturn(List.of());
+
+        AdminStatisticsDashboardResponse dashboard = service.getDashboard(
+                LocalDate.of(2026, 4, 1),
+                LocalDate.of(2026, 4, 30)
+        );
+
+        assertThat(dashboard.from()).isEqualTo(LocalDate.of(2026, 4, 1));
+        assertThat(dashboard.to()).isEqualTo(LocalDate.of(2026, 4, 30));
+        assertThat(dashboard.revenue()).isEqualByComparingTo("119.90");
+        assertThat(dashboard.orderCount()).isEqualTo(3);
+        assertThat(dashboard.activeCustomerCount()).isEqualTo(2);
+        assertThat(dashboard.hasOrderData()).isTrue();
+        verify(totalsQuery).setParameter("cancelledStatus", OrderStatus.CANCELLED);
+    }
+
+    @Test
+    void rejectsInvalidDateRangesBeforeQueryingDatabase() {
+        EntityManager entityManager = mock(EntityManager.class);
+        AdminStatisticsService service = new AdminStatisticsService(entityManager);
+
+        assertThatThrownBy(() -> service.getDashboard(
+                LocalDate.of(2026, 5, 1),
+                LocalDate.of(2026, 4, 1)
+        ))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Das Von-Datum darf nicht nach dem Bis-Datum liegen.");
+    }
+}


### PR DESCRIPTION
## Zusammenfassung
- Statistik-KPI fuer Kunden im Zeitraum an die bestehende Zeitraum-Query angebunden
- Ungueltige Datums-Query-Parameter als 400 Bad Request behandelt
- Backend-Tests fuer Zeitraum-KPIs und ungueltige Datumsbereiche ergaenzt

## Hinweis
Dieser PR basiert auf feature/US-138-statistik-dashboard, weil die Statistik-API dort eingefuehrt wurde.