### PR TITLE
Add product Eco-Score support

### DIFF
--- a/src/main/java/de/fhdw/webshop/product/Product.java
+++ b/src/main/java/de/fhdw/webshop/product/Product.java
@@ -34,6 +34,10 @@ public class Product {
     @Column(name = "co2_emission_kg", precision = 10, scale = 3)
     private BigDecimal co2EmissionKg;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "eco_score", nullable = false, length = 20)
+    private ProductEcoScore ecoScore = ProductEcoScore.NONE;
+
     @Column(length = 100)
     private String category;
 

--- a/src/main/java/de/fhdw/webshop/product/ProductController.java
+++ b/src/main/java/de/fhdw/webshop/product/ProductController.java
@@ -33,8 +33,9 @@ public class ProductController {
     public ResponseEntity<List<ProductResponse>> listProducts(
             @RequestParam(required = false) Boolean purchasable,
             @RequestParam(required = false) String category,
-            @RequestParam(required = false) String search) {
-        return ResponseEntity.ok(productService.listProducts(purchasable, category, search));
+            @RequestParam(required = false) String search,
+            @RequestParam(required = false, name = "ecoScore") List<ProductEcoScore> ecoScores) {
+        return ResponseEntity.ok(productService.listProducts(purchasable, category, search, ecoScores));
     }
 
     /** US #23, #25, #28 — Single product detail (description, image, price). */
@@ -113,6 +114,14 @@ public class ProductController {
     public ResponseEntity<ProductResponse> updateCo2Emission(@PathVariable Long id,
                                                              @Valid @RequestBody UpdateCo2EmissionRequest updateCo2EmissionRequest) {
         return ResponseEntity.ok(productService.updateCo2Emission(id, updateCo2EmissionRequest));
+    }
+
+    /** US #198 - Update Eco-Score. */
+    @PutMapping("/{id}/eco-score")
+    @PreAuthorize("hasAnyRole('EMPLOYEE', 'SALES_EMPLOYEE', 'ADMIN')")
+    public ResponseEntity<ProductResponse> updateEcoScore(@PathVariable Long id,
+                                                          @Valid @RequestBody UpdateEcoScoreRequest updateEcoScoreRequest) {
+        return ResponseEntity.ok(productService.updateEcoScore(id, updateEcoScoreRequest));
     }
 
     @GetMapping("/{id}/statistics")

--- a/src/main/java/de/fhdw/webshop/product/ProductEcoScore.java
+++ b/src/main/java/de/fhdw/webshop/product/ProductEcoScore.java
@@ -1,0 +1,10 @@
+package de.fhdw.webshop.product;
+
+public enum ProductEcoScore {
+    A,
+    B,
+    C,
+    D,
+    E,
+    NONE
+}

--- a/src/main/java/de/fhdw/webshop/product/ProductRepository.java
+++ b/src/main/java/de/fhdw/webshop/product/ProductRepository.java
@@ -4,12 +4,23 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Arrays;
 import java.util.List;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
+    default List<Product> searchProducts(Boolean purchasableOnly, String category, String searchTerm) {
+        return searchProducts(
+                purchasableOnly,
+                category,
+                false,
+                Arrays.asList(ProductEcoScore.values()),
+                searchTerm
+        );
+    }
+
     /**
-     * Flexible product search supporting all customer-facing filter combinations (US #46, #47).
+     * Flexible product search supporting all customer-facing filter combinations (US #46, #47, #198).
      * Passing null for any parameter disables that filter.
      */
     /**
@@ -22,6 +33,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             SELECT p FROM Product p
             WHERE (:purchasableOnly IS NULL OR p.purchasable = :purchasableOnly)
               AND (:category = '' OR LOWER(p.category) = LOWER(:category))
+              AND (:filterByEcoScore = false OR p.ecoScore IN :ecoScores)
               AND (:searchTerm = ''
                    OR LOWER(p.name) LIKE LOWER(CONCAT('%', :searchTerm, '%'))
                    OR LOWER(p.description) LIKE LOWER(CONCAT('%', :searchTerm, '%')))
@@ -30,6 +42,8 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     List<Product> searchProducts(
             @Param("purchasableOnly") Boolean purchasableOnly,
             @Param("category") String category,
+            @Param("filterByEcoScore") boolean filterByEcoScore,
+            @Param("ecoScores") List<ProductEcoScore> ecoScores,
             @Param("searchTerm") String searchTerm
     );
 }

--- a/src/main/java/de/fhdw/webshop/product/ProductService.java
+++ b/src/main/java/de/fhdw/webshop/product/ProductService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.Arrays;
 import java.util.List;
 
 @Service
@@ -18,11 +19,28 @@ public class ProductService {
     private final ProductRepository productRepository;
 
     public List<ProductResponse> listProducts(Boolean purchasableOnly, String category, String searchTerm) {
+        return listProducts(purchasableOnly, category, searchTerm, null);
+    }
+
+    public List<ProductResponse> listProducts(
+            Boolean purchasableOnly,
+            String category,
+            String searchTerm,
+            List<ProductEcoScore> ecoScores) {
         // Normalize null Strings to "" — JPQL IS NULL on String params infers bytea in PostgreSQL,
         // breaking LOWER(). The repository query uses = '' as the "no filter" sentinel instead.
         String normalizedCategory = (category == null) ? "" : category;
         String normalizedSearchTerm = (searchTerm == null) ? "" : searchTerm;
-        return productRepository.searchProducts(purchasableOnly, normalizedCategory, normalizedSearchTerm)
+        boolean filterByEcoScore = ecoScores != null && !ecoScores.isEmpty();
+        List<ProductEcoScore> normalizedEcoScores = filterByEcoScore
+                ? ecoScores
+                : Arrays.asList(ProductEcoScore.values());
+        return productRepository.searchProducts(
+                        purchasableOnly,
+                        normalizedCategory,
+                        filterByEcoScore,
+                        normalizedEcoScores,
+                        normalizedSearchTerm)
                 .stream()
                 .map(this::toResponse)
                 .toList();
@@ -50,6 +68,7 @@ public class ProductService {
         product.setImageUrl(productRequest.imageUrl());
         product.setRecommendedRetailPrice(productRequest.recommendedRetailPrice());
         product.setCo2EmissionKg(productRequest.co2EmissionKg());
+        product.setEcoScore(productRequest.ecoScore() == null ? ProductEcoScore.NONE : productRequest.ecoScore());
         product.setCategory(productRequest.category());
         product.setStock(25);
         return toResponse(productRepository.save(product));
@@ -110,6 +129,14 @@ public class ProductService {
         return toResponse(productRepository.save(product));
     }
 
+    /** US #198 - Update the product Eco-Score. */
+    @Transactional
+    public ProductResponse updateEcoScore(Long productId, UpdateEcoScoreRequest updateEcoScoreRequest) {
+        Product product = loadProduct(productId);
+        product.setEcoScore(updateEcoScoreRequest.ecoScore());
+        return toResponse(productRepository.save(product));
+    }
+
     public Product loadProduct(Long productId) {
         return productRepository.findById(productId)
                 .orElseThrow(() -> new EntityNotFoundException("Product not found: " + productId));
@@ -131,6 +158,7 @@ public class ProductService {
                 product.getImageUrl(),
                 product.getRecommendedRetailPrice(),
                 product.getCo2EmissionKg(),
+                product.getEcoScore(),
                 product.getCategory(),
                 product.getStock(),
                 product.isPurchasable(),

--- a/src/main/java/de/fhdw/webshop/product/dto/ProductRequest.java
+++ b/src/main/java/de/fhdw/webshop/product/dto/ProductRequest.java
@@ -1,5 +1,7 @@
 package de.fhdw.webshop.product.dto;
 
+import de.fhdw.webshop.product.ProductEcoScore;
+
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -12,5 +14,6 @@ public record ProductRequest(
         String imageUrl,
         @NotNull @DecimalMin("0.01") BigDecimal recommendedRetailPrice,
         @NotNull @DecimalMin("0.001") BigDecimal co2EmissionKg,
+        ProductEcoScore ecoScore,
         String category
 ) {}

--- a/src/main/java/de/fhdw/webshop/product/dto/ProductResponse.java
+++ b/src/main/java/de/fhdw/webshop/product/dto/ProductResponse.java
@@ -1,5 +1,7 @@
 package de.fhdw.webshop.product.dto;
 
+import de.fhdw.webshop.product.ProductEcoScore;
+
 import java.math.BigDecimal;
 import java.time.Instant;
 
@@ -10,6 +12,7 @@ public record ProductResponse(
         String imageUrl,
         BigDecimal recommendedRetailPrice,
         BigDecimal co2EmissionKg,
+        ProductEcoScore ecoScore,
         String category,
         int stock,
         boolean purchasable,

--- a/src/main/java/de/fhdw/webshop/product/dto/UpdateEcoScoreRequest.java
+++ b/src/main/java/de/fhdw/webshop/product/dto/UpdateEcoScoreRequest.java
@@ -1,0 +1,8 @@
+package de.fhdw.webshop.product.dto;
+
+import de.fhdw.webshop.product.ProductEcoScore;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateEcoScoreRequest(
+        @NotNull ProductEcoScore ecoScore
+) {}

--- a/src/main/resources/db/migration/V33__add_product_eco_score.sql
+++ b/src/main/resources/db/migration/V33__add_product_eco_score.sql
@@ -1,0 +1,26 @@
+ALTER TABLE products
+    ADD COLUMN IF NOT EXISTS eco_score VARCHAR(20) NOT NULL DEFAULT 'NONE';
+
+UPDATE products
+SET eco_score = CASE
+    WHEN co2_emission_kg < 1 THEN 'A'
+    WHEN co2_emission_kg < 5 THEN 'B'
+    WHEN co2_emission_kg < 20 THEN 'C'
+    WHEN co2_emission_kg < 80 THEN 'D'
+    ELSE 'E'
+END
+WHERE eco_score = 'NONE'
+  AND co2_emission_kg IS NOT NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'products_eco_score_check'
+    ) THEN
+        ALTER TABLE products
+            ADD CONSTRAINT products_eco_score_check
+            CHECK (eco_score IN ('A', 'B', 'C', 'D', 'E', 'NONE'));
+    END IF;
+END $$;


### PR DESCRIPTION
## Summary
- add ProductEcoScore enum and eco_score database migration
- expose Eco-Score in product create/list/detail responses
- add multi-value Eco-Score filtering and employee update endpoint

## Verification
- `.\mvnw.cmd "-Dmaven.repo.local=C:\Dev\Webshop-Backend\.m2\repository" test`

Related to SEPBFWS124A/Webshop#198
