### PR TITLE
Issue 223: Systembenachrichtigungen per Mail

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,8 @@ SERVER_PORT=8080
 # ── CORS ────────────────────────────────────────────────────────────────────
 # Comma-separated list of allowed frontend origins
 CORS_ALLOWED_ORIGINS=http://localhost:5173
+# Base URL used in transactional emails that link back to the storefront
+FRONTEND_BASE_URL=http://localhost:5173
 
 # ── Mail ────────────────────────────────────────────────────────────────────
 # Gmail: MAIL_HOST=smtp.gmail.com, MAIL_PORT=587

--- a/src/main/java/de/fhdw/webshop/order/OrderService.java
+++ b/src/main/java/de/fhdw/webshop/order/OrderService.java
@@ -11,6 +11,7 @@ import de.fhdw.webshop.cart.CartService;
 import de.fhdw.webshop.cart.CartRepository;
 import de.fhdw.webshop.discount.Coupon;
 import de.fhdw.webshop.discount.CouponRepository;
+import de.fhdw.webshop.notification.EmailService;
 import de.fhdw.webshop.order.dto.OrderItemResponse;
 import de.fhdw.webshop.order.dto.OrderApprovalResponse;
 import de.fhdw.webshop.order.dto.OrderPreviewItemResponse;
@@ -43,9 +44,9 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import de.fhdw.webshop.notification.EmailService;
 
 @Service
 @RequiredArgsConstructor
