### PR TITLE
US-221: Freigabe anfordern im Checkout

### DIFF
--- a/src/main/java/de/fhdw/webshop/order/Order.java
+++ b/src/main/java/de/fhdw/webshop/order/Order.java
@@ -90,6 +90,12 @@ public class Order {
     @Column(name = "discount_amount", nullable = false, precision = 10, scale = 2)
     private BigDecimal discountAmount = BigDecimal.ZERO;
 
+    @Column(name = "approval_reason", length = 1000)
+    private String approvalReason;
+
+    @Column(name = "approval_budget_limit", precision = 12, scale = 2)
+    private BigDecimal approvalBudgetLimit;
+
     @Column(name = "truck_identifier", length = 50)
     private String truckIdentifier;
 

--- a/src/main/java/de/fhdw/webshop/order/OrderService.java
+++ b/src/main/java/de/fhdw/webshop/order/OrderService.java
@@ -5,6 +5,7 @@ import de.fhdw.webshop.admin.AuditLogService;
 import de.fhdw.webshop.address.AddressLookupService;
 import de.fhdw.webshop.address.AddressValidationRequest;
 import de.fhdw.webshop.address.AddressValidationResponse;
+import de.fhdw.webshop.accountlink.AccountLinkRepository;
 import de.fhdw.webshop.cart.CartItem;
 import de.fhdw.webshop.cart.CartService;
 import de.fhdw.webshop.cart.CartRepository;
@@ -76,6 +77,7 @@ public class OrderService {
     private final AuditLogService auditLogService;
     private final EmailService emailService;
     private final AddressLookupService addressLookupService;
+    private final AccountLinkRepository accountLinkRepository;
 
     public List<OrderResponse> listOrdersForCustomer(Long customerId) {
         return orderRepository.findByCustomerIdOrderByCreatedAtDesc(customerId)
@@ -120,6 +122,11 @@ public class OrderService {
         if (placeOrderRequest != null && Boolean.TRUE.equals(placeOrderRequest.savePaymentMethod()) && paymentMethodRequest != null) {
             userService.savePaymentMethod(customer, paymentMethodRequest);
         }
+        if (preparedOrder.approvalRequired()) {
+            Order savedOrder = persistApprovalRequest(preparedOrder, placeOrderRequest != null ? placeOrderRequest.approvalReason() : null);
+            cartService.clearCartSilently(customer.getId());
+            return toResponse(savedOrder);
+        }
         Order savedOrder = persistPreparedOrder(preparedOrder);
         cartService.clearCartSilently(customer.getId());
         markCouponAsUsed(preparedOrder.coupon(), savedOrder, customer);
@@ -158,6 +165,7 @@ public class OrderService {
         Coupon coupon = resolveCoupon(couponCode, customer);
         String orderNumber = placeOrderRequest != null ? placeOrderRequest.previewOrderNumber() : null;
         boolean carbonCompensationSelected = placeOrderRequest != null && Boolean.TRUE.equals(placeOrderRequest.carbonCompensationSelected());
+        BigDecimal approvalBudgetLimit = resolveApprovalBudgetLimit(customer);
         String confirmationEmail = placeOrderRequest != null && placeOrderRequest.email() != null && !placeOrderRequest.email().isBlank()
                 ? placeOrderRequest.email().trim()
                 : customer.getEmail();
@@ -180,7 +188,8 @@ public class OrderService {
                 coupon,
                 customer.getId(),
                 placeOrderRequest != null && Boolean.TRUE.equals(placeOrderRequest.allowUnverifiedAddress()),
-                carbonCompensationSelected
+                carbonCompensationSelected,
+                approvalBudgetLimit
         );
     }
 
@@ -222,7 +231,8 @@ public class OrderService {
                 null,
                 null,
                 Boolean.TRUE.equals(placeOrderRequest.allowUnverifiedAddress()),
-                Boolean.TRUE.equals(placeOrderRequest.carbonCompensationSelected())
+                Boolean.TRUE.equals(placeOrderRequest.carbonCompensationSelected()),
+                null
         );
     }
 
@@ -237,7 +247,8 @@ public class OrderService {
                                        Coupon coupon,
                                        Long discountCustomerId,
                                        boolean allowUnverifiedAddress,
-                                       boolean carbonCompensationSelected) {
+                                       boolean carbonCompensationSelected,
+                                       BigDecimal approvalBudgetLimit) {
         Order order = new Order();
         DeliveryAddressSnapshot validatedDeliveryAddress = validateDeliveryAddress(deliveryAddress, allowUnverifiedAddress);
         order.setCustomer(customer);
@@ -292,6 +303,10 @@ public class OrderService {
                 carbonCompensationSelected
         );
         BigDecimal totalPrice = subtotal.add(taxAmount).add(shippingCost).add(climateContributionAmount).setScale(2, RoundingMode.HALF_UP);
+        boolean approvalRequired = approvalBudgetLimit != null && totalPrice.compareTo(approvalBudgetLimit) > 0;
+        if (approvalRequired) {
+            order.setApprovalBudgetLimit(approvalBudgetLimit);
+        }
 
         return new PreparedOrder(
                 order,
@@ -304,7 +319,9 @@ public class OrderService {
                 climateContributionAmount,
                 totalCo2EmissionKg,
                 carbonCompensationSelected,
-                totalPrice
+                totalPrice,
+                approvalRequired,
+                approvalRequired ? approvalBudgetLimit : null
         );
     }
 
@@ -365,6 +382,18 @@ public class OrderService {
         }
     }
 
+    private BigDecimal resolveApprovalBudgetLimit(User customer) {
+        if (customer == null) {
+            return null;
+        }
+
+        return accountLinkRepository.findAllForUserId(customer.getId()).stream()
+                .map(link -> link.getMaxOrderValueLimit())
+                .filter(limit -> limit != null && limit.compareTo(BigDecimal.ZERO) > 0)
+                .min(BigDecimal::compareTo)
+                .orElse(null);
+    }
+
     private BigDecimal calculateShippingCost(BigDecimal subtotal, ShippingMethod shippingMethod) {
         if (subtotal == null || subtotal.compareTo(BigDecimal.ZERO) <= 0) {
             return BigDecimal.ZERO;
@@ -412,6 +441,48 @@ public class OrderService {
         Order savedOrder = orderRepository.save(order);
         productRepository.saveAll(updatedProducts);
         return savedOrder;
+    }
+
+    private Order persistApprovalRequest(PreparedOrder preparedOrder, String approvalReason) {
+        Order order = preparedOrder.order();
+        order.setDiscountAmount(preparedOrder.discountAmount());
+        order.setTaxAmount(preparedOrder.taxAmount());
+        order.setShippingCost(preparedOrder.shippingCost());
+        order.setClimateContributionAmount(preparedOrder.climateContributionAmount());
+        order.setCarbonCompensationSelected(preparedOrder.carbonCompensationSelected());
+        order.setTotalCo2EmissionKg(preparedOrder.totalCo2EmissionKg());
+        order.setTotalPrice(preparedOrder.totalPrice());
+        order.setStatus(OrderStatus.Pending_Approval);
+        order.setApprovalBudgetLimit(preparedOrder.approvalBudgetLimit());
+        order.setApprovalReason(normalizeApprovalReason(approvalReason));
+
+        for (PreparedOrderItem preparedItem : preparedOrder.items()) {
+            Product product = preparedItem.product();
+            if (preparedItem.quantity() > product.getStock()) {
+                throw new IllegalArgumentException("Only " + product.getStock() + " units of " + product.getName() + " are available");
+            }
+
+            OrderItem orderItem = new OrderItem();
+            orderItem.setOrder(order);
+            orderItem.setProduct(product);
+            orderItem.setQuantity(preparedItem.quantity());
+            orderItem.setPriceAtOrderTime(preparedItem.unitPrice());
+            order.getItems().add(orderItem);
+        }
+
+        return orderRepository.save(order);
+    }
+
+    private String normalizeApprovalReason(String approvalReason) {
+        if (approvalReason == null || approvalReason.isBlank()) {
+            return null;
+        }
+
+        String normalizedReason = approvalReason.trim();
+        if (normalizedReason.length() > 1000) {
+            throw new IllegalArgumentException("Die Begruendung darf maximal 1000 Zeichen lang sein");
+        }
+        return normalizedReason;
     }
 
     /**
@@ -575,6 +646,8 @@ public class OrderService {
                 itemResponses,
                 order.getTruckIdentifier(),
                 estimateDeliveryAt(order),
+                order.getApprovalReason(),
+                order.getApprovalBudgetLimit(),
                 null);
     }
 
@@ -609,11 +682,15 @@ public class OrderService {
                 itemResponses,
                 order.getTruckIdentifier(),
                 estimateDeliveryAt(order),
+                order.getApprovalReason(),
+                order.getApprovalBudgetLimit(),
                 confirmationEmailSent);
     }
 
     private Instant estimateDeliveryAt(Order order) {
-        if (order.getStatus() == OrderStatus.DELIVERED || order.getStatus() == OrderStatus.CANCELLED) {
+        if (order.getStatus() == OrderStatus.Pending_Approval
+                || order.getStatus() == OrderStatus.DELIVERED
+                || order.getStatus() == OrderStatus.CANCELLED) {
             return null;
         }
 
@@ -633,6 +710,7 @@ public class OrderService {
             case PENDING, CONFIRMED -> expressShipping
                     ? EXPRESS_MIN_REMAINING_EARLY
                     : STANDARD_MIN_REMAINING_EARLY;
+            case Pending_Approval -> Duration.ZERO;
             case PACKED_IN_WAREHOUSE -> expressShipping
                     ? EXPRESS_MIN_REMAINING_PACKED
                     : STANDARD_MIN_REMAINING_PACKED;
@@ -668,6 +746,8 @@ public class OrderService {
                 preparedOrder.totalCo2EmissionKg(),
                 preparedOrder.totalPrice(),
                 preparedOrder.order().getCouponCode(),
+                preparedOrder.approvalRequired(),
+                preparedOrder.approvalBudgetLimit(),
                 itemResponses
         );
     }
@@ -744,6 +824,8 @@ public class OrderService {
             BigDecimal climateContributionAmount,
             BigDecimal totalCo2EmissionKg,
             boolean carbonCompensationSelected,
-            BigDecimal totalPrice
+            BigDecimal totalPrice,
+            boolean approvalRequired,
+            BigDecimal approvalBudgetLimit
     ) {}
 }

--- a/src/main/java/de/fhdw/webshop/order/OrderStatus.java
+++ b/src/main/java/de/fhdw/webshop/order/OrderStatus.java
@@ -2,6 +2,7 @@ package de.fhdw.webshop.order;
 
 public enum OrderStatus {
     PENDING,
+    Pending_Approval,
     CONFIRMED,
     PACKED_IN_WAREHOUSE,
     IN_TRUCK,

--- a/src/main/java/de/fhdw/webshop/order/dto/OrderPreviewResponse.java
+++ b/src/main/java/de/fhdw/webshop/order/dto/OrderPreviewResponse.java
@@ -14,5 +14,7 @@ public record OrderPreviewResponse(
         BigDecimal totalCo2EmissionKg,
         BigDecimal totalPrice,
         String couponCode,
+        Boolean approvalRequired,
+        BigDecimal approvalBudgetLimit,
         List<OrderPreviewItemResponse> items
 ) {}

--- a/src/main/java/de/fhdw/webshop/order/dto/OrderResponse.java
+++ b/src/main/java/de/fhdw/webshop/order/dto/OrderResponse.java
@@ -25,5 +25,7 @@ public record OrderResponse(
         List<OrderItemResponse> items,
         String truckIdentifier,
         Instant estimatedDeliveryAt,
+        String approvalReason,
+        BigDecimal approvalBudgetLimit,
         Boolean confirmationEmailSent
 ) {}

--- a/src/main/java/de/fhdw/webshop/order/dto/PlaceOrderRequest.java
+++ b/src/main/java/de/fhdw/webshop/order/dto/PlaceOrderRequest.java
@@ -22,5 +22,6 @@ public record PlaceOrderRequest(
         Boolean saveDeliveryAddress,
         Boolean savePaymentMethod,
         Boolean carbonCompensationSelected,
+        String approvalReason,
         List<@Valid PlaceOrderItemRequest> items
 ) {}

--- a/src/main/java/de/fhdw/webshop/warehouse/WarehouseService.java
+++ b/src/main/java/de/fhdw/webshop/warehouse/WarehouseService.java
@@ -192,6 +192,7 @@ public class WarehouseService {
             case PACKED_IN_WAREHOUSE -> OrderStatus.IN_TRUCK;
             case IN_TRUCK -> OrderStatus.SHIPPED;
             case SHIPPED -> OrderStatus.DELIVERED;
+            case Pending_Approval -> null;
             case DELIVERED, CANCELLED -> null;
         };
     }

--- a/src/main/resources/db/migration/V45__add_order_approval_requests.sql
+++ b/src/main/resources/db/migration/V45__add_order_approval_requests.sql
@@ -1,0 +1,5 @@
+ALTER TYPE order_status ADD VALUE IF NOT EXISTS 'Pending_Approval';
+
+ALTER TABLE orders
+    ADD COLUMN approval_reason VARCHAR(1000),
+    ADD COLUMN approval_budget_limit NUMERIC(12, 2);

--- a/src/test/java/de/fhdw/webshop/order/OrderServiceTest.java
+++ b/src/test/java/de/fhdw/webshop/order/OrderServiceTest.java
@@ -1,0 +1,184 @@
+package de.fhdw.webshop.order;
+
+import de.fhdw.webshop.accountlink.AccountLink;
+import de.fhdw.webshop.accountlink.AccountLinkRepository;
+import de.fhdw.webshop.address.AddressLookupService;
+import de.fhdw.webshop.address.AddressValidationResponse;
+import de.fhdw.webshop.admin.AuditLogService;
+import de.fhdw.webshop.cart.CartItem;
+import de.fhdw.webshop.cart.CartRepository;
+import de.fhdw.webshop.cart.CartService;
+import de.fhdw.webshop.discount.CouponRepository;
+import de.fhdw.webshop.order.dto.OrderPreviewResponse;
+import de.fhdw.webshop.order.dto.OrderResponse;
+import de.fhdw.webshop.order.dto.PlaceOrderRequest;
+import de.fhdw.webshop.product.Product;
+import de.fhdw.webshop.product.ProductRepository;
+import de.fhdw.webshop.product.ProductService;
+import de.fhdw.webshop.user.DeliveryAddressRepository;
+import de.fhdw.webshop.user.PaymentMethodRepository;
+import de.fhdw.webshop.user.PaymentMethodType;
+import de.fhdw.webshop.user.User;
+import de.fhdw.webshop.user.UserRole;
+import de.fhdw.webshop.user.UserService;
+import de.fhdw.webshop.user.UserType;
+import de.fhdw.webshop.user.dto.DeliveryAddressRequest;
+import de.fhdw.webshop.user.dto.PaymentMethodRequest;
+import de.fhdw.webshop.notification.EmailService;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class OrderServiceTest {
+
+    @Test
+    void previewMarksApprovalRequiredWhenBudgetLimitIsExceeded() {
+        TestContext context = newContext(new BigDecimal("100.00"));
+
+        OrderPreviewResponse preview = context.service.previewOrder(context.customer, request(null));
+
+        assertThat(preview.approvalRequired()).isTrue();
+        assertThat(preview.approvalBudgetLimit()).isEqualByComparingTo("100.00");
+        assertThat(preview.totalPrice()).isGreaterThan(preview.approvalBudgetLimit());
+    }
+
+    @Test
+    void placeOrderCreatesPendingApprovalRequestWithoutFinalOrderEffects() {
+        TestContext context = newContext(new BigDecimal("100.00"));
+        when(context.orderRepository.save(any(Order.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        OrderResponse response = context.service.placeOrder(context.customer, request("Bitte fuer das Projekt freigeben"));
+
+        ArgumentCaptor<Order> orderCaptor = ArgumentCaptor.forClass(Order.class);
+        verify(context.orderRepository).save(orderCaptor.capture());
+        Order savedOrder = orderCaptor.getValue();
+
+        assertThat(response.status()).isEqualTo(OrderStatus.Pending_Approval);
+        assertThat(savedOrder.getStatus()).isEqualTo(OrderStatus.Pending_Approval);
+        assertThat(savedOrder.getApprovalReason()).isEqualTo("Bitte fuer das Projekt freigeben");
+        assertThat(savedOrder.getApprovalBudgetLimit()).isEqualByComparingTo("100.00");
+        assertThat(savedOrder.getItems()).hasSize(1);
+        assertThat(context.product.getStock()).isEqualTo(5);
+        verify(context.cartService).clearCartSilently(context.customer.getId());
+        verify(context.productRepository, never()).saveAll(any());
+        verify(context.emailService, never()).sendEmail(any(), any(), any());
+    }
+
+    private static TestContext newContext(BigDecimal budgetLimit) {
+        OrderRepository orderRepository = mock(OrderRepository.class);
+        CartRepository cartRepository = mock(CartRepository.class);
+        CartService cartService = mock(CartService.class);
+        CouponRepository couponRepository = mock(CouponRepository.class);
+        ProductService.DiscountLookupPort discountLookupPort = mock(ProductService.DiscountLookupPort.class);
+        ProductService productService = mock(ProductService.class);
+        ProductRepository productRepository = mock(ProductRepository.class);
+        DeliveryAddressRepository deliveryAddressRepository = mock(DeliveryAddressRepository.class);
+        PaymentMethodRepository paymentMethodRepository = mock(PaymentMethodRepository.class);
+        UserService userService = mock(UserService.class);
+        AuditLogService auditLogService = mock(AuditLogService.class);
+        EmailService emailService = mock(EmailService.class);
+        AddressLookupService addressLookupService = mock(AddressLookupService.class);
+        AccountLinkRepository accountLinkRepository = mock(AccountLinkRepository.class);
+
+        OrderService service = new OrderService(
+                orderRepository,
+                cartRepository,
+                cartService,
+                couponRepository,
+                discountLookupPort,
+                productService,
+                productRepository,
+                deliveryAddressRepository,
+                paymentMethodRepository,
+                userService,
+                auditLogService,
+                emailService,
+                addressLookupService,
+                accountLinkRepository);
+
+        User customer = businessCustomer(10L, "employee");
+        User manager = businessCustomer(11L, "manager");
+        Product product = product();
+        CartItem cartItem = new CartItem();
+        cartItem.setUser(customer);
+        cartItem.setProduct(product);
+        cartItem.setQuantity(1);
+        AccountLink link = new AccountLink();
+        link.setUserA(customer);
+        link.setUserB(manager);
+        link.setMaxOrderValueLimit(budgetLimit);
+
+        when(cartRepository.findByUserId(customer.getId())).thenReturn(List.of(cartItem));
+        when(accountLinkRepository.findAllForUserId(customer.getId())).thenReturn(List.of(link));
+        when(addressLookupService.validateAddress(any())).thenReturn(new AddressValidationResponse(
+                true,
+                "Hauptstrasse 1, 33602 Bielefeld, Germany",
+                "Hauptstrasse 1",
+                "33602",
+                "Bielefeld",
+                "Germany",
+                null));
+
+        return new TestContext(service, customer, product, orderRepository, cartService, productRepository, emailService);
+    }
+
+    private static PlaceOrderRequest request(String approvalReason) {
+        return new PlaceOrderRequest(
+                null,
+                "employee@example.test",
+                "Employee Buyer",
+                "Keine Angabe",
+                "ORD-APPROVAL-TEST",
+                new DeliveryAddressRequest("Hauptstrasse 1", "Bielefeld", "33602", "Germany"),
+                ShippingMethod.STANDARD,
+                new PaymentMethodRequest(PaymentMethodType.BANK_TRANSFER, "Rechnung", null, null, null, null),
+                false,
+                true,
+                true,
+                false,
+                false,
+                false,
+                approvalReason,
+                null);
+    }
+
+    private static User businessCustomer(Long id, String username) {
+        User user = new User();
+        user.setId(id);
+        user.setUsername(username);
+        user.setEmail(username + "@example.test");
+        user.setPasswordHash("hash");
+        user.setUserType(UserType.BUSINESS);
+        user.getRoles().add(UserRole.CUSTOMER);
+        user.setActive(true);
+        return user;
+    }
+
+    private static Product product() {
+        Product product = new Product();
+        product.setId(20L);
+        product.setName("Budget Test Produkt");
+        product.setRecommendedRetailPrice(new BigDecimal("200.00"));
+        product.setStock(5);
+        product.setPurchasable(true);
+        return product;
+    }
+
+    private record TestContext(
+            OrderService service,
+            User customer,
+            Product product,
+            OrderRepository orderRepository,
+            CartService cartService,
+            ProductRepository productRepository,
+            EmailService emailService
+    ) {}
+}


### PR DESCRIPTION
## Änderungen
- Ergänzt Pending_Approval als Bestellstatus und DB-Migration für Freigabeinformationen
- Prüft B2B-Budgetlimits aus account_links.max_order_value_limit in der Order-Preview
- Legt bei Budgetüberschreitung einen Freigabeauftrag statt einer finalen Bestellung an
- Speichert optionale Begründung und leert den Warenkorb nach Anfrage
- Ergänzt fokussierte OrderService-Tests

## Issue
- Gehört zu SEPBFWS124A/Webshop#221

## Validierung
- `.\mvnw.cmd test`