### PR TITLE
US-222: Manager-Freigabe bearbeiten

### DIFF
--- a/src/main/java/de/fhdw/webshop/order/Order.java
+++ b/src/main/java/de/fhdw/webshop/order/Order.java
@@ -96,6 +96,16 @@ public class Order {
     @Column(name = "approval_budget_limit", precision = 12, scale = 2)
     private BigDecimal approvalBudgetLimit;
 
+    @Column(name = "approval_rejection_reason", length = 1000)
+    private String approvalRejectionReason;
+
+    @Column(name = "approval_decided_at")
+    private Instant approvalDecidedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "approval_decided_by_id")
+    private User approvalDecidedBy;
+
     @Column(name = "truck_identifier", length = 50)
     private String truckIdentifier;
 

--- a/src/main/java/de/fhdw/webshop/order/OrderController.java
+++ b/src/main/java/de/fhdw/webshop/order/OrderController.java
@@ -1,5 +1,7 @@
 package de.fhdw.webshop.order;
 
+import de.fhdw.webshop.order.dto.OrderApprovalDecisionRequest;
+import de.fhdw.webshop.order.dto.OrderApprovalResponse;
 import de.fhdw.webshop.order.dto.OrderResponse;
 import de.fhdw.webshop.order.dto.OrderPreviewResponse;
 import de.fhdw.webshop.order.dto.PlaceOrderRequest;
