### PR TITLE
US-210: RMA-Dashboard fuer Lager implementieren

### DIFF
--- a/src/main/java/de/fhdw/webshop/admin/navigation/AdminNavigationService.java
+++ b/src/main/java/de/fhdw/webshop/admin/navigation/AdminNavigationService.java
@@ -31,7 +31,7 @@ public class AdminNavigationService {
     private static final Set<UserRole> TRADE_IN_ROLES =
             Set.of(UserRole.EMPLOYEE, UserRole.SALES_EMPLOYEE, UserRole.ADMIN);
     private static final Set<UserRole> RETURN_REQUEST_ROLES =
-            Set.of(UserRole.EMPLOYEE, UserRole.SALES_EMPLOYEE, UserRole.ADMIN);
+            Set.of(UserRole.WAREHOUSE_EMPLOYEE, UserRole.ADMIN);
 
     private static final List<NavigationGroup> NAVIGATION = List.of(
             new NavigationGroup(
@@ -68,8 +68,8 @@ public class AdminNavigationService {
                     "Bestellungen",
                     "pi pi-shopping-bag",
                     List.of(
-                            item("trade-in", "Trade-In Anfragen", "/admin/orders/trade-in", "pi pi-refresh", TRADE_IN_ROLES),
-                            item("return-requests", "Retouren & Defekte", "/admin/orders/returns", "pi pi-camera", RETURN_REQUEST_ROLES)
+                            item("return-requests", "Offene Retouren", "/admin/orders/returns", "pi pi-barcode", RETURN_REQUEST_ROLES),
+                            item("trade-in", "Trade-In Anfragen", "/admin/orders/trade-in", "pi pi-refresh", TRADE_IN_ROLES)
                     )
             ),
             new NavigationGroup(

--- a/src/main/java/de/fhdw/webshop/returnrequest/ReturnInspectionCondition.java
+++ b/src/main/java/de/fhdw/webshop/returnrequest/ReturnInspectionCondition.java
@@ -1,0 +1,6 @@
+package de.fhdw.webshop.returnrequest;
+
+public enum ReturnInspectionCondition {
+    GOOD,
+    DEFECTIVE
+}

--- a/src/main/java/de/fhdw/webshop/returnrequest/ReturnRefundMethod.java
+++ b/src/main/java/de/fhdw/webshop/returnrequest/ReturnRefundMethod.java
@@ -1,0 +1,6 @@
+package de.fhdw.webshop.returnrequest;
+
+public enum ReturnRefundMethod {
+    ORIGINAL_PAYMENT_METHOD,
+    SHOP_CREDIT
+}

--- a/src/main/java/de/fhdw/webshop/returnrequest/ReturnRefundStatus.java
+++ b/src/main/java/de/fhdw/webshop/returnrequest/ReturnRefundStatus.java
@@ -1,0 +1,7 @@
+package de.fhdw.webshop.returnrequest;
+
+public enum ReturnRefundStatus {
+    NOT_STARTED,
+    INITIATED,
+    REJECTED
+}

--- a/src/main/java/de/fhdw/webshop/returnrequest/ReturnRequest.java
+++ b/src/main/java/de/fhdw/webshop/returnrequest/ReturnRequest.java
@@ -15,6 +15,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -55,6 +56,27 @@ public class ReturnRequest {
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt = Instant.now();
+
+    @Column(name = "inspected_at")
+    private Instant inspectedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "inspection_condition", length = 30)
+    private ReturnInspectionCondition inspectionCondition;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "refund_status", nullable = false, length = 30)
+    private ReturnRefundStatus refundStatus = ReturnRefundStatus.NOT_STARTED;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "refund_method", length = 30)
+    private ReturnRefundMethod refundMethod;
+
+    @Column(name = "refund_amount", nullable = false, precision = 10, scale = 2)
+    private BigDecimal refundAmount = BigDecimal.ZERO;
+
+    @Column(name = "refund_reference", length = 80)
+    private String refundReference;
 
     @Column(name = "defect_description", length = 500)
     private String defectDescription;

--- a/src/main/java/de/fhdw/webshop/returnrequest/ReturnRequestController.java
+++ b/src/main/java/de/fhdw/webshop/returnrequest/ReturnRequestController.java
@@ -1,6 +1,7 @@
 package de.fhdw.webshop.returnrequest;
 
 import de.fhdw.webshop.returnrequest.dto.CreateReturnRequest;
+import de.fhdw.webshop.returnrequest.dto.InspectReturnRequest;
 import de.fhdw.webshop.returnrequest.dto.ReturnRequestImageDownload;
 import de.fhdw.webshop.returnrequest.dto.ReturnRequestResponse;
 import de.fhdw.webshop.user.User;
@@ -16,7 +17,9 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -41,9 +44,29 @@ public class ReturnRequestController {
     }
 
     @GetMapping("/api/admin/returns")
-    @PreAuthorize("hasAnyRole('EMPLOYEE', 'SALES_EMPLOYEE', 'ADMIN')")
+    @PreAuthorize("hasAnyRole('EMPLOYEE', 'SALES_EMPLOYEE', 'WAREHOUSE_EMPLOYEE', 'ADMIN')")
     public ResponseEntity<List<ReturnRequestResponse>> listReturnRequestsForSupport() {
         return ResponseEntity.ok(returnRequestService.listAllForSupport());
+    }
+
+    @GetMapping("/api/admin/returns/open")
+    @PreAuthorize("hasAnyRole('WAREHOUSE_EMPLOYEE', 'ADMIN')")
+    public ResponseEntity<List<ReturnRequestResponse>> listOpenReturnRequestsForWarehouse() {
+        return ResponseEntity.ok(returnRequestService.listOpenForWarehouse());
+    }
+
+    @GetMapping("/api/admin/returns/lookup")
+    @PreAuthorize("hasAnyRole('WAREHOUSE_EMPLOYEE', 'ADMIN')")
+    public ResponseEntity<ReturnRequestResponse> lookupReturnRequestForWarehouse(@RequestParam String code) {
+        return ResponseEntity.ok(returnRequestService.lookupForWarehouse(code));
+    }
+
+    @PutMapping("/api/admin/returns/{returnRequestId}/inspection")
+    @PreAuthorize("hasAnyRole('WAREHOUSE_EMPLOYEE', 'ADMIN')")
+    public ResponseEntity<ReturnRequestResponse> inspectReturnRequest(
+            @PathVariable Long returnRequestId,
+            @Valid @RequestBody InspectReturnRequest request) {
+        return ResponseEntity.ok(returnRequestService.inspectReturnRequest(returnRequestId, request));
     }
 
     @GetMapping(value = "/api/returns/{returnRequestId}/label.pdf", produces = MediaType.APPLICATION_PDF_VALUE)
@@ -72,7 +95,7 @@ public class ReturnRequestController {
     }
 
     @GetMapping("/api/admin/returns/{returnRequestId}/images/{imageId}")
-    @PreAuthorize("hasAnyRole('EMPLOYEE', 'SALES_EMPLOYEE', 'ADMIN')")
+    @PreAuthorize("hasAnyRole('EMPLOYEE', 'SALES_EMPLOYEE', 'WAREHOUSE_EMPLOYEE', 'ADMIN')")
     public ResponseEntity<byte[]> downloadDefectImageForSupport(
             @PathVariable Long returnRequestId,
             @PathVariable Long imageId) {

--- a/src/main/java/de/fhdw/webshop/returnrequest/ReturnRequestRepository.java
+++ b/src/main/java/de/fhdw/webshop/returnrequest/ReturnRequestRepository.java
@@ -10,5 +10,9 @@ public interface ReturnRequestRepository extends JpaRepository<ReturnRequest, Lo
 
     List<ReturnRequest> findAllByOrderByCreatedAtDesc();
 
+    List<ReturnRequest> findByStatusOrderByCreatedAtDesc(ReturnRequestStatus status);
+
     Optional<ReturnRequest> findByIdAndCustomerId(Long id, Long customerId);
+
+    Optional<ReturnRequest> findByTrackingIdIgnoreCase(String trackingId);
 }

--- a/src/main/java/de/fhdw/webshop/returnrequest/ReturnRequestService.java
+++ b/src/main/java/de/fhdw/webshop/returnrequest/ReturnRequestService.java
@@ -5,6 +5,7 @@ import de.fhdw.webshop.order.OrderItem;
 import de.fhdw.webshop.order.OrderRepository;
 import de.fhdw.webshop.order.OrderStatus;
 import de.fhdw.webshop.returnrequest.dto.CreateReturnRequest;
+import de.fhdw.webshop.returnrequest.dto.InspectReturnRequest;
 import de.fhdw.webshop.returnrequest.dto.ReturnRequestImageDownload;
 import de.fhdw.webshop.returnrequest.dto.ReturnRequestImageResponse;
 import de.fhdw.webshop.returnrequest.dto.ReturnRequestImageUpload;
@@ -14,6 +15,7 @@ import de.fhdw.webshop.returnrequest.dto.ReturnRequestResponse;
 import de.fhdw.webshop.returnrequest.dto.ReturnShippingLabelResponse;
 import de.fhdw.webshop.user.User;
 import jakarta.persistence.EntityNotFoundException;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -30,6 +32,8 @@ import java.util.Map;
 import java.util.Locale;
 import java.util.UUID;
 import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -48,6 +52,7 @@ public class ReturnRequestService {
     private static final String RETURN_CENTER_COUNTRY = "Deutschland";
     private static final int MAX_DEFECT_IMAGE_COUNT = 3;
     private static final long MAX_DEFECT_IMAGE_SIZE_BYTES = 5L * 1024 * 1024;
+    private static final Pattern RMA_CODE_PATTERN = Pattern.compile("^(?:RMA[-\\s#]*)?(\\d+)$", Pattern.CASE_INSENSITIVE);
     private static final DateTimeFormatter LABEL_DATE_FORMATTER = DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm")
             .withZone(ZoneId.of("Europe/Berlin"));
 
@@ -120,6 +125,41 @@ public class ReturnRequestService {
     }
 
     @Transactional(readOnly = true)
+    public List<ReturnRequestResponse> listOpenForWarehouse() {
+        return returnRequestRepository.findByStatusOrderByCreatedAtDesc(ReturnRequestStatus.SUBMITTED).stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public ReturnRequestResponse lookupForWarehouse(String code) {
+        return toResponse(findByScanCode(code));
+    }
+
+    @Transactional
+    public ReturnRequestResponse inspectReturnRequest(Long returnRequestId, InspectReturnRequest request) {
+        ReturnRequest returnRequest = returnRequestRepository.findById(returnRequestId)
+                .orElseThrow(() -> new EntityNotFoundException("Return request not found: " + returnRequestId));
+
+        if (returnRequest.getStatus() != ReturnRequestStatus.SUBMITTED) {
+            throw new IllegalStateException("Nur offene Retouren koennen bewertet werden.");
+        }
+
+        returnRequest.setInspectionCondition(request.condition());
+        returnRequest.setInspectedAt(Instant.now());
+        returnRequest.setStatus(ReturnRequestStatus.COMPLETED);
+
+        if (request.condition() == ReturnInspectionCondition.GOOD) {
+            restockReturnedItems(returnRequest);
+            initiateRefund(returnRequest);
+        } else {
+            rejectRefund(returnRequest);
+        }
+
+        return toResponse(returnRequestRepository.save(returnRequest));
+    }
+
+    @Transactional(readOnly = true)
     public byte[] buildLabelPdf(Long customerId, Long returnRequestId) {
         ReturnRequest returnRequest = returnRequestRepository.findByIdAndCustomerId(returnRequestId, customerId)
                 .orElseThrow(() -> new EntityNotFoundException("Return request not found: " + returnRequestId));
@@ -166,6 +206,58 @@ public class ReturnRequestService {
         ReturnRequestImage image = returnRequestImageRepository.findByIdAndReturnRequestId(imageId, returnRequestId)
                 .orElseThrow(() -> new EntityNotFoundException("Return request image not found: " + imageId));
         return toDownload(image);
+    }
+
+    private ReturnRequest findByScanCode(String rawCode) {
+        String code = rawCode == null ? "" : rawCode.trim();
+        if (code.isBlank()) {
+            throw new IllegalArgumentException("Bitte Tracking-ID oder RMA-Nummer eingeben.");
+        }
+
+        return returnRequestRepository.findByTrackingIdIgnoreCase(code)
+                .or(() -> parseRmaId(code).flatMap(returnRequestRepository::findById))
+                .orElseThrow(() -> new EntityNotFoundException("Keine Retoure fuer den Scan-Code gefunden: " + code));
+    }
+
+    private java.util.Optional<Long> parseRmaId(String code) {
+        Matcher matcher = RMA_CODE_PATTERN.matcher(code);
+        if (!matcher.matches()) {
+            return java.util.Optional.empty();
+        }
+        try {
+            return java.util.Optional.of(Long.parseLong(matcher.group(1)));
+        } catch (NumberFormatException ex) {
+            return java.util.Optional.empty();
+        }
+    }
+
+    private void restockReturnedItems(ReturnRequest returnRequest) {
+        returnRequest.getItems().forEach(item -> {
+            var product = item.getOrderItem().getProduct();
+            product.setStock(product.getStock() + item.getQuantity());
+        });
+    }
+
+    private void initiateRefund(ReturnRequest returnRequest) {
+        returnRequest.setRefundStatus(ReturnRefundStatus.INITIATED);
+        returnRequest.setRefundMethod(returnRequest.getOrder().getPaymentMethodType() == null
+                ? ReturnRefundMethod.SHOP_CREDIT
+                : ReturnRefundMethod.ORIGINAL_PAYMENT_METHOD);
+        returnRequest.setRefundAmount(calculateRefundAmount(returnRequest));
+        returnRequest.setRefundReference("RMA-" + returnRequest.getId() + "-REFUND");
+    }
+
+    private void rejectRefund(ReturnRequest returnRequest) {
+        returnRequest.setRefundStatus(ReturnRefundStatus.REJECTED);
+        returnRequest.setRefundMethod(null);
+        returnRequest.setRefundAmount(BigDecimal.ZERO);
+        returnRequest.setRefundReference("RMA-" + returnRequest.getId() + "-REJECTED");
+    }
+
+    private BigDecimal calculateRefundAmount(ReturnRequest returnRequest) {
+        return returnRequest.getItems().stream()
+                .map(item -> item.getOrderItem().getPriceAtOrderTime().multiply(BigDecimal.valueOf(item.getQuantity())))
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 
     private void attachDefectDetails(ReturnRequest returnRequest, CreateReturnRequest request) {
@@ -298,6 +390,12 @@ public class ReturnRequestService {
                 returnRequest.getReason(),
                 returnRequest.getStatus(),
                 returnRequest.getCreatedAt(),
+                returnRequest.getInspectedAt(),
+                returnRequest.getInspectionCondition(),
+                returnRequest.getRefundStatus(),
+                returnRequest.getRefundMethod(),
+                returnRequest.getRefundAmount(),
+                returnRequest.getRefundReference(),
                 returnRequest.getDefectDescription(),
                 returnRequest.getDefectImages().stream()
                         .map(image -> toImageResponse(returnRequest, image))

--- a/src/main/java/de/fhdw/webshop/returnrequest/ReturnRequestStatus.java
+++ b/src/main/java/de/fhdw/webshop/returnrequest/ReturnRequestStatus.java
@@ -1,5 +1,6 @@
 package de.fhdw.webshop.returnrequest;
 
 public enum ReturnRequestStatus {
-    SUBMITTED
+    SUBMITTED,
+    COMPLETED
 }

--- a/src/main/java/de/fhdw/webshop/returnrequest/dto/InspectReturnRequest.java
+++ b/src/main/java/de/fhdw/webshop/returnrequest/dto/InspectReturnRequest.java
@@ -1,0 +1,8 @@
+package de.fhdw.webshop.returnrequest.dto;
+
+import de.fhdw.webshop.returnrequest.ReturnInspectionCondition;
+import jakarta.validation.constraints.NotNull;
+
+public record InspectReturnRequest(
+        @NotNull ReturnInspectionCondition condition
+) {}

--- a/src/main/java/de/fhdw/webshop/returnrequest/dto/ReturnRequestResponse.java
+++ b/src/main/java/de/fhdw/webshop/returnrequest/dto/ReturnRequestResponse.java
@@ -1,7 +1,11 @@
 package de.fhdw.webshop.returnrequest.dto;
 
+import de.fhdw.webshop.returnrequest.ReturnInspectionCondition;
 import de.fhdw.webshop.returnrequest.ReturnReason;
+import de.fhdw.webshop.returnrequest.ReturnRefundMethod;
+import de.fhdw.webshop.returnrequest.ReturnRefundStatus;
 import de.fhdw.webshop.returnrequest.ReturnRequestStatus;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 
@@ -15,6 +19,12 @@ public record ReturnRequestResponse(
         ReturnReason reason,
         ReturnRequestStatus status,
         Instant createdAt,
+        Instant inspectedAt,
+        ReturnInspectionCondition inspectionCondition,
+        ReturnRefundStatus refundStatus,
+        ReturnRefundMethod refundMethod,
+        BigDecimal refundAmount,
+        String refundReference,
         String defectDescription,
         List<ReturnRequestImageResponse> defectImages,
         List<ReturnRequestItemResponse> items,

--- a/src/main/resources/db/migration/V42__add_return_warehouse_inspection.sql
+++ b/src/main/resources/db/migration/V42__add_return_warehouse_inspection.sql
@@ -1,0 +1,15 @@
+ALTER TYPE return_request_status ADD VALUE IF NOT EXISTS 'COMPLETED';
+
+ALTER TABLE return_requests
+    ADD COLUMN IF NOT EXISTS inspected_at TIMESTAMP,
+    ADD COLUMN IF NOT EXISTS inspection_condition VARCHAR(30),
+    ADD COLUMN IF NOT EXISTS refund_status VARCHAR(30) NOT NULL DEFAULT 'NOT_STARTED',
+    ADD COLUMN IF NOT EXISTS refund_method VARCHAR(30),
+    ADD COLUMN IF NOT EXISTS refund_amount NUMERIC(10, 2) NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS refund_reference VARCHAR(80);
+
+CREATE INDEX IF NOT EXISTS idx_return_requests_status_created
+    ON return_requests (status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_return_requests_tracking_lookup
+    ON return_requests (LOWER(tracking_id));

--- a/src/test/java/de/fhdw/webshop/admin/navigation/AdminNavigationServiceTest.java
+++ b/src/test/java/de/fhdw/webshop/admin/navigation/AdminNavigationServiceTest.java
@@ -35,7 +35,7 @@ class AdminNavigationServiceTest {
     }
 
     @Test
-    void onlyShowsWarehouseEntryForWarehouseEmployees() {
+    void showsWarehouseAndOpenReturnsForWarehouseEmployees() {
         UserRepository userRepository = mock(UserRepository.class);
         AdminNavigationService service = new AdminNavigationService(userRepository);
         User warehouseUser = user(2L, UserRole.WAREHOUSE_EMPLOYEE);
@@ -45,10 +45,10 @@ class AdminNavigationServiceTest {
         List<AdminNavigationGroupResponse> navigation = service.getNavigationFor(warehouseUser);
 
         assertThat(navigation).extracting(AdminNavigationGroupResponse::label)
-                .containsExactly("Produktverwaltung");
-        assertThat(navigation.getFirst().items())
+                .containsExactly("Produktverwaltung", "Bestellungen");
+        assertThat(navigation.stream().flatMap(group -> group.items().stream()))
                 .extracting(AdminNavigationItemResponse::id)
-                .containsExactly("warehouse");
+                .containsExactly("warehouse", "return-requests");
     }
 
     @Test
@@ -74,7 +74,8 @@ class AdminNavigationServiceTest {
                 "customer-revenue",
                 "monitoring",
                 "alerting",
-                "warehouse");
+                "warehouse",
+                "return-requests");
     }
 
     private static User user(Long id, UserRole role) {

--- a/src/test/java/de/fhdw/webshop/returnrequest/ReturnRequestServiceTest.java
+++ b/src/test/java/de/fhdw/webshop/returnrequest/ReturnRequestServiceTest.java
@@ -6,8 +6,10 @@ import de.fhdw.webshop.order.OrderRepository;
 import de.fhdw.webshop.order.OrderStatus;
 import de.fhdw.webshop.product.Product;
 import de.fhdw.webshop.returnrequest.dto.CreateReturnRequest;
+import de.fhdw.webshop.returnrequest.dto.InspectReturnRequest;
 import de.fhdw.webshop.returnrequest.dto.ReturnRequestResponse;
 import de.fhdw.webshop.user.User;
+import de.fhdw.webshop.user.PaymentMethodType;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
@@ -167,6 +169,72 @@ class ReturnRequestServiceTest {
         verify(returnRequestRepository, never()).save(any(ReturnRequest.class));
     }
 
+    @Test
+    void inspectingGoodReturnCompletesItRestocksInventoryAndInitiatesRefund() {
+        ReturnRequestRepository returnRequestRepository = mock(ReturnRequestRepository.class);
+        ReturnRequestItemRepository returnRequestItemRepository = mock(ReturnRequestItemRepository.class);
+        ReturnRequestImageRepository returnRequestImageRepository = mock(ReturnRequestImageRepository.class);
+        OrderRepository orderRepository = mock(OrderRepository.class);
+        ReturnRequestService service = new ReturnRequestService(
+                returnRequestRepository,
+                returnRequestItemRepository,
+                returnRequestImageRepository,
+                orderRepository);
+        User customer = customer();
+        Order order = deliveredOrder(customer, Instant.now().minusSeconds(2 * 24 * 60 * 60));
+        order.setPaymentMethodType(PaymentMethodType.CREDIT_CARD);
+        OrderItem item = orderItem(101L, order, "Laptop Pro");
+        item.setQuantity(2);
+        item.getProduct().setStock(3);
+        ReturnRequest returnRequest = submittedReturnRequest(701L, customer, order, item);
+
+        when(returnRequestRepository.findById(returnRequest.getId())).thenReturn(Optional.of(returnRequest));
+        when(returnRequestRepository.save(any(ReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ReturnRequestResponse response = service.inspectReturnRequest(
+                returnRequest.getId(),
+                new InspectReturnRequest(ReturnInspectionCondition.GOOD));
+
+        assertThat(response.status()).isEqualTo(ReturnRequestStatus.COMPLETED);
+        assertThat(response.inspectionCondition()).isEqualTo(ReturnInspectionCondition.GOOD);
+        assertThat(response.refundStatus()).isEqualTo(ReturnRefundStatus.INITIATED);
+        assertThat(response.refundMethod()).isEqualTo(ReturnRefundMethod.ORIGINAL_PAYMENT_METHOD);
+        assertThat(response.refundAmount()).isEqualByComparingTo("199.98");
+        assertThat(response.refundReference()).isEqualTo("RMA-701-REFUND");
+        assertThat(item.getProduct().getStock()).isEqualTo(5);
+    }
+
+    @Test
+    void inspectingDefectiveReturnCompletesItAndRejectsRefundWithoutRestocking() {
+        ReturnRequestRepository returnRequestRepository = mock(ReturnRequestRepository.class);
+        ReturnRequestItemRepository returnRequestItemRepository = mock(ReturnRequestItemRepository.class);
+        ReturnRequestImageRepository returnRequestImageRepository = mock(ReturnRequestImageRepository.class);
+        OrderRepository orderRepository = mock(OrderRepository.class);
+        ReturnRequestService service = new ReturnRequestService(
+                returnRequestRepository,
+                returnRequestItemRepository,
+                returnRequestImageRepository,
+                orderRepository);
+        User customer = customer();
+        Order order = deliveredOrder(customer, Instant.now().minusSeconds(2 * 24 * 60 * 60));
+        OrderItem item = orderItem(101L, order, "Laptop Pro");
+        item.getProduct().setStock(3);
+        ReturnRequest returnRequest = submittedReturnRequest(702L, customer, order, item);
+
+        when(returnRequestRepository.findById(returnRequest.getId())).thenReturn(Optional.of(returnRequest));
+        when(returnRequestRepository.save(any(ReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ReturnRequestResponse response = service.inspectReturnRequest(
+                returnRequest.getId(),
+                new InspectReturnRequest(ReturnInspectionCondition.DEFECTIVE));
+
+        assertThat(response.status()).isEqualTo(ReturnRequestStatus.COMPLETED);
+        assertThat(response.inspectionCondition()).isEqualTo(ReturnInspectionCondition.DEFECTIVE);
+        assertThat(response.refundStatus()).isEqualTo(ReturnRefundStatus.REJECTED);
+        assertThat(response.refundAmount()).isEqualByComparingTo("0.00");
+        assertThat(item.getProduct().getStock()).isEqualTo(3);
+    }
+
     private static User customer() {
         User customer = new User();
         customer.setId(7L);
@@ -198,5 +266,37 @@ class ReturnRequestServiceTest {
         item.setQuantity(1);
         item.setPriceAtOrderTime(new BigDecimal("99.99"));
         return item;
+    }
+
+    private static ReturnRequest submittedReturnRequest(Long id, User customer, Order order, OrderItem orderItem) {
+        ReturnRequest returnRequest = new ReturnRequest();
+        returnRequest.setId(id);
+        returnRequest.setCustomer(customer);
+        returnRequest.setOrder(order);
+        returnRequest.setReason(ReturnReason.DOES_NOT_FIT);
+        returnRequest.setStatus(ReturnRequestStatus.SUBMITTED);
+        returnRequest.setTrackingId("WSR-TEST-" + id);
+        returnRequest.setCarrierName("Webshop Retouren");
+        returnRequest.setQrCodePayload("webshop-return:WSR-TEST-" + id);
+        returnRequest.setLabelCreatedAt(Instant.now());
+        returnRequest.setSenderName("alice");
+        returnRequest.setSenderStreet("Main Street 1");
+        returnRequest.setSenderPostalCode("33602");
+        returnRequest.setSenderCity("Bielefeld");
+        returnRequest.setSenderCountry("Deutschland");
+        returnRequest.setReturnCenterName("Webshop Ruecksendezentrum");
+        returnRequest.setReturnCenterStreet("Retourenstrasse 12");
+        returnRequest.setReturnCenterPostalCode("33602");
+        returnRequest.setReturnCenterCity("Bielefeld");
+        returnRequest.setReturnCenterCountry("Deutschland");
+
+        ReturnRequestItem item = new ReturnRequestItem();
+        item.setId(900L + orderItem.getId());
+        item.setReturnRequest(returnRequest);
+        item.setOrderItem(orderItem);
+        item.setProductName(orderItem.getProduct().getName());
+        item.setQuantity(orderItem.getQuantity());
+        returnRequest.getItems().add(item);
+        return returnRequest;
     }
 }


### PR DESCRIPTION
## Summary
- Add warehouse return lookup and inspection endpoints
- Persist inspection, refund and completion state via Flyway migration
- Restock inventory and initiate or reject refunds based on inspection result

Related frontend issue: SEPBFWS124A/Webshop#210

## Tests
- .\\mvnw.cmd test