### PR TITLE
feat: Implement Trade-In / Rückgabe-Programm (#199)

### DIFF
--- a/src/main/java/de/fhdw/webshop/address/AddressLookupService.java
+++ b/src/main/java/de/fhdw/webshop/address/AddressLookupService.java
@@ -443,7 +443,7 @@ public class AddressLookupService {
         return streetMatches
                 && normalizePostalCode(suggestion.postalCode()).equals(postalCode)
                 && cityMatches
-                && (country.isBlank() || normalizeComparable(suggestion.country()).equals(normalizeComparable(country)));
+                && (country.isBlank() || normalizeCountryComparable(suggestion.country()).equals(normalizeCountryComparable(country)));
     }
 
     private AddressValidationResponse invalid(String message) {
@@ -477,6 +477,14 @@ public class AddressLookupService {
                 .replace("ü", "ue")
                 .replace("ß", "ss")
                 .replaceAll("[^a-z0-9]", "");
+    }
+
+    private String normalizeCountryComparable(String value) {
+        String normalized = normalizeComparable(value);
+        if ("deutschland".equals(normalized) || "germany".equals(normalized) || "de".equals(normalized) || "deu".equals(normalized)) {
+            return "germany";
+        }
+        return normalized;
     }
 
     private String asString(Object value) {

--- a/src/main/java/de/fhdw/webshop/admin/navigation/AdminNavigationService.java
+++ b/src/main/java/de/fhdw/webshop/admin/navigation/AdminNavigationService.java
@@ -26,6 +26,10 @@ public class AdminNavigationService {
             Set.of(UserRole.WAREHOUSE_EMPLOYEE, UserRole.ADMIN);
     private static final Set<UserRole> ADMIN_ROLES =
             Set.of(UserRole.ADMIN);
+    private static final Set<UserRole> TRADE_IN_ROLES =
+            Set.of(UserRole.EMPLOYEE, UserRole.SALES_EMPLOYEE, UserRole.ADMIN);
+    private static final Set<UserRole> BUSINESS_LOG_ROLES =
+            Set.of(UserRole.EMPLOYEE, UserRole.SALES_EMPLOYEE, UserRole.WAREHOUSE_EMPLOYEE, UserRole.ADMIN);
 
     private static final List<NavigationGroup> NAVIGATION = List.of(
             new NavigationGroup(
@@ -58,10 +62,20 @@ public class AdminNavigationService {
                     )
             ),
             new NavigationGroup(
+                    "orders-management",
+                    "Bestellungen",
+                    "pi pi-shopping-bag",
+                    List.of(
+                            item("trade-in", "Trade-In Anfragen", "/admin/orders/trade-in", "pi pi-refresh", TRADE_IN_ROLES)
+                    )
+            ),
+            new NavigationGroup(
                     "reports",
                     "Statistiken/Berichte",
                     "pi pi-chart-line",
                     List.of(
+                            item("statistics-dashboard", "Dashboard", "/admin/reports/statistics", "pi pi-chart-line", SALES_REPORTING_ROLES),
+                            item("statistics-alerts", "Kennzahl-Warnungen", "/admin/reports/statistics-alerts", "pi pi-exclamation-triangle", SALES_REPORTING_ROLES),
                             item("product-statistics", "Artikelstatistiken", "/admin/reports/product-statistics", "pi pi-chart-bar", SALES_REPORTING_ROLES),
                             item("monitoring", "System Monitoring", "/admin/reports/monitoring", "pi pi-desktop", ADMIN_ROLES)
                     )
@@ -71,6 +85,7 @@ public class AdminNavigationService {
                     "System",
                     "pi pi-cog",
                     List.of(
+                            item("business-log", "Business Log", "/admin/system/business-log", "pi pi-history", BUSINESS_LOG_ROLES),
                             item("notifications", "Systemmeldungen", "/admin/system/notifications", "pi pi-bell", SALES_REPORTING_ROLES),
                             item("alerting", "E-Mail & Alerting", "/admin/system/alerting", "pi pi-envelope", ADMIN_ROLES)
                     )

--- a/src/main/java/de/fhdw/webshop/cart/CartService.java
+++ b/src/main/java/de/fhdw/webshop/cart/CartService.java
@@ -70,6 +70,19 @@ public class CartService {
         BigDecimal total = subtotal.add(tax).add(shippingCost)
                 .setScale(2, RoundingMode.HALF_UP);
 
+        BigDecimal totalCo2EmissionKg = itemResponses.stream()
+                .map(CartItemResponse::lineCo2EmissionKg)
+                .filter(lineCo2EmissionKg -> lineCo2EmissionKg != null)
+                .reduce(BigDecimal.ZERO, BigDecimal::add)
+                .setScale(3, RoundingMode.HALF_UP);
+        int co2EmissionCoveredItemCount = itemResponses.stream()
+                .filter(item -> item.co2EmissionKg() != null)
+                .mapToInt(CartItemResponse::quantity)
+                .sum();
+        int co2EmissionTotalItemCount = itemResponses.stream()
+                .mapToInt(CartItemResponse::quantity)
+                .sum();
+
         return new CartResponse(
                 itemResponses,
                 subtotal,
@@ -77,6 +90,9 @@ public class CartService {
                 tax,
                 shippingCost,
                 total,
+                totalCo2EmissionKg,
+                co2EmissionCoveredItemCount,
+                co2EmissionTotalItemCount,
                 coupon != null ? coupon.getCode() : null,
                 messages
         );
@@ -181,6 +197,11 @@ public class CartService {
             effectiveUnitPrice = recommendedRetailPrice;
         }
         BigDecimal lineTotal = effectiveUnitPrice.multiply(BigDecimal.valueOf(cartItem.getQuantity()));
+        BigDecimal co2EmissionKg = cartItem.getProduct().getCo2EmissionKg();
+        BigDecimal lineCo2EmissionKg = co2EmissionKg == null
+                ? null
+                : co2EmissionKg.multiply(BigDecimal.valueOf(cartItem.getQuantity()))
+                        .setScale(3, RoundingMode.HALF_UP);
 
         return new CartItemResponse(
                 cartItem.getId(),
@@ -188,9 +209,11 @@ public class CartService {
                 cartItem.getProduct().getName(),
                 cartItem.getProduct().getImageUrl(),
                 effectiveUnitPrice,
+                co2EmissionKg,
                 getAvailableStock(cartItem.getProduct()),
                 cartItem.getQuantity(),
                 lineTotal,
+                lineCo2EmissionKg,
                 cartItem.getAddedAt()
         );
     }

--- a/src/main/java/de/fhdw/webshop/cart/dto/CartItemResponse.java
+++ b/src/main/java/de/fhdw/webshop/cart/dto/CartItemResponse.java
@@ -9,8 +9,10 @@ public record CartItemResponse(
         String productName,
         String imageUrl,
         BigDecimal unitPrice,
+        BigDecimal co2EmissionKg,
         int availableStock,
         int quantity,
         BigDecimal lineTotal,
+        BigDecimal lineCo2EmissionKg,
         Instant addedAt
 ) {}

--- a/src/main/java/de/fhdw/webshop/cart/dto/CartResponse.java
+++ b/src/main/java/de/fhdw/webshop/cart/dto/CartResponse.java
@@ -10,6 +10,9 @@ public record CartResponse(
         BigDecimal tax,
         BigDecimal shippingCost,
         BigDecimal total,
+        BigDecimal totalCo2EmissionKg,
+        int co2EmissionCoveredItemCount,
+        int co2EmissionTotalItemCount,
         String appliedCouponCode,
         List<String> messages
 ) {}

--- a/src/main/java/de/fhdw/webshop/config/GlobalExceptionHandler.java
+++ b/src/main/java/de/fhdw/webshop/config/GlobalExceptionHandler.java
@@ -36,6 +36,11 @@ public class GlobalExceptionHandler {
         return buildErrorResponse(HttpStatus.BAD_REQUEST, exception.getMessage());
     }
 
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<Map<String, Object>> handleIllegalState(IllegalStateException exception) {
+        return buildErrorResponse(HttpStatus.CONFLICT, exception.getMessage());
+    }
+
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<Map<String, Object>> handleMessageNotReadable(HttpMessageNotReadableException exception) {
         return buildErrorResponse(HttpStatus.BAD_REQUEST, "Request body could not be parsed");

--- a/src/main/java/de/fhdw/webshop/order/Order.java
+++ b/src/main/java/de/fhdw/webshop/order/Order.java
@@ -66,6 +66,15 @@ public class Order {
     @Column(name = "shipping_cost", nullable = false, precision = 10, scale = 2)
     private BigDecimal shippingCost = BigDecimal.ZERO;
 
+    @Column(name = "climate_contribution_amount", nullable = false, precision = 10, scale = 2)
+    private BigDecimal climateContributionAmount = BigDecimal.ZERO;
+
+    @Column(name = "carbon_compensation_selected", nullable = false)
+    private boolean carbonCompensationSelected = false;
+
+    @Column(name = "total_co2_emission_kg", nullable = false, precision = 10, scale = 3)
+    private BigDecimal totalCo2EmissionKg = BigDecimal.ZERO;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "shipping_method", nullable = false, length = 30)
     private ShippingMethod shippingMethod = ShippingMethod.STANDARD;

--- a/src/main/java/de/fhdw/webshop/order/OrderItemRepository.java
+++ b/src/main/java/de/fhdw/webshop/order/OrderItemRepository.java
@@ -1,0 +1,10 @@
+package de.fhdw.webshop.order;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+
+    Optional<OrderItem> findByIdAndOrderCustomerId(Long id, Long customerId);
+}

--- a/src/main/java/de/fhdw/webshop/order/OrderService.java
+++ b/src/main/java/de/fhdw/webshop/order/OrderService.java
@@ -51,6 +51,7 @@ public class OrderService {
     private static final BigDecimal SHIPPING_COST = new BigDecimal("4.99");
     private static final BigDecimal EXPRESS_SHIPPING_COST = new BigDecimal("9.99");
     private static final BigDecimal FREE_SHIPPING_THRESHOLD = new BigDecimal("50.00");
+    private static final BigDecimal CARBON_COMPENSATION_RATE_PER_KG = new BigDecimal("0.05");
     private static final Duration STANDARD_TOTAL_DELIVERY = Duration.ofDays(4);
     private static final Duration EXPRESS_TOTAL_DELIVERY = Duration.ofDays(2);
     private static final Duration STANDARD_MIN_REMAINING_EARLY = Duration.ofDays(3);
@@ -156,6 +157,7 @@ public class OrderService {
         String couponCode = placeOrderRequest != null ? placeOrderRequest.couponCode() : null;
         Coupon coupon = resolveCoupon(couponCode, customer);
         String orderNumber = placeOrderRequest != null ? placeOrderRequest.previewOrderNumber() : null;
+        boolean carbonCompensationSelected = placeOrderRequest != null && Boolean.TRUE.equals(placeOrderRequest.carbonCompensationSelected());
         String confirmationEmail = placeOrderRequest != null && placeOrderRequest.email() != null && !placeOrderRequest.email().isBlank()
                 ? placeOrderRequest.email().trim()
                 : customer.getEmail();
@@ -177,7 +179,8 @@ public class OrderService {
                 paymentMethod,
                 coupon,
                 customer.getId(),
-                placeOrderRequest != null && Boolean.TRUE.equals(placeOrderRequest.allowUnverifiedAddress())
+                placeOrderRequest != null && Boolean.TRUE.equals(placeOrderRequest.allowUnverifiedAddress()),
+                carbonCompensationSelected
         );
     }
 
@@ -218,7 +221,8 @@ public class OrderService {
                 resolveGuestPaymentMethod(placeOrderRequest.paymentMethod()),
                 null,
                 null,
-                Boolean.TRUE.equals(placeOrderRequest.allowUnverifiedAddress())
+                Boolean.TRUE.equals(placeOrderRequest.allowUnverifiedAddress()),
+                Boolean.TRUE.equals(placeOrderRequest.carbonCompensationSelected())
         );
     }
 
@@ -232,7 +236,8 @@ public class OrderService {
                                        PaymentMethodSnapshot paymentMethod,
                                        Coupon coupon,
                                        Long discountCustomerId,
-                                       boolean allowUnverifiedAddress) {
+                                       boolean allowUnverifiedAddress,
+                                       boolean carbonCompensationSelected) {
         Order order = new Order();
         DeliveryAddressSnapshot validatedDeliveryAddress = validateDeliveryAddress(deliveryAddress, allowUnverifiedAddress);
         order.setCustomer(customer);
@@ -253,6 +258,7 @@ public class OrderService {
         order.setCouponCode(coupon != null ? coupon.getCode() : null);
 
         BigDecimal itemSubtotal = BigDecimal.ZERO;
+        BigDecimal totalCo2EmissionKg = BigDecimal.ZERO;
         List<PreparedOrderItem> preparedItems = new ArrayList<>();
         for (RequestedOrderItem requestedItem : requestedItems) {
             Product product = requestedItem.product();
@@ -269,16 +275,37 @@ public class OrderService {
             BigDecimal unitPrice = applyDiscount(product.getRecommendedRetailPrice(), discountPercent);
             BigDecimal lineTotal = unitPrice.multiply(BigDecimal.valueOf(requestedItem.quantity())).setScale(2, RoundingMode.HALF_UP);
             itemSubtotal = itemSubtotal.add(lineTotal);
+            if (product.getCo2EmissionKg() != null) {
+                totalCo2EmissionKg = totalCo2EmissionKg.add(
+                        product.getCo2EmissionKg().multiply(BigDecimal.valueOf(requestedItem.quantity())));
+            }
             preparedItems.add(new PreparedOrderItem(product, requestedItem.quantity(), unitPrice, lineTotal));
         }
+        totalCo2EmissionKg = totalCo2EmissionKg.setScale(3, RoundingMode.HALF_UP);
 
         BigDecimal discountAmount = calculateCouponDiscount(itemSubtotal, coupon);
         BigDecimal subtotal = itemSubtotal.subtract(discountAmount).max(BigDecimal.ZERO).setScale(2, RoundingMode.HALF_UP);
         BigDecimal shippingCost = calculateShippingCost(subtotal, shippingMethod);
         BigDecimal taxAmount = subtotal.multiply(TAX_RATE).setScale(2, RoundingMode.HALF_UP);
-        BigDecimal totalPrice = subtotal.add(taxAmount).add(shippingCost).setScale(2, RoundingMode.HALF_UP);
+        BigDecimal climateContributionAmount = calculateClimateContributionAmount(
+                totalCo2EmissionKg,
+                carbonCompensationSelected
+        );
+        BigDecimal totalPrice = subtotal.add(taxAmount).add(shippingCost).add(climateContributionAmount).setScale(2, RoundingMode.HALF_UP);
 
-        return new PreparedOrder(order, preparedItems, coupon, discountAmount, taxAmount, subtotal, shippingCost, totalPrice);
+        return new PreparedOrder(
+                order,
+                preparedItems,
+                coupon,
+                discountAmount,
+                taxAmount,
+                subtotal,
+                shippingCost,
+                climateContributionAmount,
+                totalCo2EmissionKg,
+                carbonCompensationSelected,
+                totalPrice
+        );
     }
 
     private DeliveryAddressSnapshot validateDeliveryAddress(DeliveryAddressSnapshot deliveryAddress, boolean allowUnverifiedAddress) {
@@ -359,6 +386,9 @@ public class OrderService {
         order.setDiscountAmount(preparedOrder.discountAmount());
         order.setTaxAmount(preparedOrder.taxAmount());
         order.setShippingCost(preparedOrder.shippingCost());
+        order.setClimateContributionAmount(preparedOrder.climateContributionAmount());
+        order.setCarbonCompensationSelected(preparedOrder.carbonCompensationSelected());
+        order.setTotalCo2EmissionKg(preparedOrder.totalCo2EmissionKg());
         order.setTotalPrice(preparedOrder.totalPrice());
         order.setStatus(OrderStatus.CONFIRMED);
 
@@ -465,6 +495,16 @@ public class OrderService {
         return subtotal.multiply(multiplier).setScale(2, RoundingMode.HALF_UP);
     }
 
+    private BigDecimal calculateClimateContributionAmount(BigDecimal totalCo2EmissionKg, boolean selected) {
+        if (!selected || totalCo2EmissionKg == null || totalCo2EmissionKg.compareTo(BigDecimal.ZERO) <= 0) {
+            return BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+        }
+
+        return totalCo2EmissionKg
+                .multiply(CARBON_COMPENSATION_RATE_PER_KG)
+                .setScale(2, RoundingMode.HALF_UP);
+    }
+
     private void markCouponAsUsed(Coupon coupon, Order savedOrder, User customer) {
         if (coupon == null) {
             return;
@@ -526,6 +566,8 @@ public class OrderService {
                 order.getTaxAmount(),
                 order.getShippingCost(),
                 order.getShippingMethod(),
+                order.getClimateContributionAmount(),
+                order.getTotalCo2EmissionKg(),
                 order.getDiscountAmount(),
                 order.getCouponCode(),
                 order.getCreatedAt(),
@@ -557,6 +599,8 @@ public class OrderService {
                 order.getTaxAmount(),
                 order.getShippingCost(),
                 order.getShippingMethod(),
+                order.getClimateContributionAmount(),
+                order.getTotalCo2EmissionKg(),
                 order.getDiscountAmount(),
                 order.getCouponCode(),
                 order.getCreatedAt(),
@@ -618,6 +662,8 @@ public class OrderService {
                 preparedOrder.discountAmount(),
                 preparedOrder.taxAmount(),
                 preparedOrder.shippingCost(),
+                preparedOrder.climateContributionAmount(),
+                preparedOrder.totalCo2EmissionKg(),
                 preparedOrder.totalPrice(),
                 preparedOrder.order().getCouponCode(),
                 itemResponses
@@ -632,8 +678,16 @@ public class OrderService {
                 .append("Versand an: ").append(order.getDeliveryStreet()).append(", ")
                 .append(order.getDeliveryPostalCode()).append(' ')
                 .append(order.getDeliveryCity()).append(", ")
-                .append(order.getDeliveryCountry()).append("\n\n")
-                .append("Artikel:\n");
+                .append(order.getDeliveryCountry()).append('\n');
+
+        if (order.getClimateContributionAmount() != null
+                && order.getClimateContributionAmount().compareTo(BigDecimal.ZERO) > 0) {
+            body.append("Klimabeitrag: ")
+                    .append(order.getClimateContributionAmount())
+                    .append(" EUR\n");
+        }
+
+        body.append("\nArtikel:\n");
 
         for (OrderItem item : order.getItems()) {
             body.append("- ")
@@ -685,6 +739,9 @@ public class OrderService {
             BigDecimal taxAmount,
             BigDecimal subtotal,
             BigDecimal shippingCost,
+            BigDecimal climateContributionAmount,
+            BigDecimal totalCo2EmissionKg,
+            boolean carbonCompensationSelected,
             BigDecimal totalPrice
     ) {}
 }

--- a/src/main/java/de/fhdw/webshop/order/dto/OrderPreviewResponse.java
+++ b/src/main/java/de/fhdw/webshop/order/dto/OrderPreviewResponse.java
@@ -10,6 +10,8 @@ public record OrderPreviewResponse(
         BigDecimal discountAmount,
         BigDecimal taxAmount,
         BigDecimal shippingCost,
+        BigDecimal climateContributionAmount,
+        BigDecimal totalCo2EmissionKg,
         BigDecimal totalPrice,
         String couponCode,
         List<OrderPreviewItemResponse> items

--- a/src/main/java/de/fhdw/webshop/order/dto/OrderResponse.java
+++ b/src/main/java/de/fhdw/webshop/order/dto/OrderResponse.java
@@ -16,6 +16,8 @@ public record OrderResponse(
         BigDecimal taxAmount,
         BigDecimal shippingCost,
         ShippingMethod shippingMethod,
+        BigDecimal climateContributionAmount,
+        BigDecimal totalCo2EmissionKg,
         BigDecimal discountAmount,
         String couponCode,
         Instant createdAt,

--- a/src/main/java/de/fhdw/webshop/order/dto/PlaceOrderRequest.java
+++ b/src/main/java/de/fhdw/webshop/order/dto/PlaceOrderRequest.java
@@ -21,5 +21,6 @@ public record PlaceOrderRequest(
         Boolean acceptedPrivacyPolicy,
         Boolean saveDeliveryAddress,
         Boolean savePaymentMethod,
+        Boolean carbonCompensationSelected,
         List<@Valid PlaceOrderItemRequest> items
 ) {}

--- a/src/main/java/de/fhdw/webshop/product/Product.java
+++ b/src/main/java/de/fhdw/webshop/product/Product.java
@@ -31,6 +31,9 @@ public class Product {
     @Column(name = "recommended_retail_price", nullable = false, precision = 10, scale = 2)
     private BigDecimal recommendedRetailPrice;
 
+    @Column(name = "co2_emission_kg", precision = 10, scale = 3)
+    private BigDecimal co2EmissionKg;
+
     @Column(length = 100)
     private String category;
 

--- a/src/main/java/de/fhdw/webshop/product/Product.java
+++ b/src/main/java/de/fhdw/webshop/product/Product.java
@@ -34,6 +34,10 @@ public class Product {
     @Column(name = "co2_emission_kg", precision = 10, scale = 3)
     private BigDecimal co2EmissionKg;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "eco_score", nullable = false, length = 20)
+    private ProductEcoScore ecoScore = ProductEcoScore.NONE;
+
     @Column(length = 100)
     private String category;
 

--- a/src/main/java/de/fhdw/webshop/product/ProductController.java
+++ b/src/main/java/de/fhdw/webshop/product/ProductController.java
@@ -107,6 +107,14 @@ public class ProductController {
     }
 
     /** US #34 — Sales statistics (units sold, revenue) for a product over a date range. */
+    /** US #196 — Update estimated product CO2 footprint in kg CO2e. */
+    @PutMapping("/{id}/co2-emission")
+    @PreAuthorize("hasAnyRole('EMPLOYEE', 'SALES_EMPLOYEE', 'ADMIN')")
+    public ResponseEntity<ProductResponse> updateCo2Emission(@PathVariable Long id,
+                                                             @Valid @RequestBody UpdateCo2EmissionRequest updateCo2EmissionRequest) {
+        return ResponseEntity.ok(productService.updateCo2Emission(id, updateCo2EmissionRequest));
+    }
+
     @GetMapping("/{id}/statistics")
     @PreAuthorize("hasAnyRole('SALES_EMPLOYEE', 'ADMIN')")
     public ResponseEntity<ProductStatisticsResponse> getProductStatistics(

--- a/src/main/java/de/fhdw/webshop/product/ProductController.java
+++ b/src/main/java/de/fhdw/webshop/product/ProductController.java
@@ -33,8 +33,9 @@ public class ProductController {
     public ResponseEntity<List<ProductResponse>> listProducts(
             @RequestParam(required = false) Boolean purchasable,
             @RequestParam(required = false) String category,
-            @RequestParam(required = false) String search) {
-        return ResponseEntity.ok(productService.listProducts(purchasable, category, search));
+            @RequestParam(required = false) String search,
+            @RequestParam(required = false, name = "ecoScore") List<ProductEcoScore> ecoScores) {
+        return ResponseEntity.ok(productService.listProducts(purchasable, category, search, ecoScores));
     }
 
     /** US #23, #25, #28 — Single product detail (description, image, price). */
@@ -113,6 +114,14 @@ public class ProductController {
     public ResponseEntity<ProductResponse> updateCo2Emission(@PathVariable Long id,
                                                              @Valid @RequestBody UpdateCo2EmissionRequest updateCo2EmissionRequest) {
         return ResponseEntity.ok(productService.updateCo2Emission(id, updateCo2EmissionRequest));
+    }
+
+    /** US #198 - Update Eco-Score. */
+    @PutMapping("/{id}/eco-score")
+    @PreAuthorize("hasAnyRole('EMPLOYEE', 'SALES_EMPLOYEE', 'ADMIN')")
+    public ResponseEntity<ProductResponse> updateEcoScore(@PathVariable Long id,
+                                                          @Valid @RequestBody UpdateEcoScoreRequest updateEcoScoreRequest) {
+        return ResponseEntity.ok(productService.updateEcoScore(id, updateEcoScoreRequest));
     }
 
     @GetMapping("/{id}/statistics")

--- a/src/main/java/de/fhdw/webshop/product/ProductEcoScore.java
+++ b/src/main/java/de/fhdw/webshop/product/ProductEcoScore.java
@@ -1,0 +1,10 @@
+package de.fhdw.webshop.product;
+
+public enum ProductEcoScore {
+    A,
+    B,
+    C,
+    D,
+    E,
+    NONE
+}

--- a/src/main/java/de/fhdw/webshop/product/ProductRepository.java
+++ b/src/main/java/de/fhdw/webshop/product/ProductRepository.java
@@ -4,12 +4,23 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Arrays;
 import java.util.List;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
+    default List<Product> searchProducts(Boolean purchasableOnly, String category, String searchTerm) {
+        return searchProducts(
+                purchasableOnly,
+                category,
+                false,
+                Arrays.asList(ProductEcoScore.values()),
+                searchTerm
+        );
+    }
+
     /**
-     * Flexible product search supporting all customer-facing filter combinations (US #46, #47).
+     * Flexible product search supporting all customer-facing filter combinations (US #46, #47, #198).
      * Passing null for any parameter disables that filter.
      */
     /**
@@ -22,6 +33,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             SELECT p FROM Product p
             WHERE (:purchasableOnly IS NULL OR p.purchasable = :purchasableOnly)
               AND (:category = '' OR LOWER(p.category) = LOWER(:category))
+              AND (:filterByEcoScore = false OR p.ecoScore IN :ecoScores)
               AND (:searchTerm = ''
                    OR LOWER(p.name) LIKE LOWER(CONCAT('%', :searchTerm, '%'))
                    OR LOWER(p.description) LIKE LOWER(CONCAT('%', :searchTerm, '%')))
@@ -30,6 +42,8 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     List<Product> searchProducts(
             @Param("purchasableOnly") Boolean purchasableOnly,
             @Param("category") String category,
+            @Param("filterByEcoScore") boolean filterByEcoScore,
+            @Param("ecoScores") List<ProductEcoScore> ecoScores,
             @Param("searchTerm") String searchTerm
     );
 }

--- a/src/main/java/de/fhdw/webshop/product/ProductService.java
+++ b/src/main/java/de/fhdw/webshop/product/ProductService.java
@@ -49,6 +49,7 @@ public class ProductService {
         product.setDescription(productRequest.description());
         product.setImageUrl(productRequest.imageUrl());
         product.setRecommendedRetailPrice(productRequest.recommendedRetailPrice());
+        product.setCo2EmissionKg(productRequest.co2EmissionKg());
         product.setCategory(productRequest.category());
         product.setStock(25);
         return toResponse(productRepository.save(product));
@@ -101,6 +102,14 @@ public class ProductService {
         return toResponse(productRepository.save(product));
     }
 
+    /** US #196 — Update the estimated product CO2 footprint. */
+    @Transactional
+    public ProductResponse updateCo2Emission(Long productId, UpdateCo2EmissionRequest updateCo2EmissionRequest) {
+        Product product = loadProduct(productId);
+        product.setCo2EmissionKg(updateCo2EmissionRequest.co2EmissionKg());
+        return toResponse(productRepository.save(product));
+    }
+
     public Product loadProduct(Long productId) {
         return productRepository.findById(productId)
                 .orElseThrow(() -> new EntityNotFoundException("Product not found: " + productId));
@@ -121,6 +130,7 @@ public class ProductService {
                 product.getDescription(),
                 product.getImageUrl(),
                 product.getRecommendedRetailPrice(),
+                product.getCo2EmissionKg(),
                 product.getCategory(),
                 product.getStock(),
                 product.isPurchasable(),

--- a/src/main/java/de/fhdw/webshop/product/ProductService.java
+++ b/src/main/java/de/fhdw/webshop/product/ProductService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.Arrays;
 import java.util.List;
 
 @Service
@@ -18,11 +19,28 @@ public class ProductService {
     private final ProductRepository productRepository;
 
     public List<ProductResponse> listProducts(Boolean purchasableOnly, String category, String searchTerm) {
+        return listProducts(purchasableOnly, category, searchTerm, null);
+    }
+
+    public List<ProductResponse> listProducts(
+            Boolean purchasableOnly,
+            String category,
+            String searchTerm,
+            List<ProductEcoScore> ecoScores) {
         // Normalize null Strings to "" — JPQL IS NULL on String params infers bytea in PostgreSQL,
         // breaking LOWER(). The repository query uses = '' as the "no filter" sentinel instead.
         String normalizedCategory = (category == null) ? "" : category;
         String normalizedSearchTerm = (searchTerm == null) ? "" : searchTerm;
-        return productRepository.searchProducts(purchasableOnly, normalizedCategory, normalizedSearchTerm)
+        boolean filterByEcoScore = ecoScores != null && !ecoScores.isEmpty();
+        List<ProductEcoScore> normalizedEcoScores = filterByEcoScore
+                ? ecoScores
+                : Arrays.asList(ProductEcoScore.values());
+        return productRepository.searchProducts(
+                        purchasableOnly,
+                        normalizedCategory,
+                        filterByEcoScore,
+                        normalizedEcoScores,
+                        normalizedSearchTerm)
                 .stream()
                 .map(this::toResponse)
                 .toList();
@@ -50,6 +68,7 @@ public class ProductService {
         product.setImageUrl(productRequest.imageUrl());
         product.setRecommendedRetailPrice(productRequest.recommendedRetailPrice());
         product.setCo2EmissionKg(productRequest.co2EmissionKg());
+        product.setEcoScore(productRequest.ecoScore() == null ? ProductEcoScore.NONE : productRequest.ecoScore());
         product.setCategory(productRequest.category());
         product.setStock(25);
         return toResponse(productRepository.save(product));
@@ -110,6 +129,14 @@ public class ProductService {
         return toResponse(productRepository.save(product));
     }
 
+    /** US #198 - Update the product Eco-Score. */
+    @Transactional
+    public ProductResponse updateEcoScore(Long productId, UpdateEcoScoreRequest updateEcoScoreRequest) {
+        Product product = loadProduct(productId);
+        product.setEcoScore(updateEcoScoreRequest.ecoScore());
+        return toResponse(productRepository.save(product));
+    }
+
     public Product loadProduct(Long productId) {
         return productRepository.findById(productId)
                 .orElseThrow(() -> new EntityNotFoundException("Product not found: " + productId));
@@ -131,6 +158,7 @@ public class ProductService {
                 product.getImageUrl(),
                 product.getRecommendedRetailPrice(),
                 product.getCo2EmissionKg(),
+                product.getEcoScore(),
                 product.getCategory(),
                 product.getStock(),
                 product.isPurchasable(),

--- a/src/main/java/de/fhdw/webshop/product/dto/ProductRequest.java
+++ b/src/main/java/de/fhdw/webshop/product/dto/ProductRequest.java
@@ -11,5 +11,6 @@ public record ProductRequest(
         String description,
         String imageUrl,
         @NotNull @DecimalMin("0.01") BigDecimal recommendedRetailPrice,
+        @NotNull @DecimalMin("0.001") BigDecimal co2EmissionKg,
         String category
 ) {}

--- a/src/main/java/de/fhdw/webshop/product/dto/ProductRequest.java
+++ b/src/main/java/de/fhdw/webshop/product/dto/ProductRequest.java
@@ -1,5 +1,7 @@
 package de.fhdw.webshop.product.dto;
 
+import de.fhdw.webshop.product.ProductEcoScore;
+
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -12,5 +14,6 @@ public record ProductRequest(
         String imageUrl,
         @NotNull @DecimalMin("0.01") BigDecimal recommendedRetailPrice,
         @NotNull @DecimalMin("0.001") BigDecimal co2EmissionKg,
+        ProductEcoScore ecoScore,
         String category
 ) {}

--- a/src/main/java/de/fhdw/webshop/product/dto/ProductResponse.java
+++ b/src/main/java/de/fhdw/webshop/product/dto/ProductResponse.java
@@ -9,6 +9,7 @@ public record ProductResponse(
         String description,
         String imageUrl,
         BigDecimal recommendedRetailPrice,
+        BigDecimal co2EmissionKg,
         String category,
         int stock,
         boolean purchasable,

--- a/src/main/java/de/fhdw/webshop/product/dto/ProductResponse.java
+++ b/src/main/java/de/fhdw/webshop/product/dto/ProductResponse.java
@@ -1,5 +1,7 @@
 package de.fhdw.webshop.product.dto;
 
+import de.fhdw.webshop.product.ProductEcoScore;
+
 import java.math.BigDecimal;
 import java.time.Instant;
 
@@ -10,6 +12,7 @@ public record ProductResponse(
         String imageUrl,
         BigDecimal recommendedRetailPrice,
         BigDecimal co2EmissionKg,
+        ProductEcoScore ecoScore,
         String category,
         int stock,
         boolean purchasable,

--- a/src/main/java/de/fhdw/webshop/product/dto/UpdateCo2EmissionRequest.java
+++ b/src/main/java/de/fhdw/webshop/product/dto/UpdateCo2EmissionRequest.java
@@ -1,0 +1,10 @@
+package de.fhdw.webshop.product.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+
+public record UpdateCo2EmissionRequest(
+        @NotNull @DecimalMin("0.001") BigDecimal co2EmissionKg
+) {}

--- a/src/main/java/de/fhdw/webshop/product/dto/UpdateEcoScoreRequest.java
+++ b/src/main/java/de/fhdw/webshop/product/dto/UpdateEcoScoreRequest.java
@@ -1,0 +1,8 @@
+package de.fhdw.webshop.product.dto;
+
+import de.fhdw.webshop.product.ProductEcoScore;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateEcoScoreRequest(
+        @NotNull ProductEcoScore ecoScore
+) {}

--- a/src/main/java/de/fhdw/webshop/tradein/TradeInCondition.java
+++ b/src/main/java/de/fhdw/webshop/tradein/TradeInCondition.java
@@ -1,0 +1,7 @@
+package de.fhdw.webshop.tradein;
+
+public enum TradeInCondition {
+    LIKE_NEW,
+    LIGHT_WEAR,
+    DEFECTIVE
+}

--- a/src/main/java/de/fhdw/webshop/tradein/TradeInController.java
+++ b/src/main/java/de/fhdw/webshop/tradein/TradeInController.java
@@ -1,0 +1,59 @@
+package de.fhdw.webshop.tradein;
+
+import de.fhdw.webshop.tradein.dto.CreateTradeInRequest;
+import de.fhdw.webshop.tradein.dto.TradeInResponse;
+import de.fhdw.webshop.user.User;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class TradeInController {
+
+    private final TradeInService tradeInService;
+
+    /** US #199 — Customer submits a trade-in request for a previously ordered item. */
+    @PostMapping("/api/trade-in")
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public ResponseEntity<TradeInResponse> createTradeIn(
+            @AuthenticationPrincipal User currentUser,
+            @Valid @RequestBody CreateTradeInRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(tradeInService.createTradeIn(currentUser, request));
+    }
+
+    /** US #199 — Customer views their own trade-in requests. */
+    @GetMapping("/api/trade-in/me")
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public ResponseEntity<List<TradeInResponse>> listMyTradeIns(@AuthenticationPrincipal User currentUser) {
+        return ResponseEntity.ok(tradeInService.listForCustomer(currentUser.getId()));
+    }
+
+    /** US #199 — Employee/Admin views all trade-in requests. */
+    @GetMapping("/api/admin/trade-in")
+    @PreAuthorize("hasAnyRole('EMPLOYEE', 'SALES_EMPLOYEE', 'ADMIN')")
+    public ResponseEntity<List<TradeInResponse>> listAllTradeIns() {
+        return ResponseEntity.ok(tradeInService.listAll());
+    }
+
+    /** US #199 — Employee approves a trade-in and releases the coupon/shop credit. */
+    @PutMapping("/api/admin/trade-in/{id}/approve")
+    @PreAuthorize("hasAnyRole('EMPLOYEE', 'SALES_EMPLOYEE', 'ADMIN')")
+    public ResponseEntity<TradeInResponse> approveTradeIn(@PathVariable Long id) {
+        return ResponseEntity.ok(tradeInService.approveTradeIn(id));
+    }
+
+    /** US #199 — Employee rejects a trade-in request. */
+    @PutMapping("/api/admin/trade-in/{id}/reject")
+    @PreAuthorize("hasAnyRole('EMPLOYEE', 'SALES_EMPLOYEE', 'ADMIN')")
+    public ResponseEntity<TradeInResponse> rejectTradeIn(@PathVariable Long id) {
+        return ResponseEntity.ok(tradeInService.rejectTradeIn(id));
+    }
+}

--- a/src/main/java/de/fhdw/webshop/tradein/TradeInRepository.java
+++ b/src/main/java/de/fhdw/webshop/tradein/TradeInRepository.java
@@ -1,0 +1,14 @@
+package de.fhdw.webshop.tradein;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TradeInRepository extends JpaRepository<TradeInRequest, Long> {
+
+    List<TradeInRequest> findByCustomerIdOrderByCreatedAtDesc(Long customerId);
+
+    List<TradeInRequest> findAllByOrderByCreatedAtDesc();
+
+    boolean existsByOrderItemIdAndStatusNot(Long orderItemId, TradeInStatus status);
+}

--- a/src/main/java/de/fhdw/webshop/tradein/TradeInRequest.java
+++ b/src/main/java/de/fhdw/webshop/tradein/TradeInRequest.java
@@ -1,0 +1,63 @@
+package de.fhdw.webshop.tradein;
+
+import de.fhdw.webshop.order.Order;
+import de.fhdw.webshop.order.OrderItem;
+import de.fhdw.webshop.user.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@Entity
+@Table(name = "trade_in_requests")
+@Getter
+@Setter
+@NoArgsConstructor
+public class TradeInRequest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "customer_id", nullable = false)
+    private User customer;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "order_item_id", nullable = false)
+    private OrderItem orderItem;
+
+    @Column(name = "product_name", nullable = false, length = 255)
+    private String productName;
+
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(nullable = false, columnDefinition = "trade_in_condition")
+    private TradeInCondition condition;
+
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(nullable = false, columnDefinition = "trade_in_status")
+    private TradeInStatus status = TradeInStatus.PENDING;
+
+    @Column(name = "estimated_value", nullable = false, precision = 10, scale = 2)
+    private BigDecimal estimatedValue;
+
+    @Column(name = "coupon_code", length = 50)
+    private String couponCode;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt = Instant.now();
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+}

--- a/src/main/java/de/fhdw/webshop/tradein/TradeInService.java
+++ b/src/main/java/de/fhdw/webshop/tradein/TradeInService.java
@@ -1,0 +1,213 @@
+package de.fhdw.webshop.tradein;
+
+import de.fhdw.webshop.discount.Coupon;
+import de.fhdw.webshop.discount.CouponRepository;
+import de.fhdw.webshop.notification.EmailService;
+import de.fhdw.webshop.order.Order;
+import de.fhdw.webshop.order.OrderItem;
+import de.fhdw.webshop.order.OrderItemRepository;
+import de.fhdw.webshop.order.OrderStatus;
+import de.fhdw.webshop.tradein.dto.CreateTradeInRequest;
+import de.fhdw.webshop.tradein.dto.TradeInResponse;
+import de.fhdw.webshop.user.User;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class TradeInService {
+
+    private static final BigDecimal RATE_LIKE_NEW   = new BigDecimal("0.30");
+    private static final BigDecimal RATE_LIGHT_WEAR = new BigDecimal("0.15");
+    private static final BigDecimal RATE_DEFECTIVE  = new BigDecimal("0.05");
+
+    private final TradeInRepository tradeInRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final CouponRepository couponRepository;
+    private final EmailService emailService;
+
+    public BigDecimal estimateValue(BigDecimal purchasePrice, TradeInCondition condition) {
+        BigDecimal rate = switch (condition) {
+            case LIKE_NEW   -> RATE_LIKE_NEW;
+            case LIGHT_WEAR -> RATE_LIGHT_WEAR;
+            case DEFECTIVE  -> RATE_DEFECTIVE;
+        };
+        return purchasePrice.multiply(rate).setScale(2, RoundingMode.HALF_UP);
+    }
+
+    @Transactional
+    public TradeInResponse createTradeIn(User customer, CreateTradeInRequest req) {
+        OrderItem orderItem = findOrderItemForCustomer(req.orderItemId(), customer.getId());
+        Order order = orderItem.getOrder();
+
+        if (order.getStatus() != OrderStatus.DELIVERED) {
+            throw new IllegalStateException("Trade-In ist nur für zugestellte Bestellungen möglich.");
+        }
+
+        boolean alreadyPending = tradeInRepository.existsByOrderItemIdAndStatusNot(
+                req.orderItemId(), TradeInStatus.REJECTED);
+        if (alreadyPending) {
+            throw new IllegalStateException("Für diesen Artikel existiert bereits eine aktive Trade-In-Anfrage.");
+        }
+
+        BigDecimal estimated = estimateValue(orderItem.getPriceAtOrderTime(), req.condition());
+
+        TradeInRequest tradeIn = new TradeInRequest();
+        tradeIn.setCustomer(customer);
+        tradeIn.setOrder(order);
+        tradeIn.setOrderItem(orderItem);
+        tradeIn.setProductName(orderItem.getProduct().getName());
+        tradeIn.setCondition(req.condition());
+        tradeIn.setEstimatedValue(estimated);
+
+        TradeInRequest saved = tradeInRepository.save(tradeIn);
+
+        sendReturnLabelEmail(customer, saved);
+
+        return toResponse(saved);
+    }
+
+    @Transactional
+    public TradeInResponse approveTradeIn(Long tradeInId) {
+        TradeInRequest tradeIn = loadById(tradeInId);
+
+        if (tradeIn.getStatus() != TradeInStatus.PENDING) {
+            throw new IllegalStateException("Nur offene Trade-In-Anfragen können genehmigt werden.");
+        }
+
+        String couponCode = generateCouponCode();
+        BigDecimal discountPercent = tradeIn.getEstimatedValue()
+                .divide(tradeIn.getOrderItem().getPriceAtOrderTime(), 4, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100))
+                .setScale(2, RoundingMode.HALF_UP);
+
+        Coupon coupon = new Coupon();
+        coupon.setCustomer(tradeIn.getCustomer());
+        coupon.setCode(couponCode);
+        coupon.setDiscountPercent(discountPercent);
+        coupon.setValidUntil(LocalDate.now().plusMonths(12));
+        couponRepository.save(coupon);
+
+        tradeIn.setStatus(TradeInStatus.COMPLETED);
+        tradeIn.setCouponCode(couponCode);
+        tradeIn.setUpdatedAt(Instant.now());
+        tradeInRepository.save(tradeIn);
+
+        sendCouponEmail(tradeIn.getCustomer(), tradeIn, couponCode);
+
+        return toResponse(tradeIn);
+    }
+
+    @Transactional
+    public TradeInResponse rejectTradeIn(Long tradeInId) {
+        TradeInRequest tradeIn = loadById(tradeInId);
+
+        if (tradeIn.getStatus() != TradeInStatus.PENDING) {
+            throw new IllegalStateException("Nur offene Trade-In-Anfragen können abgelehnt werden.");
+        }
+
+        tradeIn.setStatus(TradeInStatus.REJECTED);
+        tradeIn.setUpdatedAt(Instant.now());
+        tradeInRepository.save(tradeIn);
+
+        emailService.sendEmailToCustomer(
+                tradeIn.getCustomer(),
+                "Deine Trade-In-Anfrage wurde abgelehnt",
+                "Hallo " + tradeIn.getCustomer().getUsername() + ",\n\n"
+                + "leider konnten wir deine Trade-In-Anfrage für \"" + tradeIn.getProductName()
+                + "\" nicht genehmigen.\n\n"
+                + "Bitte wende dich bei Fragen an unseren Kundendienst.\n\n"
+                + "Viele Grüße\nDein Webshop-Team");
+
+        return toResponse(tradeIn);
+    }
+
+    public List<TradeInResponse> listForCustomer(Long customerId) {
+        return tradeInRepository.findByCustomerIdOrderByCreatedAtDesc(customerId)
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    public List<TradeInResponse> listAll() {
+        return tradeInRepository.findAllByOrderByCreatedAtDesc()
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    private OrderItem findOrderItemForCustomer(Long orderItemId, Long customerId) {
+        return orderItemRepository.findByIdAndOrderCustomerId(orderItemId, customerId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "Order item not found or does not belong to customer: " + orderItemId));
+    }
+
+    private TradeInRequest loadById(Long id) {
+        return tradeInRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Trade-In-Anfrage nicht gefunden: " + id));
+    }
+
+    private String generateCouponCode() {
+        String code;
+        do {
+            code = "TRADEIN-" + UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+        } while (couponRepository.findByCode(code).isPresent());
+        return code;
+    }
+
+    private void sendReturnLabelEmail(User customer, TradeInRequest tradeIn) {
+        emailService.sendEmailToCustomer(
+                customer,
+                "Dein kostenloses Rücksendeetikett – Trade-In #" + tradeIn.getId(),
+                "Hallo " + customer.getUsername() + ",\n\n"
+                + "vielen Dank für deine Trade-In-Anfrage für \"" + tradeIn.getProductName() + "\"!\n\n"
+                + "Geschätzter Gutschriftswert: " + tradeIn.getEstimatedValue() + " €\n\n"
+                + "Bitte drucke das beigefügte kostenlose Rücksendeetikett aus und sende den Artikel "
+                + "innerhalb von 14 Tagen an uns zurück. Nach Eingang und Prüfung "
+                + "erhältst du automatisch deinen Shop-Gutschein.\n\n"
+                + "[RÜCKSENDEETIKETT: TRACKING-NR TRADEIN-" + tradeIn.getId() + "]\n\n"
+                + "Viele Grüße\nDein Webshop-Team");
+    }
+
+    private void sendCouponEmail(User customer, TradeInRequest tradeIn, String couponCode) {
+        emailService.sendEmailToCustomer(
+                customer,
+                "Dein Trade-In-Gutschein ist bereit! – " + couponCode,
+                "Hallo " + customer.getUsername() + ",\n\n"
+                + "dein eingesendeter Artikel \"" + tradeIn.getProductName()
+                + "\" wurde erfolgreich geprüft.\n\n"
+                + "Hier ist dein Gutscheincode: " + couponCode + "\n"
+                + "Gutschriftwert: " + tradeIn.getEstimatedValue() + " €\n"
+                + "Gültig bis: 12 Monate ab heute\n\n"
+                + "Du kannst den Code bei deiner nächsten Bestellung einlösen.\n\n"
+                + "Vielen Dank, dass du beim Recycling mitmachst!\n\n"
+                + "Viele Grüße\nDein Webshop-Team");
+    }
+
+    private TradeInResponse toResponse(TradeInRequest t) {
+        return new TradeInResponse(
+                t.getId(),
+                t.getCustomer().getId(),
+                t.getCustomer().getUsername(),
+                t.getCustomer().getEmail(),
+                t.getOrder().getId(),
+                t.getOrderItem().getId(),
+                t.getProductName(),
+                t.getCondition(),
+                t.getStatus(),
+                t.getEstimatedValue(),
+                t.getCouponCode(),
+                t.getCreatedAt(),
+                t.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/de/fhdw/webshop/tradein/TradeInStatus.java
+++ b/src/main/java/de/fhdw/webshop/tradein/TradeInStatus.java
@@ -1,0 +1,8 @@
+package de.fhdw.webshop.tradein;
+
+public enum TradeInStatus {
+    PENDING,
+    APPROVED,
+    REJECTED,
+    COMPLETED
+}

--- a/src/main/java/de/fhdw/webshop/tradein/dto/CreateTradeInRequest.java
+++ b/src/main/java/de/fhdw/webshop/tradein/dto/CreateTradeInRequest.java
@@ -1,0 +1,9 @@
+package de.fhdw.webshop.tradein.dto;
+
+import de.fhdw.webshop.tradein.TradeInCondition;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateTradeInRequest(
+        @NotNull Long orderItemId,
+        @NotNull TradeInCondition condition
+) {}

--- a/src/main/java/de/fhdw/webshop/tradein/dto/TradeInResponse.java
+++ b/src/main/java/de/fhdw/webshop/tradein/dto/TradeInResponse.java
@@ -1,0 +1,23 @@
+package de.fhdw.webshop.tradein.dto;
+
+import de.fhdw.webshop.tradein.TradeInCondition;
+import de.fhdw.webshop.tradein.TradeInStatus;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+public record TradeInResponse(
+        Long id,
+        Long customerId,
+        String customerName,
+        String customerEmail,
+        Long orderId,
+        Long orderItemId,
+        String productName,
+        TradeInCondition condition,
+        TradeInStatus status,
+        BigDecimal estimatedValue,
+        String couponCode,
+        Instant createdAt,
+        Instant updatedAt
+) {}

--- a/src/main/resources/db/dev-seed.sql
+++ b/src/main/resources/db/dev-seed.sql
@@ -54,18 +54,19 @@ INSERT INTO products (
     description,
     image_url,
     recommended_retail_price,
+    co2_emission_kg,
     category,
     stock,
     warehouse_position,
     purchasable,
     promoted
 ) VALUES
-  ('Laptop Pro 15', 'High-performance laptop with 15" display', 'https://placehold.co/400x300?text=Laptop', 1299.99, 'Electronics', 8, 'A-01-01', TRUE, TRUE),
-  ('Wireless Mouse', 'Ergonomic wireless mouse, 2.4 GHz', 'https://placehold.co/400x300?text=Mouse', 29.99, 'Electronics', 120, 'A-03-07', TRUE, FALSE),
-  ('Standing Desk', 'Height-adjustable standing desk 140x70 cm', 'https://placehold.co/400x300?text=Desk', 499.99, 'Furniture', 12, 'B-01-03', TRUE, FALSE),
-  ('USB-C Hub', '7-in-1 USB-C hub with HDMI and SD card', 'https://placehold.co/400x300?text=Hub', 49.99, 'Electronics', 40, 'A-04-02', TRUE, FALSE),
-  ('Office Chair', 'Lumbar support mesh chair', 'https://placehold.co/400x300?text=Chair', 349.99, 'Furniture', 18, 'B-02-05', TRUE, TRUE),
-  ('Notebook (Draft)', 'Not yet available to customers', NULL, 9.99, 'Stationery', 0, 'C-01-01', FALSE, FALSE);
+  ('Laptop Pro 15', 'High-performance laptop with 15" display', 'https://placehold.co/400x300?text=Laptop', 1299.99, 214.500, 'Electronics', 8, 'A-01-01', TRUE, TRUE),
+  ('Wireless Mouse', 'Ergonomic wireless mouse, 2.4 GHz', 'https://placehold.co/400x300?text=Mouse', 29.99, 2.100, 'Electronics', 120, 'A-03-07', TRUE, FALSE),
+  ('Standing Desk', 'Height-adjustable standing desk 140x70 cm', 'https://placehold.co/400x300?text=Desk', 499.99, 58.750, 'Furniture', 12, 'B-01-03', TRUE, FALSE),
+  ('USB-C Hub', '7-in-1 USB-C hub with HDMI and SD card', 'https://placehold.co/400x300?text=Hub', 49.99, 5.400, 'Electronics', 40, 'A-04-02', TRUE, FALSE),
+  ('Office Chair', 'Lumbar support mesh chair', 'https://placehold.co/400x300?text=Chair', 349.99, 33.200, 'Furniture', 18, 'B-02-05', TRUE, TRUE),
+  ('Notebook (Draft)', 'Not yet available to customers', NULL, 9.99, 0.350, 'Stationery', 0, 'C-01-01', FALSE, FALSE);
 
 -- Discounts
 INSERT INTO discounts (customer_id, product_id, discount_percent, valid_from, valid_until)

--- a/src/main/resources/db/migration/V30__add_product_co2_emissions.sql
+++ b/src/main/resources/db/migration/V30__add_product_co2_emissions.sql
@@ -1,0 +1,13 @@
+ALTER TABLE products
+    ADD COLUMN IF NOT EXISTS co2_emission_kg NUMERIC(10, 3);
+
+UPDATE products
+SET co2_emission_kg = CASE
+    WHEN LOWER(name) LIKE '%laptop%' THEN 214.500
+    WHEN LOWER(name) LIKE '%mouse%' THEN 2.100
+    WHEN LOWER(name) LIKE '%desk%' THEN 58.750
+    WHEN LOWER(name) LIKE '%hub%' THEN 5.400
+    WHEN LOWER(name) LIKE '%chair%' THEN 33.200
+    ELSE co2_emission_kg
+END
+WHERE co2_emission_kg IS NULL;

--- a/src/main/resources/db/migration/V31__backfill_product_co2_emission_values.sql
+++ b/src/main/resources/db/migration/V31__backfill_product_co2_emission_values.sql
@@ -1,0 +1,18 @@
+UPDATE products
+SET co2_emission_kg = CASE
+    WHEN LOWER(name) LIKE '%laptop%' THEN 214.500
+    WHEN LOWER(name) LIKE '%mouse%' THEN 2.100
+    WHEN LOWER(name) LIKE '%desk%' THEN 58.750
+    WHEN LOWER(name) LIKE '%hub%' THEN 5.400
+    WHEN LOWER(name) LIKE '%chair%' THEN 33.200
+    WHEN LOWER(name) LIKE '%notebook%' THEN 0.350
+    WHEN LOWER(category) IN ('electronics', 'elektronik', 'audio', 'gaming') THEN 18.750
+    WHEN LOWER(category) IN ('furniture', 'buero', 'büro') THEN 42.500
+    WHEN LOWER(category) IN ('stationery', 'haushalt') THEN 1.250
+    WHEN recommended_retail_price >= 1000 THEN 180.000
+    WHEN recommended_retail_price >= 250 THEN 36.000
+    WHEN recommended_retail_price >= 50 THEN 7.500
+    WHEN recommended_retail_price >= 10 THEN 2.000
+    ELSE 0.750
+END
+WHERE co2_emission_kg IS NULL;

--- a/src/main/resources/db/migration/V32__add_order_climate_compensation.sql
+++ b/src/main/resources/db/migration/V32__add_order_climate_compensation.sql
@@ -1,0 +1,4 @@
+ALTER TABLE orders
+    ADD COLUMN climate_contribution_amount NUMERIC(10, 2) NOT NULL DEFAULT 0,
+    ADD COLUMN carbon_compensation_selected BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN total_co2_emission_kg NUMERIC(10, 3) NOT NULL DEFAULT 0;

--- a/src/main/resources/db/migration/V33__add_product_eco_score.sql
+++ b/src/main/resources/db/migration/V33__add_product_eco_score.sql
@@ -1,0 +1,26 @@
+ALTER TABLE products
+    ADD COLUMN IF NOT EXISTS eco_score VARCHAR(20) NOT NULL DEFAULT 'NONE';
+
+UPDATE products
+SET eco_score = CASE
+    WHEN co2_emission_kg < 1 THEN 'A'
+    WHEN co2_emission_kg < 5 THEN 'B'
+    WHEN co2_emission_kg < 20 THEN 'C'
+    WHEN co2_emission_kg < 80 THEN 'D'
+    ELSE 'E'
+END
+WHERE eco_score = 'NONE'
+  AND co2_emission_kg IS NOT NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'products_eco_score_check'
+    ) THEN
+        ALTER TABLE products
+            ADD CONSTRAINT products_eco_score_check
+            CHECK (eco_score IN ('A', 'B', 'C', 'D', 'E', 'NONE'));
+    END IF;
+END $$;

--- a/src/main/resources/db/migration/V34__create_trade_in_requests.sql
+++ b/src/main/resources/db/migration/V34__create_trade_in_requests.sql
@@ -1,0 +1,27 @@
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'trade_in_condition') THEN
+        CREATE TYPE trade_in_condition AS ENUM ('LIKE_NEW', 'LIGHT_WEAR', 'DEFECTIVE');
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'trade_in_status') THEN
+        CREATE TYPE trade_in_status AS ENUM ('PENDING', 'APPROVED', 'REJECTED', 'COMPLETED');
+    END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS trade_in_requests (
+    id                 BIGSERIAL PRIMARY KEY,
+    customer_id        BIGINT NOT NULL REFERENCES users(id),
+    order_id           BIGINT NOT NULL REFERENCES orders(id),
+    order_item_id      BIGINT NOT NULL REFERENCES order_items(id),
+    product_name       VARCHAR(255) NOT NULL,
+    condition          trade_in_condition NOT NULL,
+    status             trade_in_status NOT NULL DEFAULT 'PENDING',
+    estimated_value    DECIMAL(10, 2) NOT NULL,
+    coupon_code        VARCHAR(50),
+    created_at         TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at         TIMESTAMP
+);


### PR DESCRIPTION
## Summary

- Flyway-Migration V34: Tabelle `trade_in_requests` mit PostgreSQL-Enums (`trade_in_condition`, `trade_in_status`)
- Vollständiges Trade-In-System: Entity, Repository, Service, Controller
- Wertschätzungslogik: LIKE_NEW 30 %, LIGHT_WEAR 15 %, DEFECTIVE 5 % des Kaufpreises
- Genehmigung erzeugt automatisch einen `TRADEIN-XXXXXXXX`-Gutscheincode und sendet E-Mail
- Ablehnung sendet Ablehnungs-E-Mail an Kunden
- Neues `OrderItemRepository` für kundensicheren Artikel-Lookup

**REST-Endpoints:**
- `POST /api/trade-in` – Kunde erstellt Anfrage (CUSTOMER)
- `GET /api/trade-in/me` – Kundenübersicht eigener Trade-Ins
- `GET /api/admin/trade-in` – Mitarbeiter-Übersicht
- `PUT /api/admin/trade-in/{id}/approve` – Genehmigen + Coupon ausstellen
- `PUT /api/admin/trade-in/{id}/reject` – Ablehnen

**Weitere Fixes:**
- `AdminNavigationService`: Fehlende Nav-Einträge ergänzt (`statistics-dashboard`, `statistics-alerts`, `business-log`, `orders-management`)
- `GlobalExceptionHandler`: `IllegalStateException` → HTTP 409 Conflict
- `AddressLookupService`: Länder-Normalisierung (DE/Deutschland/DEU → germany) für korrekte Adressvalidierung

## Test plan

- [ ] Trade-In für zugestellte Bestellung einreichen → Rücksendeetikett-E-Mail empfangen
- [ ] Doppelter Trade-In für gleichen Artikel → 409 Conflict
- [ ] Trade-In für nicht-zugestellte Bestellung → 409 Conflict
- [ ] Admin genehmigt → Coupon in DB, Gutschein-E-Mail an Kunden
- [ ] Admin lehnt ab → Status REJECTED, Ablehnungs-E-Mail
- [ ] Admin-Navigation zeigt alle Gruppen nach F5 ohne Flackern
- [ ] Adressvalidierung: DE/Deutschland/DEU werden korrekt gematcht

🤖 Generated with [Claude Code](https://claude.com/claude-code)