### PR TITLE
US-229: Produktvarianten verwalten

### DIFF
--- a/src/main/java/de/fhdw/webshop/product/Product.java
+++ b/src/main/java/de/fhdw/webshop/product/Product.java
@@ -7,6 +7,8 @@ import lombok.Setter;
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "products")
@@ -43,6 +45,28 @@ public class Product {
 
     @Column(nullable = false)
     private int stock = 25;
+
+    @Column(length = 100)
+    private String sku;
+
+    @Column(name = "has_variants", nullable = false)
+    private boolean hasVariants = false;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_product_id")
+    private Product parentProduct;
+
+    @OneToMany(mappedBy = "parentProduct", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("id ASC")
+    private List<Product> variants = new ArrayList<>();
+
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("displayOrder ASC")
+    private List<ProductVariantAttribute> variantAttributes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("displayOrder ASC")
+    private List<ProductVariantOption> variantOptions = new ArrayList<>();
 
     @Column(name = "warehouse_position", length = 80)
     private String warehousePosition;

--- a/src/main/java/de/fhdw/webshop/product/ProductController.java
+++ b/src/main/java/de/fhdw/webshop/product/ProductController.java
@@ -60,6 +60,15 @@ public class ProductController {
         return ResponseEntity.status(HttpStatus.CREATED).body(productService.createProduct(productRequest, currentUser));
     }
 
+    /** US #229 - Update article data including variant matrix. */
+    @PutMapping("/{id}")
+    @PreAuthorize("hasAnyRole('EMPLOYEE', 'SALES_EMPLOYEE', 'ADMIN')")
+    public ResponseEntity<ProductResponse> updateProduct(@PathVariable Long id,
+                                                         @Valid @RequestBody ProductRequest productRequest,
+                                                         @AuthenticationPrincipal User currentUser) {
+        return ResponseEntity.ok(productService.updateProduct(id, productRequest, currentUser));
+    }
+
     /** US #14 — Delete a product. */
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAnyRole('EMPLOYEE', 'SALES_EMPLOYEE', 'ADMIN')")
@@ -112,6 +121,15 @@ public class ProductController {
                                                        @Valid @RequestBody UpdatePriceRequest updatePriceRequest,
                                                        @AuthenticationPrincipal User currentUser) {
         return ResponseEntity.ok(productService.updatePrice(id, updatePriceRequest, currentUser));
+    }
+
+    /** US #229 - Update product or variant stock. */
+    @PutMapping("/{id}/stock")
+    @PreAuthorize("hasAnyRole('EMPLOYEE', 'SALES_EMPLOYEE', 'ADMIN')")
+    public ResponseEntity<ProductResponse> updateStock(@PathVariable Long id,
+                                                       @Valid @RequestBody UpdateStockRequest updateStockRequest,
+                                                       @AuthenticationPrincipal User currentUser) {
+        return ResponseEntity.ok(productService.updateStock(id, updateStockRequest, currentUser));
     }
 
     /** US #34 — Sales statistics (units sold, revenue) for a product over a date range. */

--- a/src/main/java/de/fhdw/webshop/product/ProductRepository.java
+++ b/src/main/java/de/fhdw/webshop/product/ProductRepository.java
@@ -31,7 +31,8 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
      */
     @Query("""
             SELECT p FROM Product p
-            WHERE (:purchasableOnly IS NULL OR p.purchasable = :purchasableOnly)
+            WHERE p.parentProduct IS NULL
+              AND (:purchasableOnly IS NULL OR p.purchasable = :purchasableOnly)
               AND (:category = '' OR LOWER(p.category) = LOWER(:category))
               AND (:filterByEcoScore = false OR p.ecoScore IN :ecoScores)
               AND (:searchTerm = ''

--- a/src/main/java/de/fhdw/webshop/product/ProductService.java
+++ b/src/main/java/de/fhdw/webshop/product/ProductService.java
@@ -11,8 +11,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -21,17 +27,17 @@ public class ProductService {
     private final ProductRepository productRepository;
     private final AuditLogService auditLogService;
 
+    @Transactional(readOnly = true)
     public List<ProductResponse> listProducts(Boolean purchasableOnly, String category, String searchTerm) {
         return listProducts(purchasableOnly, category, searchTerm, null);
     }
 
+    @Transactional(readOnly = true)
     public List<ProductResponse> listProducts(
             Boolean purchasableOnly,
             String category,
             String searchTerm,
             List<ProductEcoScore> ecoScores) {
-        // Normalize null Strings to "" — JPQL IS NULL on String params infers bytea in PostgreSQL,
-        // breaking LOWER(). The repository query uses = '' as the "no filter" sentinel instead.
         String normalizedCategory = (category == null) ? "" : category;
         String normalizedSearchTerm = (searchTerm == null) ? "" : searchTerm;
         boolean filterByEcoScore = ecoScores != null && !ecoScores.isEmpty();
@@ -49,11 +55,12 @@ public class ProductService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
     public ProductResponse getProduct(Long productId) {
         return toResponse(loadProduct(productId));
     }
 
-    /** US #31 — Returns the price after applying the customer's best active discount. */
+    @Transactional(readOnly = true)
     public ProductPriceResponse getPriceForCustomer(Long productId, User customer,
                                                     DiscountLookupPort discountLookupPort) {
         Product product = loadProduct(productId);
@@ -62,25 +69,32 @@ public class ProductService {
         return new ProductPriceResponse(productId, product.getRecommendedRetailPrice(), effectivePrice, bestDiscountPercent);
     }
 
-    /** US #13 — Add a new article to the catalogue. */
     @Transactional
     public ProductResponse createProduct(ProductRequest productRequest, User actingUser) {
         Product product = new Product();
-        product.setName(productRequest.name());
-        product.setDescription(productRequest.description());
-        product.setImageUrl(productRequest.imageUrl());
-        product.setRecommendedRetailPrice(productRequest.recommendedRetailPrice());
-        product.setCo2EmissionKg(productRequest.co2EmissionKg());
-        product.setEcoScore(productRequest.ecoScore() == null ? ProductEcoScore.NONE : productRequest.ecoScore());
-        product.setCategory(productRequest.category());
-        product.setStock(25);
+        applyProductRequest(product, productRequest);
         Product savedProduct = productRepository.save(product);
-        recordProductAction(actingUser, "CREATE_PRODUCT", savedProduct,
-                "Product created: " + savedProduct.getName());
+        syncVariants(savedProduct, productRequest);
+        Product savedWithVariants = productRepository.save(savedProduct);
+        recordProductAction(actingUser, "CREATE_PRODUCT", savedWithVariants,
+                "Product created: " + savedWithVariants.getName());
+        return toResponse(savedWithVariants);
+    }
+
+    @Transactional
+    public ProductResponse updateProduct(Long productId, ProductRequest productRequest, User actingUser) {
+        Product product = loadProduct(productId);
+        if (product.getParentProduct() != null) {
+            throw new IllegalArgumentException("Variant products must be edited through their parent product.");
+        }
+        applyProductRequest(product, productRequest);
+        syncVariants(product, productRequest);
+        Product savedProduct = productRepository.save(product);
+        recordProductAction(actingUser, "UPDATE_PRODUCT", savedProduct,
+                "Product updated: " + savedProduct.getName());
         return toResponse(savedProduct);
     }
 
-    /** US #14 — Remove an article from the catalogue. */
     @Transactional
     public void deleteProduct(Long productId, User actingUser) {
         Product product = loadProduct(productId);
@@ -89,18 +103,17 @@ public class ProductService {
                 "Product deleted: " + product.getName());
     }
 
-    /** US #15 — Toggle whether customers can see and buy the article. */
     @Transactional
     public ProductResponse setPurchasable(Long productId, boolean purchasable, User actingUser) {
         Product product = loadProduct(productId);
         product.setPurchasable(purchasable);
+        product.getVariants().forEach(variant -> variant.setPurchasable(purchasable));
         Product savedProduct = productRepository.save(product);
         recordProductAction(actingUser, "SET_PRODUCT_PURCHASABLE", savedProduct,
                 "Product purchasable set to " + purchasable + ": " + savedProduct.getName());
         return toResponse(savedProduct);
     }
 
-    /** US #26 — Toggle promoted flag (highlighted on storefront). */
     @Transactional
     public ProductResponse setPromoted(Long productId, boolean promoted, User actingUser) {
         Product product = loadProduct(productId);
@@ -111,18 +124,17 @@ public class ProductService {
         return toResponse(savedProduct);
     }
 
-    /** US #16 — Update description text. */
     @Transactional
     public ProductResponse updateDescription(Long productId, UpdateDescriptionRequest updateDescriptionRequest, User actingUser) {
         Product product = loadProduct(productId);
         product.setDescription(updateDescriptionRequest.description());
+        product.getVariants().forEach(variant -> variant.setDescription(updateDescriptionRequest.description()));
         Product savedProduct = productRepository.save(product);
         recordProductAction(actingUser, "UPDATE_PRODUCT_DESCRIPTION", savedProduct,
                 "Product description updated: " + savedProduct.getName());
         return toResponse(savedProduct);
     }
 
-    /** US #17 — Update product image URL. */
     @Transactional
     public ProductResponse updateImage(Long productId, UpdateImageRequest updateImageRequest, User actingUser) {
         Product product = loadProduct(productId);
@@ -133,7 +145,6 @@ public class ProductService {
         return toResponse(savedProduct);
     }
 
-    /** US #18 — Update recommended retail price (SALES_EMPLOYEE only). */
     @Transactional
     public ProductResponse updatePrice(Long productId, UpdatePriceRequest updatePriceRequest, User actingUser) {
         Product product = loadProduct(productId);
@@ -144,20 +155,30 @@ public class ProductService {
         return toResponse(savedProduct);
     }
 
-    /** US #196 — Update the estimated product CO2 footprint. */
     @Transactional
     public ProductResponse updateCo2Emission(Long productId, UpdateCo2EmissionRequest updateCo2EmissionRequest) {
         Product product = loadProduct(productId);
         product.setCo2EmissionKg(updateCo2EmissionRequest.co2EmissionKg());
+        product.getVariants().forEach(variant -> variant.setCo2EmissionKg(updateCo2EmissionRequest.co2EmissionKg()));
         return toResponse(productRepository.save(product));
     }
 
-    /** US #198 - Update the product Eco-Score. */
     @Transactional
     public ProductResponse updateEcoScore(Long productId, UpdateEcoScoreRequest updateEcoScoreRequest) {
         Product product = loadProduct(productId);
         product.setEcoScore(updateEcoScoreRequest.ecoScore());
+        product.getVariants().forEach(variant -> variant.setEcoScore(updateEcoScoreRequest.ecoScore()));
         return toResponse(productRepository.save(product));
+    }
+
+    @Transactional
+    public ProductResponse updateStock(Long productId, UpdateStockRequest updateStockRequest, User actingUser) {
+        Product product = loadProduct(productId);
+        product.setStock(updateStockRequest.stock());
+        Product savedProduct = productRepository.save(product);
+        recordProductAction(actingUser, "UPDATE_PRODUCT_STOCK", savedProduct,
+                "Product stock updated to " + updateStockRequest.stock() + ": " + savedProduct.getName());
+        return toResponse(savedProduct);
     }
 
     public Product loadProduct(Long productId) {
@@ -184,10 +205,275 @@ public class ProductService {
                 product.getEcoScore(),
                 product.getCategory(),
                 product.getStock(),
+                product.getSku(),
                 product.isPurchasable(),
                 product.isPromoted(),
+                product.isHasVariants(),
+                product.getParentProduct() == null ? null : product.getParentProduct().getId(),
+                toVariantValues(product),
+                product.getParentProduct() == null ? toAttributeResponses(product) : List.of(),
+                product.getParentProduct() == null
+                        ? product.getVariants().stream().map(this::toResponse).toList()
+                        : List.of(),
                 product.getCreatedAt()
         );
+    }
+
+    private void applyProductRequest(Product product, ProductRequest productRequest) {
+        product.setName(productRequest.name().trim());
+        product.setDescription(trimToNull(productRequest.description()));
+        product.setImageUrl(trimToNull(productRequest.imageUrl()));
+        product.setRecommendedRetailPrice(productRequest.recommendedRetailPrice());
+        product.setCo2EmissionKg(productRequest.co2EmissionKg());
+        product.setEcoScore(productRequest.ecoScore() == null ? ProductEcoScore.NONE : productRequest.ecoScore());
+        product.setCategory(trimToNull(productRequest.category()));
+        product.setStock(productRequest.stock() == null ? product.getStock() : productRequest.stock());
+        product.setSku(trimToNull(productRequest.sku()));
+        if (productRequest.purchasable() != null) {
+            product.setPurchasable(productRequest.purchasable());
+        }
+        product.setHasVariants(productRequest.hasVariants());
+    }
+
+    private void syncVariants(Product parent, ProductRequest productRequest) {
+        if (!productRequest.hasVariants()) {
+            parent.getVariantAttributes().clear();
+            parent.getVariants().clear();
+            return;
+        }
+
+        List<NormalizedAttribute> attributes = normalizeAttributes(productRequest.variantAttributes());
+        if (attributes.isEmpty()) {
+            parent.getVariantAttributes().clear();
+            parent.getVariants().clear();
+            parent.setHasVariants(false);
+            return;
+        }
+
+        replaceVariantAttributes(parent, attributes);
+        List<ProductVariantRequest> requestedVariants = normalizeVariantRequests(productRequest, attributes);
+        Set<String> desiredKeys = requestedVariants.stream()
+                .map(variant -> signature(normalizeVariantValues(variant.values(), attributes)))
+                .collect(LinkedHashSet::new, Set::add, Set::addAll);
+
+        parent.getVariants().removeIf(variant -> !desiredKeys.contains(signature(toVariantValues(variant))));
+        Map<Long, Product> existingById = new LinkedHashMap<>();
+        Map<String, Product> existingBySignature = new LinkedHashMap<>();
+        for (Product variant : parent.getVariants()) {
+            existingById.put(variant.getId(), variant);
+            existingBySignature.put(signature(toVariantValues(variant)), variant);
+        }
+
+        int index = 1;
+        for (ProductVariantRequest variantRequest : requestedVariants) {
+            Map<String, String> values = normalizeVariantValues(variantRequest.values(), attributes);
+            Product variant = variantRequest.id() == null ? null : existingById.get(variantRequest.id());
+            if (variant == null) {
+                variant = existingBySignature.get(signature(values));
+            }
+            if (variant == null) {
+                variant = new Product();
+                variant.setParentProduct(parent);
+                parent.getVariants().add(variant);
+            }
+            applyVariant(parent, variant, variantRequest, values, index++);
+        }
+    }
+
+    private void replaceVariantAttributes(Product parent, List<NormalizedAttribute> attributes) {
+        parent.getVariantAttributes().clear();
+        int attributeIndex = 0;
+        for (NormalizedAttribute normalizedAttribute : attributes) {
+            ProductVariantAttribute attribute = new ProductVariantAttribute();
+            attribute.setProduct(parent);
+            attribute.setName(normalizedAttribute.name());
+            attribute.setDisplayOrder(attributeIndex++);
+            int valueIndex = 0;
+            for (String value : normalizedAttribute.values()) {
+                ProductVariantAttributeValue attributeValue = new ProductVariantAttributeValue();
+                attributeValue.setAttribute(attribute);
+                attributeValue.setValue(value);
+                attributeValue.setDisplayOrder(valueIndex++);
+                attribute.getValues().add(attributeValue);
+            }
+            parent.getVariantAttributes().add(attribute);
+        }
+    }
+
+    private void applyVariant(Product parent, Product variant, ProductVariantRequest variantRequest,
+                              Map<String, String> values, int index) {
+        variant.setName(parent.getName() + " - " + String.join(" / ", values.values()));
+        variant.setDescription(parent.getDescription());
+        variant.setImageUrl(firstNonBlank(variantRequest.imageUrl(), parent.getImageUrl()));
+        variant.setRecommendedRetailPrice(variantRequest.recommendedRetailPrice() == null
+                ? parent.getRecommendedRetailPrice()
+                : variantRequest.recommendedRetailPrice());
+        variant.setCo2EmissionKg(parent.getCo2EmissionKg());
+        variant.setEcoScore(parent.getEcoScore());
+        variant.setCategory(parent.getCategory());
+        variant.setStock(variantRequest.stock() == null ? parent.getStock() : variantRequest.stock());
+        variant.setSku(firstNonBlank(variantRequest.sku(), buildGeneratedSku(parent, index)));
+        variant.setPurchasable(parent.isPurchasable());
+        variant.setPromoted(false);
+        variant.setHasVariants(false);
+
+        variant.getVariantOptions().clear();
+        int optionIndex = 0;
+        for (Map.Entry<String, String> entry : values.entrySet()) {
+            ProductVariantOption option = new ProductVariantOption();
+            option.setProduct(variant);
+            option.setAttributeName(entry.getKey());
+            option.setAttributeValue(entry.getValue());
+            option.setDisplayOrder(optionIndex++);
+            variant.getVariantOptions().add(option);
+        }
+    }
+
+    private List<ProductVariantRequest> normalizeVariantRequests(ProductRequest productRequest,
+                                                                 List<NormalizedAttribute> attributes) {
+        if (productRequest.variants() != null && !productRequest.variants().isEmpty()) {
+            return productRequest.variants().stream()
+                    .filter(Objects::nonNull)
+                    .filter(variant -> !normalizeVariantValues(variant.values(), attributes).isEmpty())
+                    .toList();
+        }
+
+        List<Map<String, String>> combinations = buildCombinations(attributes, 0, new LinkedHashMap<>());
+        List<ProductVariantRequest> generatedVariants = new ArrayList<>();
+        int index = 1;
+        for (Map<String, String> values : combinations) {
+            generatedVariants.add(new ProductVariantRequest(
+                    null,
+                    buildGeneratedSkuFromName(productRequest.sku(), productRequest.name(), index++),
+                    productRequest.recommendedRetailPrice(),
+                    productRequest.stock() == null ? 25 : productRequest.stock(),
+                    productRequest.imageUrl(),
+                    values
+            ));
+        }
+        return generatedVariants;
+    }
+
+    private List<Map<String, String>> buildCombinations(List<NormalizedAttribute> attributes, int attributeIndex,
+                                                        LinkedHashMap<String, String> current) {
+        if (attributeIndex >= attributes.size()) {
+            return List.of(new LinkedHashMap<>(current));
+        }
+
+        List<Map<String, String>> combinations = new ArrayList<>();
+        NormalizedAttribute attribute = attributes.get(attributeIndex);
+        for (String value : attribute.values()) {
+            current.put(attribute.name(), value);
+            combinations.addAll(buildCombinations(attributes, attributeIndex + 1, current));
+        }
+        current.remove(attribute.name());
+        return combinations;
+    }
+
+    private List<NormalizedAttribute> normalizeAttributes(List<ProductVariantAttributeRequest> attributes) {
+        if (attributes == null) {
+            return List.of();
+        }
+
+        List<NormalizedAttribute> normalizedAttributes = new ArrayList<>();
+        Set<String> seenNames = new LinkedHashSet<>();
+        for (ProductVariantAttributeRequest attribute : attributes) {
+            if (attribute == null || trimToNull(attribute.name()) == null) {
+                continue;
+            }
+            String name = attribute.name().trim();
+            if (!seenNames.add(name.toLowerCase())) {
+                continue;
+            }
+            List<String> values = normalizeValues(attribute.values());
+            if (!values.isEmpty()) {
+                normalizedAttributes.add(new NormalizedAttribute(name, values));
+            }
+        }
+        return normalizedAttributes;
+    }
+
+    private List<String> normalizeValues(List<String> values) {
+        if (values == null) {
+            return List.of();
+        }
+        List<String> normalizedValues = new ArrayList<>();
+        Set<String> seenValues = new LinkedHashSet<>();
+        for (String value : values) {
+            String normalizedValue = trimToNull(value);
+            if (normalizedValue != null && seenValues.add(normalizedValue.toLowerCase())) {
+                normalizedValues.add(normalizedValue);
+            }
+        }
+        return normalizedValues;
+    }
+
+    private Map<String, String> normalizeVariantValues(Map<String, String> values, List<NormalizedAttribute> attributes) {
+        if (values == null || values.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, String> normalizedValues = new LinkedHashMap<>();
+        for (NormalizedAttribute attribute : attributes) {
+            String value = values.get(attribute.name());
+            if (trimToNull(value) == null || !attribute.values().contains(value.trim())) {
+                return Map.of();
+            }
+            normalizedValues.put(attribute.name(), value.trim());
+        }
+        return normalizedValues;
+    }
+
+    private List<ProductVariantAttributeResponse> toAttributeResponses(Product product) {
+        return product.getVariantAttributes().stream()
+                .map(attribute -> new ProductVariantAttributeResponse(
+                        attribute.getName(),
+                        attribute.getValues().stream()
+                                .map(ProductVariantAttributeValue::getValue)
+                                .toList()))
+                .toList();
+    }
+
+    private Map<String, String> toVariantValues(Product product) {
+        Map<String, String> values = new LinkedHashMap<>();
+        product.getVariantOptions().stream()
+                .sorted((left, right) -> Integer.compare(left.getDisplayOrder(), right.getDisplayOrder()))
+                .forEach(option -> values.put(option.getAttributeName(), option.getAttributeValue()));
+        return values;
+    }
+
+    private String signature(Map<String, String> values) {
+        return values.entrySet().stream()
+                .map(entry -> entry.getKey().toLowerCase() + "=" + entry.getValue().toLowerCase())
+                .reduce((left, right) -> left + "|" + right)
+                .orElse("");
+    }
+
+    private String firstNonBlank(String first, String second) {
+        String normalizedFirst = trimToNull(first);
+        return normalizedFirst == null ? trimToNull(second) : normalizedFirst;
+    }
+
+    private String buildGeneratedSku(Product parent, int index) {
+        return buildGeneratedSkuFromName(parent.getSku(), parent.getName(), index);
+    }
+
+    private String buildGeneratedSkuFromName(String sku, String name, int index) {
+        String base = firstNonBlank(sku, name);
+        if (base == null) {
+            base = "PRODUCT";
+        }
+        String normalizedBase = base.trim()
+                .toUpperCase()
+                .replaceAll("[^A-Z0-9]+", "-")
+                .replaceAll("(^-|-$)", "");
+        return (normalizedBase.isBlank() ? "PRODUCT" : normalizedBase) + "-V" + index;
+    }
+
+    private String trimToNull(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return null;
+        }
+        return value.trim();
     }
 
     private void recordProductAction(User actingUser, String action, Product product, String details) {
@@ -200,7 +486,8 @@ public class ProductService {
                 details);
     }
 
-    /** Port interface so ProductService does not depend on the discount package directly. */
+    private record NormalizedAttribute(String name, List<String> values) {}
+
     @FunctionalInterface
     public interface DiscountLookupPort {
         BigDecimal findBestActiveDiscountPercent(Long customerId, Long productId);

--- a/src/main/java/de/fhdw/webshop/product/ProductVariantAttribute.java
+++ b/src/main/java/de/fhdw/webshop/product/ProductVariantAttribute.java
@@ -1,0 +1,35 @@
+package de.fhdw.webshop.product;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "product_variant_attributes")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ProductVariantAttribute {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "display_order", nullable = false)
+    private int displayOrder;
+
+    @OneToMany(mappedBy = "attribute", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("displayOrder ASC")
+    private List<ProductVariantAttributeValue> values = new ArrayList<>();
+}

--- a/src/main/java/de/fhdw/webshop/product/ProductVariantAttributeValue.java
+++ b/src/main/java/de/fhdw/webshop/product/ProductVariantAttributeValue.java
@@ -1,0 +1,28 @@
+package de.fhdw.webshop.product;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "product_variant_attribute_values")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ProductVariantAttributeValue {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "attribute_id", nullable = false)
+    private ProductVariantAttribute attribute;
+
+    @Column(nullable = false, length = 100)
+    private String value;
+
+    @Column(name = "display_order", nullable = false)
+    private int displayOrder;
+}

--- a/src/main/java/de/fhdw/webshop/product/ProductVariantOption.java
+++ b/src/main/java/de/fhdw/webshop/product/ProductVariantOption.java
@@ -1,0 +1,31 @@
+package de.fhdw.webshop.product;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "product_variant_options")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ProductVariantOption {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @Column(name = "attribute_name", nullable = false, length = 100)
+    private String attributeName;
+
+    @Column(name = "attribute_value", nullable = false, length = 100)
+    private String attributeValue;
+
+    @Column(name = "display_order", nullable = false)
+    private int displayOrder;
+}

--- a/src/main/java/de/fhdw/webshop/product/dto/ProductRequest.java
+++ b/src/main/java/de/fhdw/webshop/product/dto/ProductRequest.java
@@ -5,8 +5,10 @@ import de.fhdw.webshop.product.ProductEcoScore;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 public record ProductRequest(
         @NotBlank String name,
@@ -15,5 +17,11 @@ public record ProductRequest(
         @NotNull @DecimalMin("0.01") BigDecimal recommendedRetailPrice,
         @NotNull @DecimalMin("0.001") BigDecimal co2EmissionKg,
         ProductEcoScore ecoScore,
-        String category
+        String category,
+        @PositiveOrZero Integer stock,
+        String sku,
+        Boolean purchasable,
+        boolean hasVariants,
+        List<ProductVariantAttributeRequest> variantAttributes,
+        List<ProductVariantRequest> variants
 ) {}

--- a/src/main/java/de/fhdw/webshop/product/dto/ProductResponse.java
+++ b/src/main/java/de/fhdw/webshop/product/dto/ProductResponse.java
@@ -4,6 +4,8 @@ import de.fhdw.webshop.product.ProductEcoScore;
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.List;
+import java.util.Map;
 
 public record ProductResponse(
         Long id,
@@ -15,7 +17,13 @@ public record ProductResponse(
         ProductEcoScore ecoScore,
         String category,
         int stock,
+        String sku,
         boolean purchasable,
         boolean promoted,
+        boolean hasVariants,
+        Long parentProductId,
+        Map<String, String> variantValues,
+        List<ProductVariantAttributeResponse> variantAttributes,
+        List<ProductResponse> variants,
         Instant createdAt
 ) {}

--- a/src/main/java/de/fhdw/webshop/product/dto/ProductVariantAttributeRequest.java
+++ b/src/main/java/de/fhdw/webshop/product/dto/ProductVariantAttributeRequest.java
@@ -1,0 +1,10 @@
+package de.fhdw.webshop.product.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.List;
+
+public record ProductVariantAttributeRequest(
+        @NotBlank String name,
+        List<String> values
+) {}

--- a/src/main/java/de/fhdw/webshop/product/dto/ProductVariantAttributeResponse.java
+++ b/src/main/java/de/fhdw/webshop/product/dto/ProductVariantAttributeResponse.java
@@ -1,0 +1,8 @@
+package de.fhdw.webshop.product.dto;
+
+import java.util.List;
+
+public record ProductVariantAttributeResponse(
+        String name,
+        List<String> values
+) {}

--- a/src/main/java/de/fhdw/webshop/product/dto/ProductVariantRequest.java
+++ b/src/main/java/de/fhdw/webshop/product/dto/ProductVariantRequest.java
@@ -1,0 +1,16 @@
+package de.fhdw.webshop.product.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.PositiveOrZero;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+public record ProductVariantRequest(
+        Long id,
+        String sku,
+        @DecimalMin("0.01") BigDecimal recommendedRetailPrice,
+        @PositiveOrZero Integer stock,
+        String imageUrl,
+        Map<String, String> values
+) {}

--- a/src/main/java/de/fhdw/webshop/product/dto/UpdateStockRequest.java
+++ b/src/main/java/de/fhdw/webshop/product/dto/UpdateStockRequest.java
@@ -1,0 +1,7 @@
+package de.fhdw.webshop.product.dto;
+
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record UpdateStockRequest(
+        @PositiveOrZero int stock
+) {}

--- a/src/main/resources/db/migration/V50__add_product_variants.sql
+++ b/src/main/resources/db/migration/V50__add_product_variants.sql
@@ -1,0 +1,33 @@
+ALTER TABLE products
+    ADD COLUMN sku VARCHAR(100),
+    ADD COLUMN has_variants BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN parent_product_id BIGINT REFERENCES products(id) ON DELETE CASCADE;
+
+CREATE INDEX ix_products_sku ON products (sku) WHERE sku IS NOT NULL;
+CREATE INDEX ix_products_parent_product_id ON products (parent_product_id);
+
+CREATE TABLE product_variant_attributes (
+    id              BIGSERIAL       PRIMARY KEY,
+    product_id      BIGINT          NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+    name            VARCHAR(100)    NOT NULL,
+    display_order   INTEGER         NOT NULL DEFAULT 0
+);
+
+CREATE TABLE product_variant_attribute_values (
+    id              BIGSERIAL       PRIMARY KEY,
+    attribute_id    BIGINT          NOT NULL REFERENCES product_variant_attributes(id) ON DELETE CASCADE,
+    value           VARCHAR(100)    NOT NULL,
+    display_order   INTEGER         NOT NULL DEFAULT 0
+);
+
+CREATE TABLE product_variant_options (
+    id                  BIGSERIAL       PRIMARY KEY,
+    product_id          BIGINT          NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+    attribute_name      VARCHAR(100)    NOT NULL,
+    attribute_value     VARCHAR(100)    NOT NULL,
+    display_order       INTEGER         NOT NULL DEFAULT 0
+);
+
+CREATE INDEX ix_variant_attributes_product_id ON product_variant_attributes(product_id);
+CREATE INDEX ix_variant_attribute_values_attribute_id ON product_variant_attribute_values(attribute_id);
+CREATE INDEX ix_variant_options_product_id ON product_variant_options(product_id);

--- a/src/test/java/de/fhdw/webshop/product/ProductServiceVariantTest.java
+++ b/src/test/java/de/fhdw/webshop/product/ProductServiceVariantTest.java
@@ -1,0 +1,124 @@
+package de.fhdw.webshop.product;
+
+import de.fhdw.webshop.admin.AuditLogService;
+import de.fhdw.webshop.product.dto.ProductRequest;
+import de.fhdw.webshop.product.dto.ProductResponse;
+import de.fhdw.webshop.product.dto.ProductVariantAttributeRequest;
+import de.fhdw.webshop.product.dto.ProductVariantRequest;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ProductServiceVariantTest {
+
+    @Test
+    void createProductGeneratesVariantMatrixFromAttributes() {
+        ProductService service = serviceWithSavingRepository();
+        ProductRequest request = request(List.of());
+
+        ProductResponse response = service.createProduct(request, null);
+
+        assertThat(response.hasVariants()).isTrue();
+        assertThat(response.variantAttributes())
+                .extracting(attribute -> attribute.name())
+                .containsExactly("Farbe", "Groesse");
+        assertThat(response.variants()).hasSize(4);
+        assertThat(response.variants())
+                .extracting(ProductResponse::description)
+                .containsOnly("Atmungsaktives Team-Shirt");
+        assertThat(response.variants())
+                .extracting(ProductResponse::sku)
+                .containsExactly("TEAM-SHIRT-V1", "TEAM-SHIRT-V2", "TEAM-SHIRT-V3", "TEAM-SHIRT-V4");
+        assertThat(response.variants().getFirst().variantValues())
+                .containsEntry("Farbe", "Rot")
+                .containsEntry("Groesse", "S");
+    }
+
+    @Test
+    void createProductPersistsPerVariantOverrides() {
+        ProductService service = serviceWithSavingRepository();
+        ProductVariantRequest customVariant = new ProductVariantRequest(
+                null,
+                "SHIRT-ROT-S",
+                new BigDecimal("34.99"),
+                7,
+                "https://example.test/rot-s.jpg",
+                Map.of("Farbe", "Rot", "Groesse", "S")
+        );
+
+        ProductResponse response = service.createProduct(request(List.of(customVariant)), null);
+
+        assertThat(response.variants()).hasSize(1);
+        ProductResponse variant = response.variants().getFirst();
+        assertThat(variant.sku()).isEqualTo("SHIRT-ROT-S");
+        assertThat(variant.recommendedRetailPrice()).isEqualByComparingTo("34.99");
+        assertThat(variant.stock()).isEqualTo(7);
+        assertThat(variant.imageUrl()).isEqualTo("https://example.test/rot-s.jpg");
+        assertThat(variant.description()).isEqualTo(response.description());
+    }
+
+    @Test
+    void createProductAllowsUnavailableCombinationsToBeOmitted() {
+        ProductService service = serviceWithSavingRepository();
+        ProductVariantRequest redSmall = variant("SHIRT-ROT-S", "Rot", "S");
+        ProductVariantRequest blueMedium = variant("SHIRT-BLAU-M", "Blau", "M");
+
+        ProductResponse response = service.createProduct(request(List.of(redSmall, blueMedium)), null);
+
+        assertThat(response.variants()).hasSize(2);
+        assertThat(response.variants())
+                .extracting(ProductResponse::sku)
+                .containsExactly("SHIRT-ROT-S", "SHIRT-BLAU-M");
+        assertThat(response.variants())
+                .extracting(ProductResponse::variantValues)
+                .containsExactly(
+                        Map.of("Farbe", "Rot", "Groesse", "S"),
+                        Map.of("Farbe", "Blau", "Groesse", "M")
+                );
+    }
+
+    private ProductService serviceWithSavingRepository() {
+        ProductRepository productRepository = mock(ProductRepository.class);
+        when(productRepository.save(any(Product.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        return new ProductService(productRepository, mock(AuditLogService.class));
+    }
+
+    private ProductRequest request(List<ProductVariantRequest> variants) {
+        return new ProductRequest(
+                "Team Shirt",
+                "Atmungsaktives Team-Shirt",
+                "https://example.test/shirt.jpg",
+                new BigDecimal("29.99"),
+                new BigDecimal("1.250"),
+                ProductEcoScore.B,
+                "Textilien",
+                20,
+                "TEAM-SHIRT",
+                true,
+                true,
+                List.of(
+                        new ProductVariantAttributeRequest("Farbe", List.of("Rot", "Blau")),
+                        new ProductVariantAttributeRequest("Groesse", List.of("S", "M"))
+                ),
+                variants
+        );
+    }
+
+    private ProductVariantRequest variant(String sku, String color, String size) {
+        return new ProductVariantRequest(
+                null,
+                sku,
+                new BigDecimal("29.99"),
+                20,
+                "https://example.test/shirt.jpg",
+                Map.of("Farbe", color, "Groesse", size)
+        );
+    }
+}


### PR DESCRIPTION
## Änderungen
- erweitert Produkte um Variantenflag, SKU und Parent-/Kind-Produktbeziehungen
- ergänzt Flyway-Migrationen und DTOs für Variantenattribute, Variantenwerte und Variantenoptionen
- generiert und persistiert aktive Variantenkombinationen mit SKU, Preis, Bestand und Bild
- vererbt allgemeine Eigenschaften vom Elternprodukt auf Varianten

## Validierung
- mvnw -Dtest=ProductServiceVariantTest test
- gesamtes mvn test kompiliert, fällt aber in bestehenden AdminNavigationServiceTest-Erwartungen
- Frontend-Build separat grün