@@ -81,6 +82,9 @@ public class OrderService {
     private final EmailService emailService;
     private final AddressLookupService addressLookupService;
     private final AccountLinkRepository accountLinkRepository;
+
+    @Value("${app.frontend.base-url:http://localhost:5173}")
+    private String frontendBaseUrl;
 
     public List<OrderResponse> listOrdersForCustomer(Long customerId) {
         return orderRepository.findByCustomerIdOrderByCreatedAtDesc(customerId)
@@ -163,6 +167,7 @@ public class OrderService {
                 AuditInitiator.USER,
                 "Manager rejected order request " + savedOrder.getOrderNumber() + " for customer "
                         + savedOrder.getCustomer().getId());
+        sendApprovalRejectedNotification(savedOrder, normalizedReason);
         return toApprovalResponse(savedOrder, null);
     }
 
@@ -534,7 +539,9 @@ public class OrderService {
             order.getItems().add(orderItem);
         }
 
-        return orderRepository.save(order);
+        Order savedOrder = orderRepository.save(order);
+        sendApprovalRequestNotifications(savedOrder);
+        return savedOrder;
     }
 
     private String normalizeApprovalReason(String approvalReason) {
@@ -714,6 +721,38 @@ public class OrderService {
         if (order.getStatus() != OrderStatus.Pending_Approval) {
             throw new IllegalArgumentException("Only pending approval requests can be processed");
         }
+    }
+
+    private void sendApprovalRequestNotifications(Order order) {
+        if (order.getCustomer() == null) {
+            return;
+        }
+
+        List<User> managers = accountLinkRepository.findAllForUserId(order.getCustomer().getId()).stream()
+                .map(link -> link.getUserA().getId().equals(order.getCustomer().getId()) ? link.getUserB() : link.getUserA())
+                .filter(manager -> manager != null
+                        && !manager.getId().equals(order.getCustomer().getId())
+                        && manager.isActive()
+                        && manager.getUserType() == UserType.BUSINESS
+                        && manager.hasRole(UserRole.CUSTOMER))
+                .distinct()
+                .toList();
+
+        for (User manager : managers) {
+            emailService.sendEmail(
+                    manager.getEmail(),
+                    "Freigabe erforderlich: " + order.getOrderNumber(),
+                    buildApprovalRequestEmailBody(order, manager)
+            );
+        }
+    }
+
+    private void sendApprovalRejectedNotification(Order order, String reason) {
+        emailService.sendEmail(
+                order.getCustomerEmail(),
+                "Freigabe abgelehnt: " + order.getOrderNumber(),
+                buildApprovalRejectedEmailBody(order, reason)
+        );
     }
 
     private String resolveOrderNumber(String requestedOrderNumber) {
@@ -946,6 +985,56 @@ public class OrderService {
                 "Bestellbestaetigung " + order.getOrderNumber(),
                 body.toString()
         );
+    }
+
+    private String buildApprovalRequestEmailBody(Order order, User manager) {
+        String requesterName = order.getCustomerName() != null && !order.getCustomerName().isBlank()
+                ? order.getCustomerName()
+                : order.getCustomer().getUsername();
+
+        StringBuilder body = new StringBuilder()
+                .append("Hallo ").append(manager.getUsername()).append(",\n\n")
+                .append("eine Bestellung von ").append(requesterName)
+                .append(" wartet auf deine Freigabe.\n\n")
+                .append("Bestellnummer: ").append(order.getOrderNumber()).append('\n')
+                .append("Gesamtbetrag: ").append(order.getTotalPrice()).append(" EUR\n");
+
+        if (order.getApprovalBudgetLimit() != null) {
+            body.append("Budgetlimit: ").append(order.getApprovalBudgetLimit()).append(" EUR\n");
+        }
+        if (order.getApprovalReason() != null && !order.getApprovalReason().isBlank()) {
+            body.append("Begruendung: ").append(order.getApprovalReason()).append('\n');
+        }
+
+        body.append("\nLink zur Anfrage: ").append(buildApprovalRequestLink()).append('\n')
+                .append("\nBitte pruefe die Anfrage zeitnah im Profilbereich.");
+
+        return body.toString();
+    }
+
+    private String buildApprovalRejectedEmailBody(Order order, String reason) {
+        String requesterName = order.getCustomerName() != null && !order.getCustomerName().isBlank()
+                ? order.getCustomerName()
+                : "dein Team";
+
+        return new StringBuilder()
+                .append("Hallo ").append(requesterName).append(",\n\n")
+                .append("deine Bestellanfrage wurde abgelehnt.\n\n")
+                .append("Bestellnummer: ").append(order.getOrderNumber()).append('\n')
+                .append("Gesamtbetrag: ").append(order.getTotalPrice()).append(" EUR\n")
+                .append("Begruendung des Managers: ").append(reason).append('\n')
+                .append("\nBitte passe die Bestellung bei Bedarf an und reiche sie erneut ein.")
+                .toString();
+    }
+
+    private String buildApprovalRequestLink() {
+        String normalizedBaseUrl = frontendBaseUrl == null || frontendBaseUrl.isBlank()
+                ? "http://localhost:5173"
+                : frontendBaseUrl.trim();
+        if (normalizedBaseUrl.endsWith("/")) {
+            normalizedBaseUrl = normalizedBaseUrl.substring(0, normalizedBaseUrl.length() - 1);
+        }
+        return normalizedBaseUrl + "/profile";
     }
 
     private record DeliveryAddressSnapshot(

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -6,6 +6,12 @@
       "description": "Comma-separated list of email addresses that receive monitoring alerts. Defaults to spring.mail.username (self-send). Leave empty to suppress alert emails."
     },
     {
+      "name": "app.frontend.base-url",
+      "type": "java.lang.String",
+      "description": "Base URL used in transactional emails that link back to the storefront.",
+      "defaultValue": "http://localhost:5173"
+    },
+    {
       "name": "alert.error-rate.threshold",
       "type": "java.lang.Integer",
       "description": "Number of HTTP 5xx errors in a 15-minute window that triggers an alert email.",

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,6 +21,7 @@ app.jwt.expiration-ms=${JWT_EXPIRATION_MS:86400000}
 
 # ── CORS ────────────────────────────────────────────────────────────────────
 app.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:5173}
+app.frontend.base-url=${FRONTEND_BASE_URL:http://localhost:5173}
 
 # ── Mail ────────────────────────────────────────────────────────────────────
 # Gmail: MAIL_HOST=smtp.gmail.com, MAIL_PORT=587, MAIL_USERNAME/PASSWORD=<App-Passwort>

--- a/src/test/java/de/fhdw/webshop/order/OrderServiceTest.java
+++ b/src/test/java/de/fhdw/webshop/order/OrderServiceTest.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -71,7 +72,13 @@ class OrderServiceTest {
         assertThat(context.product.getStock()).isEqualTo(5);
         verify(context.cartService).clearCartSilently(context.customer.getId());
         verify(context.productRepository, never()).saveAll(any());
-        verify(context.emailService, never()).sendEmail(any(), any(), any());
+        ArgumentCaptor<String> addressCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> subjectCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(context.emailService).sendEmail(addressCaptor.capture(), subjectCaptor.capture(), bodyCaptor.capture());
+        assertThat(addressCaptor.getValue()).isEqualTo(context.manager.getEmail());
+        assertThat(subjectCaptor.getValue()).contains("Freigabe erforderlich", savedOrder.getOrderNumber());
+        assertThat(bodyCaptor.getValue()).contains("Link zur Anfrage", "/profile", savedOrder.getOrderNumber());
     }
 
     @Test
@@ -95,7 +102,32 @@ class OrderServiceTest {
         assertThat(pendingOrder.getApprovalDecidedAt()).isNotNull();
         assertThat(context.product.getStock()).isEqualTo(4);
         verify(context.productRepository).saveAll(List.of(context.product));
-        verify(context.emailService).sendEmail(any(), any(), any());
+        verify(context.emailService, times(2)).sendEmail(any(), any(), any());
+    }
+
+    @Test
+    void rejectApprovalRequestSendsReasonToEmployee() {
+        TestContext context = newContext(new BigDecimal("100.00"));
+        Order pendingOrder = pendingApprovalOrder(context.customer, context.product);
+        when(context.orderRepository.findApprovalRequestForManager(pendingOrder.getId(), context.manager.getId()))
+                .thenReturn(Optional.of(pendingOrder));
+        when(context.orderRepository.save(any(Order.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var approvalResponse = context.service.rejectApprovalRequest(
+                context.manager,
+                pendingOrder.getId(),
+                "Budget fuer dieses Quartal ausgeschoepft");
+
+        assertThat(approvalResponse.status()).isEqualTo(OrderStatus.Rejected);
+        assertThat(approvalResponse.rejectionReason()).isEqualTo("Budget fuer dieses Quartal ausgeschoepft");
+
+        ArgumentCaptor<String> addressCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> subjectCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(context.emailService).sendEmail(addressCaptor.capture(), subjectCaptor.capture(), bodyCaptor.capture());
+        assertThat(addressCaptor.getValue()).isEqualTo(context.customer.getEmail());
+        assertThat(subjectCaptor.getValue()).contains("Freigabe abgelehnt", pendingOrder.getOrderNumber());
+        assertThat(bodyCaptor.getValue()).contains("Budget fuer dieses Quartal ausgeschoepft", pendingOrder.getOrderNumber());
     }
 
     @Test


### PR DESCRIPTION
## What changed
- send an email to linked B2B managers when an order approval request is created
- send an email to the requesting employee when an approval request is rejected, including the manager's reason
- add a configurable frontend base URL for links in transactional emails
- extend OrderService tests for the approval notification paths

## Why
Issue #223 requires email notifications for B2B approval status changes so managers and employees do not need to poll the system.

## Validation
- .\mvnw.cmd '-Dmaven.multiModuleProjectDirectory=C:\Dev\Webshop-Backend' '-Dmaven.user.home=C:\Dev\.m2' '-Dmaven.repo.local=C:\Dev\.m2\repository' -Dtest=OrderServiceTest test
