### PR TITLE
Account-Link-Richtung persistieren

### DIFF
--- a/src/main/java/de/fhdw/webshop/accountlink/AccountLink.java
+++ b/src/main/java/de/fhdw/webshop/accountlink/AccountLink.java
@@ -44,6 +44,14 @@ public class AccountLink {
     @JoinColumn(name = "user_b_id", nullable = false)
     private User userB;
 
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "source_user_id", nullable = false)
+    private User sourceUser;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "target_user_id", nullable = false)
+    private User targetUser;
+
     @Column(name = "max_order_value_limit", precision = 12, scale = 2)
     private BigDecimal maxOrderValueLimit;
 

--- a/src/main/java/de/fhdw/webshop/accountlink/AccountLinkService.java
+++ b/src/main/java/de/fhdw/webshop/accountlink/AccountLinkService.java
@@ -132,6 +132,8 @@ public class AccountLinkService {
             link.setUserA(targetUser);
             link.setUserB(sourceUser);
         }
+        link.setSourceUser(sourceUser);
+        link.setTargetUser(targetUser);
 
         AccountLink savedLink = accountLinkRepository.save(link);
         auditLogService.record(adminUser, "CREATE_ACCOUNT_LINK", "AccountLink", savedLink.getId(),
@@ -183,9 +185,13 @@ public class AccountLinkService {
 
     private AccountLinkResponse toResponse(AccountLink link, Long sourceUserId) {
         User linkedUser = linkedUser(link, sourceUserId);
+        User linkSourceUser = link.getSourceUser() != null ? link.getSourceUser() : link.getUserA();
+        User linkTargetUser = link.getTargetUser() != null ? link.getTargetUser() : link.getUserB();
         return new AccountLinkResponse(
                 link.getId(),
                 toProfileResponse(linkedUser),
+                toProfileResponse(linkSourceUser),
+                toProfileResponse(linkTargetUser),
                 link.getCreatedAt());
     }
 

--- a/src/main/java/de/fhdw/webshop/accountlink/dto/AccountLinkResponse.java
+++ b/src/main/java/de/fhdw/webshop/accountlink/dto/AccountLinkResponse.java
@@ -6,5 +6,7 @@ import java.time.Instant;
 public record AccountLinkResponse(
         Long id,
         UserProfileResponse linkedUser,
+        UserProfileResponse sourceUser,
+        UserProfileResponse targetUser,
         Instant createdAt
 ) {}

--- a/src/main/resources/db/migration/V47__add_account_link_direction.sql
+++ b/src/main/resources/db/migration/V47__add_account_link_direction.sql
@@ -1,0 +1,32 @@
+ALTER TABLE account_links
+    ADD COLUMN source_user_id BIGINT REFERENCES users(id) ON DELETE CASCADE,
+    ADD COLUMN target_user_id BIGINT REFERENCES users(id) ON DELETE CASCADE;
+
+UPDATE account_links
+SET source_user_id = parsed.source_user_id,
+    target_user_id = parsed.target_user_id
+FROM (
+    SELECT
+        entity_id AS account_link_id,
+        (regexp_match(details, 'Admin linked users ([0-9]+) and ([0-9]+)'))[1]::BIGINT AS source_user_id,
+        (regexp_match(details, 'Admin linked users ([0-9]+) and ([0-9]+)'))[2]::BIGINT AS target_user_id
+    FROM audit_log
+    WHERE action = 'CREATE_ACCOUNT_LINK'
+      AND entity_type = 'AccountLink'
+      AND details ~ 'Admin linked users [0-9]+ and [0-9]+'
+) parsed
+WHERE account_links.id = parsed.account_link_id;
+
+UPDATE account_links
+SET source_user_id = user_a_id,
+    target_user_id = user_b_id
+WHERE source_user_id IS NULL
+  AND target_user_id IS NULL;
+
+ALTER TABLE account_links
+    ALTER COLUMN source_user_id SET NOT NULL,
+    ALTER COLUMN target_user_id SET NOT NULL,
+    ADD CONSTRAINT chk_account_links_direction_distinct CHECK (source_user_id <> target_user_id);
+
+CREATE INDEX idx_account_links_source_user ON account_links(source_user_id);
+CREATE INDEX idx_account_links_target_user ON account_links(target_user_id);

--- a/src/main/resources/db/migration/V48__repair_account_link_direction_from_audit.sql
+++ b/src/main/resources/db/migration/V48__repair_account_link_direction_from_audit.sql
@@ -1,0 +1,16 @@
+UPDATE account_links
+SET source_user_id = parsed.source_user_id,
+    target_user_id = parsed.target_user_id
+FROM (
+    SELECT
+        entity_id AS account_link_id,
+        (regexp_match(details, 'Admin linked users ([0-9]+) and ([0-9]+)'))[1]::BIGINT AS source_user_id,
+        (regexp_match(details, 'Admin linked users ([0-9]+) and ([0-9]+)'))[2]::BIGINT AS target_user_id
+    FROM audit_log
+    WHERE action = 'CREATE_ACCOUNT_LINK'
+      AND entity_type = 'AccountLink'
+      AND details ~ 'Admin linked users [0-9]+ and [0-9]+'
+) parsed
+WHERE account_links.id = parsed.account_link_id
+  AND (account_links.source_user_id <> parsed.source_user_id
+       OR account_links.target_user_id <> parsed.target_user_id);

--- a/src/test/java/de/fhdw/webshop/accountlink/AccountLinkServiceTest.java
+++ b/src/test/java/de/fhdw/webshop/accountlink/AccountLinkServiceTest.java
@@ -1,5 +1,6 @@
 package de.fhdw.webshop.accountlink;
 
+import de.fhdw.webshop.accountlink.dto.AccountLinkResponse;
 import de.fhdw.webshop.accountlink.dto.TeamBudgetResponse;
 import de.fhdw.webshop.admin.AuditInitiator;
 import de.fhdw.webshop.admin.AuditLogService;
@@ -12,6 +13,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -23,6 +25,59 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class AccountLinkServiceTest {
+
+    @Test
+    void listsAccountLinksWithStoredDirection() {
+        AccountLinkRepository accountLinkRepository = mock(AccountLinkRepository.class);
+        UserRepository userRepository = mock(UserRepository.class);
+        AccountLinkService service = newService(accountLinkRepository, userRepository, mock(AuditLogService.class));
+        User viewedUser = businessCustomer(2L, "target");
+        User sourceUser = businessCustomer(1L, "source");
+        AccountLink link = link(9L, sourceUser, viewedUser, null);
+        link.setSourceUser(sourceUser);
+        link.setTargetUser(viewedUser);
+
+        when(userRepository.findById(2L)).thenReturn(Optional.of(viewedUser));
+        when(accountLinkRepository.findAllForUserId(2L)).thenReturn(List.of(link));
+
+        List<AccountLinkResponse> links = service.listLinks(2L);
+
+        assertThat(links).hasSize(1);
+        assertThat(links.getFirst().linkedUser().id()).isEqualTo(1L);
+        assertThat(links.getFirst().sourceUser().id()).isEqualTo(1L);
+        assertThat(links.getFirst().targetUser().id()).isEqualTo(2L);
+    }
+
+    @Test
+    void createLinksStoresSourceAndTargetDirection() {
+        AccountLinkRepository accountLinkRepository = mock(AccountLinkRepository.class);
+        UserRepository userRepository = mock(UserRepository.class);
+        AuditLogService auditLogService = mock(AuditLogService.class);
+        AccountLinkService service = newService(accountLinkRepository, userRepository, auditLogService);
+        User adminUser = businessCustomer(99L, "admin");
+        User sourceUser = businessCustomer(8L, "source");
+        User targetUser = businessCustomer(3L, "target");
+
+        when(userRepository.findById(8L)).thenReturn(Optional.of(sourceUser));
+        when(userRepository.findById(3L)).thenReturn(Optional.of(targetUser));
+        when(accountLinkRepository.existsByUserAIdAndUserBId(3L, 8L)).thenReturn(false);
+        when(accountLinkRepository.save(org.mockito.ArgumentMatchers.any(AccountLink.class)))
+                .thenAnswer(invocation -> {
+                    AccountLink saved = invocation.getArgument(0);
+                    saved.setId(15L);
+                    return saved;
+                });
+        when(accountLinkRepository.findAllForUserId(8L)).thenReturn(List.of());
+
+        service.createLinks(8L, List.of(3L), adminUser);
+
+        ArgumentCaptor<AccountLink> captor = ArgumentCaptor.forClass(AccountLink.class);
+        verify(accountLinkRepository).save(captor.capture());
+        assertThat(captor.getValue().getUserA().getId()).isEqualTo(3L);
+        assertThat(captor.getValue().getUserB().getId()).isEqualTo(8L);
+        assertThat(captor.getValue().getSourceUser().getId()).isEqualTo(8L);
+        assertThat(captor.getValue().getTargetUser().getId()).isEqualTo(3L);
+    }
 
     @Test
     void listsTeamBudgetsForBusinessCustomer() {


### PR DESCRIPTION
## Summary
- stores account link source and target users in the database
- returns sourceUser and targetUser through the account link API
- backfills and repairs existing directions from CREATE_ACCOUNT_LINK audit entries
- covers direction behavior with AccountLinkService tests

## Validation
- .\\mvnw.cmd '-Dmaven.multiModuleProjectDirectory=C:\\Dev\\Webshop-Backend' '-Dmaven.user.home=C:\\Dev\\.m2' '-Dmaven.repo.local=C:\\Dev\\.m2\\repository' -Dtest=AccountLinkServiceTest test