@@ -38,6 +40,32 @@ public class OrderController {
     public ResponseEntity<OrderResponse> getOrder(@PathVariable Long id,
                                                   @AuthenticationPrincipal User currentUser) {
         return ResponseEntity.ok(orderService.getOrder(id, currentUser.getId()));
+    }
+
+    /** Issue #222 - B2B manager views pending approval requests for linked employees. */
+    @GetMapping("/approvals/pending")
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public ResponseEntity<List<OrderApprovalResponse>> listPendingApprovals(@AuthenticationPrincipal User currentUser) {
+        return ResponseEntity.ok(orderService.listPendingApprovalRequests(currentUser));
+    }
+
+    /** Issue #222 - B2B manager approves a pending request and triggers the regular order flow. */
+    @PostMapping("/approvals/{id}/approve")
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public ResponseEntity<OrderApprovalResponse> approveApproval(
+            @PathVariable Long id,
+            @AuthenticationPrincipal User currentUser) {
+        return ResponseEntity.ok(orderService.approveApprovalRequest(currentUser, id));
+    }
+
+    /** Issue #222 - B2B manager rejects a pending request with a required reason. */
+    @PostMapping("/approvals/{id}/reject")
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public ResponseEntity<OrderApprovalResponse> rejectApproval(
+            @PathVariable Long id,
+            @AuthenticationPrincipal User currentUser,
+            @Valid @RequestBody OrderApprovalDecisionRequest request) {
+        return ResponseEntity.ok(orderService.rejectApprovalRequest(currentUser, id, request.reason()));
     }
 
     /** US #42 — Place an order from the current cart contents. */

--- a/src/main/java/de/fhdw/webshop/order/OrderRepository.java
+++ b/src/main/java/de/fhdw/webshop/order/OrderRepository.java
@@ -24,6 +24,41 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 
         List<Order> findByStatusNotInOrderByCreatedAtAsc(Collection<OrderStatus> statuses);
 
+        @Query("""
+                        SELECT DISTINCT o FROM Order o
+                        JOIN FETCH o.customer customer
+                        LEFT JOIN FETCH o.items item
+                        LEFT JOIN FETCH item.product
+                        WHERE o.status = :status
+                          AND customer.id <> :managerId
+                          AND EXISTS (
+                                SELECT link.id FROM AccountLink link
+                                WHERE (link.userA.id = :managerId AND link.userB.id = customer.id)
+                                   OR (link.userB.id = :managerId AND link.userA.id = customer.id)
+                          )
+                        ORDER BY o.createdAt ASC
+                        """)
+        List<Order> findApprovalRequestsForManager(
+                        @Param("managerId") Long managerId,
+                        @Param("status") OrderStatus status);
+
+        @Query("""
+                        SELECT DISTINCT o FROM Order o
+                        JOIN FETCH o.customer customer
+                        LEFT JOIN FETCH o.items item
+                        LEFT JOIN FETCH item.product
+                        WHERE o.id = :orderId
+                          AND customer.id <> :managerId
+                          AND EXISTS (
+                                SELECT link.id FROM AccountLink link
+                                WHERE (link.userA.id = :managerId AND link.userB.id = customer.id)
+                                   OR (link.userB.id = :managerId AND link.userA.id = customer.id)
+                          )
+                        """)
+        Optional<Order> findApprovalRequestForManager(
+                        @Param("orderId") Long orderId,
+                        @Param("managerId") Long managerId);
+
         /**
          * US #29 — Orders for a customer within a date range (for revenue statistics).
          */

--- a/src/main/java/de/fhdw/webshop/order/OrderService.java
+++ b/src/main/java/de/fhdw/webshop/order/OrderService.java
@@ -12,6 +12,7 @@ import de.fhdw.webshop.cart.CartRepository;
 import de.fhdw.webshop.discount.Coupon;
 import de.fhdw.webshop.discount.CouponRepository;
 import de.fhdw.webshop.order.dto.OrderItemResponse;
+import de.fhdw.webshop.order.dto.OrderApprovalResponse;
 import de.fhdw.webshop.order.dto.OrderPreviewItemResponse;
 import de.fhdw.webshop.order.dto.OrderPreviewResponse;
 import de.fhdw.webshop.order.dto.OrderResponse;
@@ -26,6 +27,8 @@ import de.fhdw.webshop.user.PaymentMethodRepository;
 import de.fhdw.webshop.user.PaymentMethodSupport;
 import de.fhdw.webshop.user.User;
 import de.fhdw.webshop.user.UserService;
+import de.fhdw.webshop.user.UserRole;
+import de.fhdw.webshop.user.UserType;
 import de.fhdw.webshop.user.dto.DeliveryAddressRequest;
 import de.fhdw.webshop.user.dto.PaymentMethodRequest;
 import jakarta.persistence.EntityNotFoundException;
@@ -100,6 +103,67 @@ public class OrderService {
         Order order = orderRepository.findByIdAndCustomerId(orderId, customerId)
                 .orElseThrow(() -> new EntityNotFoundException("Order not found: " + orderId));
         return toResponse(order);
+    }
+
+    @Transactional(readOnly = true)
+    public List<OrderApprovalResponse> listPendingApprovalRequests(User manager) {
+        requireBusinessApprovalManager(manager);
+        return orderRepository.findApprovalRequestsForManager(manager.getId(), OrderStatus.Pending_Approval).stream()
+                .map(order -> toApprovalResponse(order, null))
+                .toList();
+    }
+
+    @Transactional
+    public OrderApprovalResponse approveApprovalRequest(User manager, Long orderId) {
+        requireBusinessApprovalManager(manager);
+        Order order = loadApprovalRequestForManager(manager, orderId);
+        requirePendingApproval(order);
+
+        List<Product> updatedProducts = new ArrayList<>();
+        for (OrderItem orderItem : order.getItems()) {
+            Product product = orderItem.getProduct();
+            if (!product.isPurchasable() || product.getStock() <= 0) {
+                throw new IllegalArgumentException(product.getName() + " is no longer available");
+            }
+            if (orderItem.getQuantity() > product.getStock()) {
+                throw new IllegalArgumentException("Only " + product.getStock() + " units of " + product.getName() + " are available");
+            }
+            product.setStock(product.getStock() - orderItem.getQuantity());
+            updatedProducts.add(product);
+        }
+
+        order.setStatus(OrderStatus.CONFIRMED);
+        order.setApprovalDecidedAt(Instant.now());
+        order.setApprovalDecidedBy(manager);
+        order.setApprovalRejectionReason(null);
+        Order savedOrder = orderRepository.save(order);
+        productRepository.saveAll(updatedProducts);
+        markCouponAsUsedByCode(savedOrder, manager);
+        auditLogService.record(manager, "APPROVE_ORDER_REQUEST", "Order", savedOrder.getId(),
+                AuditInitiator.USER,
+                "Manager approved order request " + savedOrder.getOrderNumber() + " for customer "
+                        + savedOrder.getCustomer().getId());
+        boolean confirmationEmailSent = sendOrderConfirmation(savedOrder);
+        return toApprovalResponse(savedOrder, confirmationEmailSent);
+    }
+
+    @Transactional
+    public OrderApprovalResponse rejectApprovalRequest(User manager, Long orderId, String reason) {
+        requireBusinessApprovalManager(manager);
+        Order order = loadApprovalRequestForManager(manager, orderId);
+        requirePendingApproval(order);
+        String normalizedReason = normalizeRequiredRejectionReason(reason);
+
+        order.setStatus(OrderStatus.Rejected);
+        order.setApprovalRejectionReason(normalizedReason);
+        order.setApprovalDecidedAt(Instant.now());
+        order.setApprovalDecidedBy(manager);
+        Order savedOrder = orderRepository.save(order);
+        auditLogService.record(manager, "REJECT_ORDER_REQUEST", "Order", savedOrder.getId(),
+                AuditInitiator.USER,
+                "Manager rejected order request " + savedOrder.getOrderNumber() + " for customer "
+                        + savedOrder.getCustomer().getId());
+        return toApprovalResponse(savedOrder, null);
     }
 
     /** US #42 - Convert the current cart into a confirmed order. Coupon reduces the order subtotal. */
@@ -485,6 +549,18 @@ public class OrderService {
         return normalizedReason;
     }
 
+    private String normalizeRequiredRejectionReason(String reason) {
+        if (reason == null || reason.isBlank()) {
+            throw new IllegalArgumentException("Bitte einen Ablehnungsgrund eingeben");
+        }
+
+        String normalizedReason = reason.trim();
+        if (normalizedReason.length() > 1000) {
+            throw new IllegalArgumentException("Die Begruendung darf maximal 1000 Zeichen lang sein");
+        }
+        return normalizedReason;
+    }
+
     /**
      * Looks up and validates a coupon code. Returns null if no code was provided.
      * Throws IllegalArgumentException if the code is invalid, expired, already used,
@@ -593,6 +669,53 @@ public class OrderService {
                 "code=" + coupon.getCode() + ", orderId=" + savedOrder.getId());
     }
 
+    private void markCouponAsUsedByCode(Order savedOrder, User manager) {
+        String couponCode = savedOrder.getCouponCode();
+        if (couponCode == null || couponCode.isBlank()) {
+            return;
+        }
+
+        Coupon coupon = couponRepository.findByCode(couponCode)
+                .orElseThrow(() -> new IllegalArgumentException("Coupon code not found: " + couponCode));
+        if (savedOrder.getCustomer() == null || !coupon.getCustomer().getId().equals(savedOrder.getCustomer().getId())) {
+            throw new IllegalArgumentException("Coupon does not belong to the approved customer");
+        }
+        if (coupon.isUsed()) {
+            throw new IllegalArgumentException("Coupon has already been used: " + couponCode);
+        }
+
+        coupon.setUsed(true);
+        coupon.setUsedAt(Instant.now());
+        couponRepository.save(coupon);
+        auditLogService.record(
+                savedOrder.getCustomer(),
+                "APPLY_COUPON",
+                "Coupon",
+                coupon.getId(),
+                AuditInitiator.USER,
+                "code=" + coupon.getCode() + ", orderId=" + savedOrder.getId()
+                        + ", approvedBy=" + manager.getId());
+    }
+
+    private void requireBusinessApprovalManager(User manager) {
+        if (manager == null
+                || manager.getUserType() != UserType.BUSINESS
+                || !manager.hasRole(UserRole.CUSTOMER)) {
+            throw new IllegalArgumentException("Order approvals are only available for B2B customer administrators");
+        }
+    }
+
+    private Order loadApprovalRequestForManager(User manager, Long orderId) {
+        return orderRepository.findApprovalRequestForManager(orderId, manager.getId())
+                .orElseThrow(() -> new EntityNotFoundException("Order approval request not found: " + orderId));
+    }
+
+    private void requirePendingApproval(Order order) {
+        if (order.getStatus() != OrderStatus.Pending_Approval) {
+            throw new IllegalArgumentException("Only pending approval requests can be processed");
+        }
+    }
+
     private String resolveOrderNumber(String requestedOrderNumber) {
         if (requestedOrderNumber != null && !requestedOrderNumber.isBlank()) {
             return requestedOrderNumber.trim();
@@ -651,6 +774,42 @@ public class OrderService {
                 null);
     }
 
+    private OrderApprovalResponse toApprovalResponse(Order order, Boolean confirmationEmailSent) {
+        User requester = order.getCustomer();
+        List<OrderItemResponse> itemResponses = order.getItems().stream()
+                .map(orderItem -> new OrderItemResponse(
+                        orderItem.getId(),
+                        orderItem.getProduct().getId(),
+                        orderItem.getProduct().getName(),
+                        orderItem.getProduct().isPurchasable(),
+                        orderItem.getQuantity(),
+                        orderItem.getPriceAtOrderTime(),
+                        orderItem.getPriceAtOrderTime()
+                                .multiply(BigDecimal.valueOf(orderItem.getQuantity()))))
+                .toList();
+
+        return new OrderApprovalResponse(
+                order.getId(),
+                order.getOrderNumber(),
+                order.getStatus(),
+                requester != null ? requester.getId() : null,
+                requester != null ? requester.getUsername() : order.getCustomerName(),
+                requester != null ? requester.getEmail() : order.getCustomerEmail(),
+                order.getCreatedAt(),
+                order.getTotalPrice(),
+                order.getTaxAmount(),
+                order.getShippingCost(),
+                order.getShippingMethod(),
+                order.getDiscountAmount(),
+                order.getCouponCode(),
+                order.getApprovalReason(),
+                order.getApprovalBudgetLimit(),
+                order.getApprovalRejectionReason(),
+                order.getApprovalDecidedAt(),
+                itemResponses,
+                confirmationEmailSent);
+    }
+
     private OrderResponse toResponse(Order order, boolean confirmationEmailSent) {
         List<OrderItemResponse> itemResponses = order.getItems().stream()
                 .map(orderItem -> new OrderItemResponse(
@@ -689,6 +848,7 @@ public class OrderService {
 
     private Instant estimateDeliveryAt(Order order) {
         if (order.getStatus() == OrderStatus.Pending_Approval
+                || order.getStatus() == OrderStatus.Rejected
                 || order.getStatus() == OrderStatus.DELIVERED
                 || order.getStatus() == OrderStatus.CANCELLED) {
             return null;
@@ -710,7 +870,7 @@ public class OrderService {
             case PENDING, CONFIRMED -> expressShipping
                     ? EXPRESS_MIN_REMAINING_EARLY
                     : STANDARD_MIN_REMAINING_EARLY;
-            case Pending_Approval -> Duration.ZERO;
+            case Pending_Approval, Rejected -> Duration.ZERO;
             case PACKED_IN_WAREHOUSE -> expressShipping
                     ? EXPRESS_MIN_REMAINING_PACKED
                     : STANDARD_MIN_REMAINING_PACKED;

--- a/src/main/java/de/fhdw/webshop/order/OrderStatus.java
+++ b/src/main/java/de/fhdw/webshop/order/OrderStatus.java
@@ -3,6 +3,7 @@ package de.fhdw.webshop.order;
 public enum OrderStatus {
     PENDING,
     Pending_Approval,
+    Rejected,
     CONFIRMED,
     PACKED_IN_WAREHOUSE,
     IN_TRUCK,

--- a/src/main/java/de/fhdw/webshop/order/dto/OrderApprovalDecisionRequest.java
+++ b/src/main/java/de/fhdw/webshop/order/dto/OrderApprovalDecisionRequest.java
@@ -1,0 +1,8 @@
+package de.fhdw.webshop.order.dto;
+
+import jakarta.validation.constraints.Size;
+
+public record OrderApprovalDecisionRequest(
+        @Size(max = 1000, message = "Die Begruendung darf maximal 1000 Zeichen lang sein")
+        String reason
+) {}

--- a/src/main/java/de/fhdw/webshop/order/dto/OrderApprovalResponse.java
+++ b/src/main/java/de/fhdw/webshop/order/dto/OrderApprovalResponse.java
@@ -1,0 +1,30 @@
+package de.fhdw.webshop.order.dto;
+
+import de.fhdw.webshop.order.OrderStatus;
+import de.fhdw.webshop.order.ShippingMethod;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+public record OrderApprovalResponse(
+        Long id,
+        String orderNumber,
+        OrderStatus status,
+        Long requesterId,
+        String requesterName,
+        String requesterEmail,
+        Instant createdAt,
+        BigDecimal totalPrice,
+        BigDecimal taxAmount,
+        BigDecimal shippingCost,
+        ShippingMethod shippingMethod,
+        BigDecimal discountAmount,
+        String couponCode,
+        String approvalReason,
+        BigDecimal approvalBudgetLimit,
+        String rejectionReason,
+        Instant decidedAt,
+        List<OrderItemResponse> items,
+        Boolean confirmationEmailSent
+) {}

--- a/src/main/java/de/fhdw/webshop/warehouse/WarehouseService.java
+++ b/src/main/java/de/fhdw/webshop/warehouse/WarehouseService.java
@@ -52,7 +52,11 @@ public class WarehouseService {
     @Transactional(readOnly = true)
     public List<WarehouseOrderResponse> listOrders(OrderStatus status) {
         List<Order> orders = status == null
-                ? orderRepository.findByStatusNotInOrderByCreatedAtAsc(List.of(OrderStatus.DELIVERED, OrderStatus.CANCELLED))
+                ? orderRepository.findByStatusNotInOrderByCreatedAtAsc(List.of(
+                        OrderStatus.DELIVERED,
+                        OrderStatus.CANCELLED,
+                        OrderStatus.Pending_Approval,
+                        OrderStatus.Rejected))
                 : orderRepository.findByStatusOrderByCreatedAtAsc(status);
 
         List<Order> filteredOrders = orders.stream()
@@ -135,7 +139,7 @@ public class WarehouseService {
     @Transactional
     public AutoAssignTruckIdentifiersResponse autoAssignTruckIdentifiers() {
         List<Order> activeOrders = orderRepository.findByStatusNotInOrderByCreatedAtAsc(
-                List.of(OrderStatus.DELIVERED, OrderStatus.CANCELLED)
+                List.of(OrderStatus.DELIVERED, OrderStatus.CANCELLED, OrderStatus.Pending_Approval, OrderStatus.Rejected)
         ).stream()
                 .filter(order -> TRUCK_ASSIGNABLE_STATUSES.contains(order.getStatus()))
                 .toList();
@@ -192,7 +196,7 @@ public class WarehouseService {
             case PACKED_IN_WAREHOUSE -> OrderStatus.IN_TRUCK;
             case IN_TRUCK -> OrderStatus.SHIPPED;
             case SHIPPED -> OrderStatus.DELIVERED;
-            case Pending_Approval -> null;
+            case Pending_Approval, Rejected -> null;
             case DELIVERED, CANCELLED -> null;
         };
     }

--- a/src/main/resources/db/migration/V46__add_order_approval_decisions.sql
+++ b/src/main/resources/db/migration/V46__add_order_approval_decisions.sql
@@ -1,0 +1,6 @@
+ALTER TYPE order_status ADD VALUE IF NOT EXISTS 'Rejected';
+
+ALTER TABLE orders
+    ADD COLUMN approval_rejection_reason VARCHAR(1000),
+    ADD COLUMN approval_decided_at TIMESTAMP,
+    ADD COLUMN approval_decided_by_id BIGINT REFERENCES users(id);

--- a/src/test/java/de/fhdw/webshop/order/OrderServiceTest.java
+++ b/src/test/java/de/fhdw/webshop/order/OrderServiceTest.java
@@ -27,10 +27,12 @@ import de.fhdw.webshop.user.dto.PaymentMethodRequest;
 import de.fhdw.webshop.notification.EmailService;
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -70,6 +72,45 @@ class OrderServiceTest {
         verify(context.cartService).clearCartSilently(context.customer.getId());
         verify(context.productRepository, never()).saveAll(any());
         verify(context.emailService, never()).sendEmail(any(), any(), any());
+    }
+
+    @Test
+    void approveApprovalRequestConfirmsOrderAndAppliesFinalOrderEffects() {
+        TestContext context = newContext(new BigDecimal("100.00"));
+        Order pendingOrder = pendingApprovalOrder(context.customer, context.product);
+        when(context.orderRepository.findApprovalRequestForManager(pendingOrder.getId(), context.manager.getId()))
+                .thenReturn(Optional.of(pendingOrder));
+        when(context.orderRepository.save(any(Order.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(context.emailService.sendEmail(any(), any(), any())).thenReturn(true);
+
+        OrderResponse regularResponse = context.service.placeOrder(context.customer, request("Projektbedarf"));
+        assertThat(regularResponse.status()).isEqualTo(OrderStatus.Pending_Approval);
+
+        var approvalResponse = context.service.approveApprovalRequest(context.manager, pendingOrder.getId());
+
+        assertThat(approvalResponse.status()).isEqualTo(OrderStatus.CONFIRMED);
+        assertThat(approvalResponse.confirmationEmailSent()).isTrue();
+        assertThat(pendingOrder.getStatus()).isEqualTo(OrderStatus.CONFIRMED);
+        assertThat(pendingOrder.getApprovalDecidedBy()).isEqualTo(context.manager);
+        assertThat(pendingOrder.getApprovalDecidedAt()).isNotNull();
+        assertThat(context.product.getStock()).isEqualTo(4);
+        verify(context.productRepository).saveAll(List.of(context.product));
+        verify(context.emailService).sendEmail(any(), any(), any());
+    }
+
+    @Test
+    void rejectApprovalRequestRequiresReason() {
+        TestContext context = newContext(new BigDecimal("100.00"));
+        Order pendingOrder = pendingApprovalOrder(context.customer, context.product);
+        when(context.orderRepository.findApprovalRequestForManager(pendingOrder.getId(), context.manager.getId()))
+                .thenReturn(Optional.of(pendingOrder));
+
+        assertThatThrownBy(() -> context.service.rejectApprovalRequest(context.manager, pendingOrder.getId(), " "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Ablehnungsgrund");
+
+        assertThat(pendingOrder.getStatus()).isEqualTo(OrderStatus.Pending_Approval);
+        verify(context.orderRepository, never()).save(pendingOrder);
     }
 
     private static TestContext newContext(BigDecimal budgetLimit) {
@@ -127,7 +168,7 @@ class OrderServiceTest {
                 "Germany",
                 null));
 
-        return new TestContext(service, customer, product, orderRepository, cartService, productRepository, emailService);
+        return new TestContext(service, customer, manager, product, orderRepository, cartService, productRepository, emailService);
     }
 
     private static PlaceOrderRequest request(String approvalReason) {
@@ -172,9 +213,41 @@ class OrderServiceTest {
         return product;
     }
 
+    private static Order pendingApprovalOrder(User customer, Product product) {
+        Order order = new Order();
+        order.setId(500L);
+        order.setCustomer(customer);
+        order.setOrderNumber("ORD-APPROVAL-500");
+        order.setCustomerEmail(customer.getEmail());
+        order.setCustomerName(customer.getUsername());
+        order.setDeliveryStreet("Hauptstrasse 1");
+        order.setDeliveryCity("Bielefeld");
+        order.setDeliveryPostalCode("33602");
+        order.setDeliveryCountry("Germany");
+        order.setPaymentMethodType(PaymentMethodType.BANK_TRANSFER);
+        order.setPaymentMaskedDetails("Rechnung");
+        order.setTotalPrice(new BigDecimal("238.00"));
+        order.setTaxAmount(new BigDecimal("38.00"));
+        order.setShippingCost(BigDecimal.ZERO);
+        order.setDiscountAmount(BigDecimal.ZERO);
+        order.setStatus(OrderStatus.Pending_Approval);
+        order.setApprovalReason("Projektbedarf");
+        order.setApprovalBudgetLimit(new BigDecimal("100.00"));
+
+        OrderItem item = new OrderItem();
+        item.setId(501L);
+        item.setOrder(order);
+        item.setProduct(product);
+        item.setQuantity(1);
+        item.setPriceAtOrderTime(new BigDecimal("200.00"));
+        order.getItems().add(item);
+        return order;
+    }
+
     private record TestContext(
             OrderService service,
             User customer,
+            User manager,
             Product product,
             OrderRepository orderRepository,
             CartService cartService,


### PR DESCRIPTION
## What changed
- Adds database support for rejected approval requests and approval decision metadata.
- Adds manager endpoints to list, approve, and reject pending employee order approvals.
- Reuses the regular order-finalization effects on approval: stock reduction, coupon usage, confirmation email, and audit logging.
- Excludes pending/rejected approval requests from warehouse processing and covers the approval flow with service tests.

## Why
US-222 needs backend and database support so B2B managers can continue or stop employee order requests.

## Validation
- .\mvnw.cmd test
