### PR TITLE
Add product CO2 footprint support

### DIFF
--- a/src/main/java/de/fhdw/webshop/cart/CartService.java
+++ b/src/main/java/de/fhdw/webshop/cart/CartService.java
@@ -70,6 +70,19 @@ public class CartService {
         BigDecimal total = subtotal.add(tax).add(shippingCost)
                 .setScale(2, RoundingMode.HALF_UP);
 
+        BigDecimal totalCo2EmissionKg = itemResponses.stream()
+                .map(CartItemResponse::lineCo2EmissionKg)
+                .filter(lineCo2EmissionKg -> lineCo2EmissionKg != null)
+                .reduce(BigDecimal.ZERO, BigDecimal::add)
+                .setScale(3, RoundingMode.HALF_UP);
+        int co2EmissionCoveredItemCount = itemResponses.stream()
+                .filter(item -> item.co2EmissionKg() != null)
+                .mapToInt(CartItemResponse::quantity)
+                .sum();
+        int co2EmissionTotalItemCount = itemResponses.stream()
+                .mapToInt(CartItemResponse::quantity)
+                .sum();
+
         return new CartResponse(
                 itemResponses,
                 subtotal,
@@ -77,6 +90,9 @@ public class CartService {
                 tax,
                 shippingCost,
                 total,
+                totalCo2EmissionKg,
+                co2EmissionCoveredItemCount,
+                co2EmissionTotalItemCount,
                 coupon != null ? coupon.getCode() : null,
                 messages
         );
@@ -181,6 +197,11 @@ public class CartService {
             effectiveUnitPrice = recommendedRetailPrice;
         }
         BigDecimal lineTotal = effectiveUnitPrice.multiply(BigDecimal.valueOf(cartItem.getQuantity()));
+        BigDecimal co2EmissionKg = cartItem.getProduct().getCo2EmissionKg();
+        BigDecimal lineCo2EmissionKg = co2EmissionKg == null
+                ? null
+                : co2EmissionKg.multiply(BigDecimal.valueOf(cartItem.getQuantity()))
+                        .setScale(3, RoundingMode.HALF_UP);
 
         return new CartItemResponse(
                 cartItem.getId(),
@@ -188,9 +209,11 @@ public class CartService {
                 cartItem.getProduct().getName(),
                 cartItem.getProduct().getImageUrl(),
                 effectiveUnitPrice,
+                co2EmissionKg,
                 getAvailableStock(cartItem.getProduct()),
                 cartItem.getQuantity(),
                 lineTotal,
+                lineCo2EmissionKg,
                 cartItem.getAddedAt()
         );
     }

--- a/src/main/java/de/fhdw/webshop/cart/dto/CartItemResponse.java
+++ b/src/main/java/de/fhdw/webshop/cart/dto/CartItemResponse.java
@@ -9,8 +9,10 @@ public record CartItemResponse(
         String productName,
         String imageUrl,
         BigDecimal unitPrice,
+        BigDecimal co2EmissionKg,
         int availableStock,
         int quantity,
         BigDecimal lineTotal,
+        BigDecimal lineCo2EmissionKg,
         Instant addedAt
 ) {}

--- a/src/main/java/de/fhdw/webshop/cart/dto/CartResponse.java
+++ b/src/main/java/de/fhdw/webshop/cart/dto/CartResponse.java
@@ -10,6 +10,9 @@ public record CartResponse(
         BigDecimal tax,
         BigDecimal shippingCost,
         BigDecimal total,
+        BigDecimal totalCo2EmissionKg,
+        int co2EmissionCoveredItemCount,
+        int co2EmissionTotalItemCount,
         String appliedCouponCode,
         List<String> messages
 ) {}

--- a/src/main/java/de/fhdw/webshop/product/Product.java
+++ b/src/main/java/de/fhdw/webshop/product/Product.java
@@ -31,6 +31,9 @@ public class Product {
     @Column(name = "recommended_retail_price", nullable = false, precision = 10, scale = 2)
     private BigDecimal recommendedRetailPrice;
 
+    @Column(name = "co2_emission_kg", precision = 10, scale = 3)
+    private BigDecimal co2EmissionKg;
+
     @Column(length = 100)
     private String category;
 

--- a/src/main/java/de/fhdw/webshop/product/ProductController.java
+++ b/src/main/java/de/fhdw/webshop/product/ProductController.java
@@ -107,6 +107,14 @@ public class ProductController {
     }
 
     /** US #34 — Sales statistics (units sold, revenue) for a product over a date range. */
+    /** US #196 — Update estimated product CO2 footprint in kg CO2e. */
+    @PutMapping("/{id}/co2-emission")
+    @PreAuthorize("hasAnyRole('EMPLOYEE', 'SALES_EMPLOYEE', 'ADMIN')")
+    public ResponseEntity<ProductResponse> updateCo2Emission(@PathVariable Long id,
+                                                             @Valid @RequestBody UpdateCo2EmissionRequest updateCo2EmissionRequest) {
+        return ResponseEntity.ok(productService.updateCo2Emission(id, updateCo2EmissionRequest));
+    }
+
     @GetMapping("/{id}/statistics")
     @PreAuthorize("hasAnyRole('SALES_EMPLOYEE', 'ADMIN')")
     public ResponseEntity<ProductStatisticsResponse> getProductStatistics(

--- a/src/main/java/de/fhdw/webshop/product/ProductService.java
+++ b/src/main/java/de/fhdw/webshop/product/ProductService.java
@@ -49,6 +49,7 @@ public class ProductService {
         product.setDescription(productRequest.description());
         product.setImageUrl(productRequest.imageUrl());
         product.setRecommendedRetailPrice(productRequest.recommendedRetailPrice());
+        product.setCo2EmissionKg(productRequest.co2EmissionKg());
         product.setCategory(productRequest.category());
         product.setStock(25);
         return toResponse(productRepository.save(product));
@@ -101,6 +102,14 @@ public class ProductService {
         return toResponse(productRepository.save(product));
     }
 
+    /** US #196 — Update the estimated product CO2 footprint. */
+    @Transactional
+    public ProductResponse updateCo2Emission(Long productId, UpdateCo2EmissionRequest updateCo2EmissionRequest) {
+        Product product = loadProduct(productId);
+        product.setCo2EmissionKg(updateCo2EmissionRequest.co2EmissionKg());
+        return toResponse(productRepository.save(product));
+    }
+
     public Product loadProduct(Long productId) {
         return productRepository.findById(productId)
                 .orElseThrow(() -> new EntityNotFoundException("Product not found: " + productId));
@@ -121,6 +130,7 @@ public class ProductService {
                 product.getDescription(),
                 product.getImageUrl(),
                 product.getRecommendedRetailPrice(),
+                product.getCo2EmissionKg(),
                 product.getCategory(),
                 product.getStock(),
                 product.isPurchasable(),

--- a/src/main/java/de/fhdw/webshop/product/dto/ProductRequest.java
+++ b/src/main/java/de/fhdw/webshop/product/dto/ProductRequest.java
@@ -11,5 +11,6 @@ public record ProductRequest(
         String description,
         String imageUrl,
         @NotNull @DecimalMin("0.01") BigDecimal recommendedRetailPrice,
+        @NotNull @DecimalMin("0.001") BigDecimal co2EmissionKg,
         String category
 ) {}

--- a/src/main/java/de/fhdw/webshop/product/dto/ProductResponse.java
+++ b/src/main/java/de/fhdw/webshop/product/dto/ProductResponse.java
@@ -9,6 +9,7 @@ public record ProductResponse(
         String description,
         String imageUrl,
         BigDecimal recommendedRetailPrice,
+        BigDecimal co2EmissionKg,
         String category,
         int stock,
         boolean purchasable,

--- a/src/main/java/de/fhdw/webshop/product/dto/UpdateCo2EmissionRequest.java
+++ b/src/main/java/de/fhdw/webshop/product/dto/UpdateCo2EmissionRequest.java
@@ -1,0 +1,10 @@
+package de.fhdw.webshop.product.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+
+public record UpdateCo2EmissionRequest(
+        @NotNull @DecimalMin("0.001") BigDecimal co2EmissionKg
+) {}

--- a/src/main/resources/db/dev-seed.sql
+++ b/src/main/resources/db/dev-seed.sql
@@ -54,18 +54,19 @@ INSERT INTO products (
     description,
     image_url,
     recommended_retail_price,
+    co2_emission_kg,
     category,
     stock,
     warehouse_position,
     purchasable,
     promoted
 ) VALUES
-  ('Laptop Pro 15', 'High-performance laptop with 15" display', 'https://placehold.co/400x300?text=Laptop', 1299.99, 'Electronics', 8, 'A-01-01', TRUE, TRUE),
-  ('Wireless Mouse', 'Ergonomic wireless mouse, 2.4 GHz', 'https://placehold.co/400x300?text=Mouse', 29.99, 'Electronics', 120, 'A-03-07', TRUE, FALSE),
-  ('Standing Desk', 'Height-adjustable standing desk 140x70 cm', 'https://placehold.co/400x300?text=Desk', 499.99, 'Furniture', 12, 'B-01-03', TRUE, FALSE),
-  ('USB-C Hub', '7-in-1 USB-C hub with HDMI and SD card', 'https://placehold.co/400x300?text=Hub', 49.99, 'Electronics', 40, 'A-04-02', TRUE, FALSE),
-  ('Office Chair', 'Lumbar support mesh chair', 'https://placehold.co/400x300?text=Chair', 349.99, 'Furniture', 18, 'B-02-05', TRUE, TRUE),
-  ('Notebook (Draft)', 'Not yet available to customers', NULL, 9.99, 'Stationery', 0, 'C-01-01', FALSE, FALSE);
+  ('Laptop Pro 15', 'High-performance laptop with 15" display', 'https://placehold.co/400x300?text=Laptop', 1299.99, 214.500, 'Electronics', 8, 'A-01-01', TRUE, TRUE),
+  ('Wireless Mouse', 'Ergonomic wireless mouse, 2.4 GHz', 'https://placehold.co/400x300?text=Mouse', 29.99, 2.100, 'Electronics', 120, 'A-03-07', TRUE, FALSE),
+  ('Standing Desk', 'Height-adjustable standing desk 140x70 cm', 'https://placehold.co/400x300?text=Desk', 499.99, 58.750, 'Furniture', 12, 'B-01-03', TRUE, FALSE),
+  ('USB-C Hub', '7-in-1 USB-C hub with HDMI and SD card', 'https://placehold.co/400x300?text=Hub', 49.99, 5.400, 'Electronics', 40, 'A-04-02', TRUE, FALSE),
+  ('Office Chair', 'Lumbar support mesh chair', 'https://placehold.co/400x300?text=Chair', 349.99, 33.200, 'Furniture', 18, 'B-02-05', TRUE, TRUE),
+  ('Notebook (Draft)', 'Not yet available to customers', NULL, 9.99, 0.350, 'Stationery', 0, 'C-01-01', FALSE, FALSE);
 
 -- Discounts
 INSERT INTO discounts (customer_id, product_id, discount_percent, valid_from, valid_until)

--- a/src/main/resources/db/migration/V30__add_product_co2_emissions.sql
+++ b/src/main/resources/db/migration/V30__add_product_co2_emissions.sql
@@ -1,0 +1,13 @@
+ALTER TABLE products
+    ADD COLUMN IF NOT EXISTS co2_emission_kg NUMERIC(10, 3);
+
+UPDATE products
+SET co2_emission_kg = CASE
+    WHEN LOWER(name) LIKE '%laptop%' THEN 214.500
+    WHEN LOWER(name) LIKE '%mouse%' THEN 2.100
+    WHEN LOWER(name) LIKE '%desk%' THEN 58.750
+    WHEN LOWER(name) LIKE '%hub%' THEN 5.400
+    WHEN LOWER(name) LIKE '%chair%' THEN 33.200
+    ELSE co2_emission_kg
+END
+WHERE co2_emission_kg IS NULL;

--- a/src/main/resources/db/migration/V31__backfill_product_co2_emission_values.sql
+++ b/src/main/resources/db/migration/V31__backfill_product_co2_emission_values.sql
@@ -1,0 +1,18 @@
+UPDATE products
+SET co2_emission_kg = CASE
+    WHEN LOWER(name) LIKE '%laptop%' THEN 214.500
+    WHEN LOWER(name) LIKE '%mouse%' THEN 2.100
+    WHEN LOWER(name) LIKE '%desk%' THEN 58.750
+    WHEN LOWER(name) LIKE '%hub%' THEN 5.400
+    WHEN LOWER(name) LIKE '%chair%' THEN 33.200
+    WHEN LOWER(name) LIKE '%notebook%' THEN 0.350
+    WHEN LOWER(category) IN ('electronics', 'elektronik', 'audio', 'gaming') THEN 18.750
+    WHEN LOWER(category) IN ('furniture', 'buero', 'büro') THEN 42.500
+    WHEN LOWER(category) IN ('stationery', 'haushalt') THEN 1.250
+    WHEN recommended_retail_price >= 1000 THEN 180.000
+    WHEN recommended_retail_price >= 250 THEN 36.000
+    WHEN recommended_retail_price >= 50 THEN 7.500
+    WHEN recommended_retail_price >= 10 THEN 2.000
+    ELSE 0.750
+END
+WHERE co2_emission_kg IS NULL;


### PR DESCRIPTION
## Summary
- add co2_emission_kg to products via Flyway migrations and seed data
- expose CO2 footprint on product and cart DTOs
- add endpoint for editing product CO2 values from administration

## Tests
- mvnw test