### PR TITLE
feat(agb): #249 AGB-Versionierung mit DB-Tabelle, Endpoint und Checko…

### DIFF
--- a/src/main/java/de/fhdw/webshop/accountlink/AccountLinkService.java
+++ b/src/main/java/de/fhdw/webshop/accountlink/AccountLinkService.java
@@ -217,6 +217,7 @@ public class AccountLinkService {
                 user.getRoles(),
                 user.getUserType(),
                 user.getCustomerNumber(),
-                user.isActive());
+                user.isActive(),
+                user.getAgbAcceptedAt());
     }
 }

--- a/src/main/java/de/fhdw/webshop/admin/AdminController.java
+++ b/src/main/java/de/fhdw/webshop/admin/AdminController.java
@@ -61,7 +61,7 @@ public class AdminController {
                 .map(user -> new UserProfileResponse(
                         user.getId(), user.getUsername(), user.getEmail(),
                         user.getRoles(), user.getUserType(), user.getCustomerNumber(),
-                        user.isActive()))
+                        user.isActive(), user.getAgbAcceptedAt()))
                 .toList();
         return ResponseEntity.ok(users);
     }
@@ -190,7 +190,8 @@ public class AdminController {
                 user.getRoles(),
                 user.getUserType(),
                 user.getCustomerNumber(),
-                user.isActive());
+                user.isActive(),
+                user.getAgbAcceptedAt());
     }
 
     @PatchMapping("/users/{id}/deactivate")

--- a/src/main/java/de/fhdw/webshop/agb/AgbController.java
+++ b/src/main/java/de/fhdw/webshop/agb/AgbController.java
@@ -1,0 +1,33 @@
+package de.fhdw.webshop.agb;
+
+import de.fhdw.webshop.agb.dto.AgbVersionResponse;
+import de.fhdw.webshop.agb.dto.CreateAgbVersionRequest;
+import de.fhdw.webshop.user.User;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class AgbController {
+
+    private final AgbService agbService;
+
+    @GetMapping("/api/agb/latest")
+    public ResponseEntity<AgbVersionResponse> getLatest() {
+        return ResponseEntity.ok(agbService.getLatestVersion());
+    }
+
+    @PostMapping("/api/admin/agb")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<AgbVersionResponse> createVersion(
+            @Valid @RequestBody CreateAgbVersionRequest request,
+            @AuthenticationPrincipal User currentUser) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(agbService.createNewVersion(request.agbText(), currentUser));
+    }
+}

--- a/src/main/java/de/fhdw/webshop/agb/AgbDataInitializer.java
+++ b/src/main/java/de/fhdw/webshop/agb/AgbDataInitializer.java
@@ -1,0 +1,18 @@
+package de.fhdw.webshop.agb;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AgbDataInitializer implements ApplicationRunner {
+
+    private final AgbService agbService;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        agbService.seedInitialAgbIfMissing();
+    }
+}

--- a/src/main/java/de/fhdw/webshop/agb/AgbService.java
+++ b/src/main/java/de/fhdw/webshop/agb/AgbService.java
@@ -1,0 +1,126 @@
+package de.fhdw.webshop.agb;
+
+import de.fhdw.webshop.admin.AuditInitiator;
+import de.fhdw.webshop.admin.AuditLogService;
+import de.fhdw.webshop.agb.dto.AgbVersionResponse;
+import de.fhdw.webshop.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+
+@Service
+@RequiredArgsConstructor
+public class AgbService {
+
+    static final String INITIAL_AGB_TEXT =
+            "# Allgemeine Geschäftsbedingungen\n\n" +
+            "## 1. Geltungsbereich\n\n" +
+            "Diese Allgemeinen Geschäftsbedingungen gelten für alle Bestellungen, die Verbraucher und " +
+            "Unternehmer über den Online-Shop von Fachhochschule der Wirtschaft (FHDW) gGmbH abgeben. " +
+            "Verbraucher ist jede natürliche Person, die ein Rechtsgeschäft zu Zwecken abschließt, die " +
+            "überwiegend weder ihrer gewerblichen noch ihrer selbstständigen beruflichen Tätigkeit " +
+            "zugerechnet werden können. Unternehmer ist jede natürliche oder juristische Person oder " +
+            "rechtsfähige Personengesellschaft, die bei Abschluss eines Rechtsgeschäfts in Ausübung " +
+            "ihrer gewerblichen oder selbstständigen beruflichen Tätigkeit handelt.\n\n" +
+            "## 2. Vertragspartner\n\n" +
+            "Der Kaufvertrag kommt zustande mit Fachhochschule der Wirtschaft (FHDW) gGmbH, " +
+            "Hauptstraße 2, 51465 Bergisch Gladbach.\n\n" +
+            "## 3. Angebot und Vertragsschluss\n\n" +
+            "- Die Darstellung der Produkte im Online-Shop stellt noch kein rechtlich bindendes Angebot, " +
+            "sondern eine unverbindliche Aufforderung zur Bestellung dar.\n" +
+            "- Durch Anklicken des Buttons \"Jetzt verbindlich bestellen\" geben Sie ein verbindliches " +
+            "Angebot zum Abschluss eines Kaufvertrags ab.\n" +
+            "- Der Vertrag kommt erst zustande, wenn wir die Bestellung durch eine Auftragsbestätigung " +
+            "per E-Mail annehmen oder die Ware versenden.\n" +
+            "- Wir können Bestellungen ablehnen, wenn Produkte nicht verfügbar sind, Preis- oder " +
+            "Systemfehler vorliegen oder Missbrauchsverdacht besteht.\n\n" +
+            "## 4. Kundenkonto\n\n" +
+            "Bestellungen können - je nach Shop-Funktion - über ein Kundenkonto oder als Gast erfolgen. " +
+            "Zugangsdaten sind vertraulich zu behandeln. Nutzer sind verpflichtet, ihre Angaben im " +
+            "Kundenkonto aktuell und wahrheitsgemäß zu halten.\n\n" +
+            "## 5. Preise und Versandkosten\n\n" +
+            "Sämtliche im Shop ausgewiesenen Preise verstehen sich in Euro inklusive gesetzlicher " +
+            "Umsatzsteuer, soweit nicht ausdrücklich anders gekennzeichnet. Hinzu kommen die im " +
+            "Bestellprozess transparent ausgewiesenen Versandkosten.\n\n" +
+            "Rabatte, Gutscheine und kundenspezifische Preislogiken werden nur nach Maßgabe der jeweils " +
+            "im Warenkorb und Checkout angezeigten Bedingungen berücksichtigt.\n\n" +
+            "## 6. Zahlungsbedingungen\n\n" +
+            "Die jeweils verfügbaren Zahlungsarten werden Ihnen im Checkout angezeigt. Die Belastung oder " +
+            "Zahlungsanweisung erfolgt gemäß der ausgewählten Zahlungsart. Wir behalten uns vor, " +
+            "bestimmte Zahlungsarten im Einzelfall nicht anzubieten.\n\n" +
+            "## 7. Lieferbedingungen\n\n" +
+            "- Lieferungen erfolgen an die von Ihnen im Bestellprozess angegebene Lieferadresse.\n" +
+            "- Angegebene Lieferzeiten verstehen sich als realistische Regellaufzeiten und stehen unter " +
+            "dem Vorbehalt ordnungsgemäßer Selbstbelieferung sowie unvorhersehbarer Störungen.\n" +
+            "- Teillieferungen sind zulässig, soweit dies für Sie zumutbar ist.\n" +
+            "- Ist eine Zustellung wiederholt nicht möglich, können wir vom Vertrag zurücktreten, " +
+            "nachdem wir Sie erfolglos kontaktiert haben.\n\n" +
+            "## 8. Eigentumsvorbehalt\n\n" +
+            "Die Ware bleibt bis zur vollständigen Bezahlung unser Eigentum. Gegenüber Unternehmern gilt " +
+            "dies bis zur vollständigen Begleichung sämtlicher Forderungen aus der laufenden " +
+            "Geschäftsbeziehung.\n\n" +
+            "## 9. Gewährleistung und Haftung für Mängel\n\n" +
+            "Es gelten die gesetzlichen Mängelhaftungsrechte. Gegenüber Unternehmern beträgt die " +
+            "Gewährleistungsfrist für neu hergestellte Sachen ein Jahr ab Gefahrübergang, soweit " +
+            "gesetzlich zulässig und nicht zwingende Vorschriften entgegenstehen.\n\n" +
+            "## 10. Haftung\n\n" +
+            "- Wir haften unbeschränkt bei Vorsatz, grober Fahrlässigkeit, bei Verletzung von Leben, " +
+            "Körper oder Gesundheit sowie nach zwingenden gesetzlichen Vorschriften.\n" +
+            "- Bei leicht fahrlässiger Verletzung wesentlicher Vertragspflichten ist unsere Haftung auf " +
+            "den vertragstypischen, vorhersehbaren Schaden begrenzt.\n" +
+            "- Im Übrigen ist die Haftung für leicht fahrlässige Pflichtverletzungen ausgeschlossen.\n\n" +
+            "## 11. Anwendbares Recht\n\n" +
+            "Es gilt deutsches Recht unter Ausschluss des UN-Kaufrechts. Gegenüber Verbrauchern gilt " +
+            "diese Rechtswahl nur insoweit, als dadurch nicht der Schutz zwingender Bestimmungen des " +
+            "Rechts des Staates entzogen wird, in dem der Verbraucher seinen gewöhnlichen Aufenthalt hat.\n\n" +
+            "## 12. Streitbeilegung\n\n" +
+            "Wir sind grundsätzlich nicht bereit und nicht verpflichtet, an Streitbeilegungsverfahren vor " +
+            "einer Verbraucherschlichtungsstelle teilzunehmen, sofern keine gesetzliche Verpflichtung besteht.";
+
+    static final Instant INITIAL_AGB_CREATED_AT = Instant.parse("2026-04-21T00:00:00Z");
+
+    private final AgbVersionRepository agbVersionRepository;
+    private final AuditLogService auditLogService;
+
+    public AgbVersionResponse getLatestVersion() {
+        return agbVersionRepository.findTopByOrderByCreatedAtDesc()
+                .map(v -> new AgbVersionResponse(v.getId(), v.getAgbText(), v.getCreatedAt()))
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Keine AGB-Version gefunden"));
+    }
+
+    @Transactional
+    public AgbVersionResponse createNewVersion(String agbText, User admin) {
+        AgbVersion version = new AgbVersion();
+        version.setAgbText(agbText);
+        AgbVersion saved = agbVersionRepository.save(version);
+        auditLogService.record(admin, "CREATE_AGB_VERSION", "AgbVersion", saved.getId(),
+                AuditInitiator.ADMIN, "Neue AGB-Version erstellt: " + saved.getCreatedAt());
+        return new AgbVersionResponse(saved.getId(), saved.getAgbText(), saved.getCreatedAt());
+    }
+
+    @Transactional
+    public void seedInitialAgbIfMissing() {
+        if (agbVersionRepository.count() > 0) {
+            return;
+        }
+        AgbVersion initial = new AgbVersion();
+        initial.setAgbText(INITIAL_AGB_TEXT);
+        initial.setCreatedAt(INITIAL_AGB_CREATED_AT);
+        agbVersionRepository.save(initial);
+    }
+
+    public boolean userNeedsToAcceptAgb(User user) {
+        if (user.getAgbAcceptedAt() == null) {
+            return true;
+        }
+        var latest = agbVersionRepository.findTopByOrderByCreatedAtDesc();
+        if (latest.isEmpty()) {
+            return false;
+        }
+        return user.getAgbAcceptedAt().isBefore(latest.get().getCreatedAt());
+    }
+}

--- a/src/main/java/de/fhdw/webshop/agb/AgbVersion.java
+++ b/src/main/java/de/fhdw/webshop/agb/AgbVersion.java
@@ -1,0 +1,26 @@
+package de.fhdw.webshop.agb;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "agb_versions")
+@Getter
+@Setter
+@NoArgsConstructor
+public class AgbVersion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "agb_text", nullable = false, columnDefinition = "TEXT")
+    private String agbText;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt = Instant.now();
+}

--- a/src/main/java/de/fhdw/webshop/agb/AgbVersionRepository.java
+++ b/src/main/java/de/fhdw/webshop/agb/AgbVersionRepository.java
@@ -1,0 +1,9 @@
+package de.fhdw.webshop.agb;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AgbVersionRepository extends JpaRepository<AgbVersion, Long> {
+    Optional<AgbVersion> findTopByOrderByCreatedAtDesc();
+}

--- a/src/main/java/de/fhdw/webshop/agb/dto/AgbVersionResponse.java
+++ b/src/main/java/de/fhdw/webshop/agb/dto/AgbVersionResponse.java
@@ -1,0 +1,5 @@
+package de.fhdw.webshop.agb.dto;
+
+import java.time.Instant;
+
+public record AgbVersionResponse(Long id, String agbText, Instant createdAt) {}

--- a/src/main/java/de/fhdw/webshop/agb/dto/CreateAgbVersionRequest.java
+++ b/src/main/java/de/fhdw/webshop/agb/dto/CreateAgbVersionRequest.java
@@ -1,0 +1,8 @@
+package de.fhdw.webshop.agb.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreateAgbVersionRequest(
+    @NotBlank @Size(min = 10, max = 100_000) String agbText
+) {}

--- a/src/main/java/de/fhdw/webshop/config/SecurityConfig.java
+++ b/src/main/java/de/fhdw/webshop/config/SecurityConfig.java
@@ -58,6 +58,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/health").permitAll()
                         // Actuator endpoints — only reachable on internal management port 8081 (not exposed via Docker)
                         .requestMatchers("/actuator/**").permitAll()
+                        // AGB – latest version readable without login (shown on /agb page and checkout)
+                        .requestMatchers(HttpMethod.GET, "/api/agb/latest").permitAll()
                         // Shoppi chatbot — public, auth-aware (personal context only when authenticated)
                         .requestMatchers(HttpMethod.POST, "/api/chat/message").permitAll()
                         // All other endpoints require authentication

--- a/src/main/java/de/fhdw/webshop/customer/CustomerController.java
+++ b/src/main/java/de/fhdw/webshop/customer/CustomerController.java
@@ -79,7 +79,8 @@ public class CustomerController {
                         user.getRoles(),
                         user.getUserType(),
                         user.getCustomerNumber(),
-                        user.isActive()))
+                        user.isActive(),
+                        user.getAgbAcceptedAt()))
                 .toList();
         return ResponseEntity.ok(customers);
     }
@@ -108,7 +109,8 @@ public class CustomerController {
                 customer.getRoles(),
                 customer.getUserType(),
                 customer.getCustomerNumber(),
-                customer.isActive()));
+                customer.isActive(),
+                customer.getAgbAcceptedAt()));
     }
 
     /** US #11 - View a customer's cart on their behalf. */
@@ -256,7 +258,8 @@ public class CustomerController {
                 customer.getRoles(),
                 customer.getUserType(),
                 customer.getCustomerNumber(),
-                customer.isActive());
+                customer.isActive(),
+                customer.getAgbAcceptedAt());
 
         CartResponse cart = cartService.getCart(id);
         BigDecimal cartTotal = cart != null && cart.total() != null ? cart.total() : BigDecimal.ZERO;

--- a/src/main/java/de/fhdw/webshop/order/OrderService.java
+++ b/src/main/java/de/fhdw/webshop/order/OrderService.java
@@ -6,6 +6,7 @@ import de.fhdw.webshop.address.AddressLookupService;
 import de.fhdw.webshop.address.AddressValidationRequest;
 import de.fhdw.webshop.address.AddressValidationResponse;
 import de.fhdw.webshop.accountlink.AccountLinkRepository;
+import de.fhdw.webshop.agb.AgbService;
 import de.fhdw.webshop.cart.CartItem;
 import de.fhdw.webshop.cart.CartService;
 import de.fhdw.webshop.cart.CartRepository;
@@ -27,6 +28,7 @@ import de.fhdw.webshop.user.PaymentMethod;
 import de.fhdw.webshop.user.PaymentMethodRepository;
 import de.fhdw.webshop.user.PaymentMethodSupport;
 import de.fhdw.webshop.user.User;
+import de.fhdw.webshop.user.UserRepository;
 import de.fhdw.webshop.user.UserService;
 import de.fhdw.webshop.user.UserRole;
 import de.fhdw.webshop.user.UserType;
@@ -78,6 +80,8 @@ public class OrderService {
     private final DeliveryAddressRepository deliveryAddressRepository;
     private final PaymentMethodRepository paymentMethodRepository;
     private final UserService userService;
+    private final UserRepository userRepository;
+    private final AgbService agbService;
     private final AuditLogService auditLogService;
     private final EmailService emailService;
     private final AddressLookupService addressLookupService;
@@ -181,7 +185,17 @@ public class OrderService {
     /** US #42 - Convert the current cart into a confirmed order. Coupon reduces the order subtotal. */
     @Transactional
     public OrderResponse placeOrder(User customer, PlaceOrderRequest placeOrderRequest) {
-        validateLegalAcceptance(placeOrderRequest);
+        boolean needsAcceptance = agbService.userNeedsToAcceptAgb(customer);
+        if (needsAcceptance) {
+            if (!Boolean.TRUE.equals(placeOrderRequest != null ? placeOrderRequest.acceptedTermsAndConditions() : null)) {
+                throw new IllegalArgumentException("Bitte akzeptiere die aktuellen AGB vor der Bestellung.");
+            }
+            customer.setAgbAcceptedAt(Instant.now());
+            userRepository.save(customer);
+        }
+        if (placeOrderRequest == null || !Boolean.TRUE.equals(placeOrderRequest.acceptedPrivacyPolicy())) {
+            throw new IllegalArgumentException("Bitte akzeptiere AGB, Widerrufsbelehrung und Datenschutzhinweise vor der Bestellung");
+        }
         PreparedOrder preparedOrder = prepareCustomerOrder(customer, placeOrderRequest);
         DeliveryAddressRequest deliveryAddressRequest = placeOrderRequest != null ? placeOrderRequest.deliveryAddress() : null;
         PaymentMethodRequest paymentMethodRequest = placeOrderRequest != null ? placeOrderRequest.paymentMethod() : null;

--- a/src/main/java/de/fhdw/webshop/user/User.java
+++ b/src/main/java/de/fhdw/webshop/user/User.java
@@ -72,6 +72,9 @@ public class User implements UserDetails {
     @Column(name = "current_login_streak", nullable = false)
     private int currentLoginStreak = 0;
 
+    @Column(name = "agb_accepted_at")
+    private Instant agbAcceptedAt;
+
     // ── Convenience helpers ────────────────────────────────────────────────────
 
     public boolean hasRole(UserRole role) {

--- a/src/main/java/de/fhdw/webshop/user/UserService.java
+++ b/src/main/java/de/fhdw/webshop/user/UserService.java
@@ -109,7 +109,8 @@ public class UserService {
                 user.getRoles(),
                 user.getUserType(),
                 user.getCustomerNumber(),
-                user.isActive()
+                user.isActive(),
+                user.getAgbAcceptedAt()
         );
     }
 

--- a/src/main/java/de/fhdw/webshop/user/dto/UserProfileResponse.java
+++ b/src/main/java/de/fhdw/webshop/user/dto/UserProfileResponse.java
@@ -3,6 +3,7 @@ package de.fhdw.webshop.user.dto;
 import de.fhdw.webshop.user.UserRole;
 import de.fhdw.webshop.user.UserType;
 
+import java.time.Instant;
 import java.util.Set;
 
 public record UserProfileResponse(
@@ -12,5 +13,6 @@ public record UserProfileResponse(
         Set<UserRole> roles,
         UserType userType,
         String customerNumber,
-        boolean active
+        boolean active,
+        Instant agbAcceptedAt
 ) {}

--- a/src/main/resources/db/migration/V50__create_agb_versions.sql
+++ b/src/main/resources/db/migration/V50__create_agb_versions.sql
@@ -1,0 +1,71 @@
+CREATE TABLE agb_versions (
+    id         BIGSERIAL    PRIMARY KEY,
+    agb_text   TEXT         NOT NULL,
+    created_at TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE users
+    ADD COLUMN agb_accepted_at TIMESTAMPTZ;
+
+INSERT INTO agb_versions (agb_text, created_at)
+SELECT $$# Allgemeine Geschäftsbedingungen
+
+## 1. Geltungsbereich
+
+Diese Allgemeinen Geschäftsbedingungen gelten für alle Bestellungen, die Verbraucher und Unternehmer über den Online-Shop von Fachhochschule der Wirtschaft (FHDW) gGmbH abgeben. Verbraucher ist jede natürliche Person, die ein Rechtsgeschäft zu Zwecken abschließt, die überwiegend weder ihrer gewerblichen noch ihrer selbstständigen beruflichen Tätigkeit zugerechnet werden können. Unternehmer ist jede natürliche oder juristische Person oder rechtsfähige Personengesellschaft, die bei Abschluss eines Rechtsgeschäfts in Ausübung ihrer gewerblichen oder selbstständigen beruflichen Tätigkeit handelt.
+
+## 2. Vertragspartner
+
+Der Kaufvertrag kommt zustande mit Fachhochschule der Wirtschaft (FHDW) gGmbH, Hauptstraße 2, 51465 Bergisch Gladbach.
+
+## 3. Angebot und Vertragsschluss
+
+- Die Darstellung der Produkte im Online-Shop stellt noch kein rechtlich bindendes Angebot, sondern eine unverbindliche Aufforderung zur Bestellung dar.
+- Durch Anklicken des Buttons "Jetzt verbindlich bestellen" geben Sie ein verbindliches Angebot zum Abschluss eines Kaufvertrags ab.
+- Der Vertrag kommt erst zustande, wenn wir die Bestellung durch eine Auftragsbestätigung per E-Mail annehmen oder die Ware versenden.
+- Wir können Bestellungen ablehnen, wenn Produkte nicht verfügbar sind, Preis- oder Systemfehler vorliegen oder Missbrauchsverdacht besteht.
+
+## 4. Kundenkonto
+
+Bestellungen können - je nach Shop-Funktion - über ein Kundenkonto oder als Gast erfolgen. Zugangsdaten sind vertraulich zu behandeln. Nutzer sind verpflichtet, ihre Angaben im Kundenkonto aktuell und wahrheitsgemäß zu halten.
+
+## 5. Preise und Versandkosten
+
+Sämtliche im Shop ausgewiesenen Preise verstehen sich in Euro inklusive gesetzlicher Umsatzsteuer, soweit nicht ausdrücklich anders gekennzeichnet. Hinzu kommen die im Bestellprozess transparent ausgewiesenen Versandkosten.
+
+Rabatte, Gutscheine und kundenspezifische Preislogiken werden nur nach Maßgabe der jeweils im Warenkorb und Checkout angezeigten Bedingungen berücksichtigt.
+
+## 6. Zahlungsbedingungen
+
+Die jeweils verfügbaren Zahlungsarten werden Ihnen im Checkout angezeigt. Die Belastung oder Zahlungsanweisung erfolgt gemäß der ausgewählten Zahlungsart. Wir behalten uns vor, bestimmte Zahlungsarten im Einzelfall nicht anzubieten.
+
+## 7. Lieferbedingungen
+
+- Lieferungen erfolgen an die von Ihnen im Bestellprozess angegebene Lieferadresse.
+- Angegebene Lieferzeiten verstehen sich als realistische Regellaufzeiten und stehen unter dem Vorbehalt ordnungsgemäßer Selbstbelieferung sowie unvorhersehbarer Störungen.
+- Teillieferungen sind zulässig, soweit dies für Sie zumutbar ist.
+- Ist eine Zustellung wiederholt nicht möglich, können wir vom Vertrag zurücktreten, nachdem wir Sie erfolglos kontaktiert haben.
+
+## 8. Eigentumsvorbehalt
+
+Die Ware bleibt bis zur vollständigen Bezahlung unser Eigentum. Gegenüber Unternehmern gilt dies bis zur vollständigen Begleichung sämtlicher Forderungen aus der laufenden Geschäftsbeziehung.
+
+## 9. Gewährleistung und Haftung für Mängel
+
+Es gelten die gesetzlichen Mängelhaftungsrechte. Gegenüber Unternehmern beträgt die Gewährleistungsfrist für neu hergestellte Sachen ein Jahr ab Gefahrübergang, soweit gesetzlich zulässig und nicht zwingende Vorschriften entgegenstehen.
+
+## 10. Haftung
+
+- Wir haften unbeschränkt bei Vorsatz, grober Fahrlässigkeit, bei Verletzung von Leben, Körper oder Gesundheit sowie nach zwingenden gesetzlichen Vorschriften.
+- Bei leicht fahrlässiger Verletzung wesentlicher Vertragspflichten ist unsere Haftung auf den vertragstypischen, vorhersehbaren Schaden begrenzt.
+- Im Übrigen ist die Haftung für leicht fahrlässige Pflichtverletzungen ausgeschlossen.
+
+## 11. Anwendbares Recht
+
+Es gilt deutsches Recht unter Ausschluss des UN-Kaufrechts. Gegenüber Verbrauchern gilt diese Rechtswahl nur insoweit, als dadurch nicht der Schutz zwingender Bestimmungen des Rechts des Staates entzogen wird, in dem der Verbraucher seinen gewöhnlichen Aufenthalt hat.
+
+## 12. Streitbeilegung
+
+Wir sind grundsätzlich nicht bereit und nicht verpflichtet, an Streitbeilegungsverfahren vor einer Verbraucherschlichtungsstelle teilzunehmen, sofern keine gesetzliche Verpflichtung besteht.$$,
+'2026-04-21 00:00:00+00'
+WHERE NOT EXISTS (SELECT 1 FROM agb_versions);

--- a/src/test/java/de/fhdw/webshop/order/OrderServiceTest.java
+++ b/src/test/java/de/fhdw/webshop/order/OrderServiceTest.java
@@ -5,6 +5,8 @@ import de.fhdw.webshop.accountlink.AccountLinkRepository;
 import de.fhdw.webshop.address.AddressLookupService;
 import de.fhdw.webshop.address.AddressValidationResponse;
 import de.fhdw.webshop.admin.AuditLogService;
+import de.fhdw.webshop.agb.AgbService;
+import de.fhdw.webshop.user.UserRepository;
 import de.fhdw.webshop.cart.CartItem;
 import de.fhdw.webshop.cart.CartRepository;
 import de.fhdw.webshop.cart.CartService;
@@ -156,6 +158,8 @@ class OrderServiceTest {
         DeliveryAddressRepository deliveryAddressRepository = mock(DeliveryAddressRepository.class);
         PaymentMethodRepository paymentMethodRepository = mock(PaymentMethodRepository.class);
         UserService userService = mock(UserService.class);
+        UserRepository userRepository = mock(UserRepository.class);
+        AgbService agbService = mock(AgbService.class);
         AuditLogService auditLogService = mock(AuditLogService.class);
         EmailService emailService = mock(EmailService.class);
         AddressLookupService addressLookupService = mock(AddressLookupService.class);
@@ -172,6 +176,8 @@ class OrderServiceTest {
                 deliveryAddressRepository,
                 paymentMethodRepository,
                 userService,
+                userRepository,
+                agbService,
                 auditLogService,
                 emailService,
                 addressLookupService,


### PR DESCRIPTION
…ut-Validierung

- V50-Migration: Tabelle agb_versions (id, agb_text, created_at) und agb_accepted_at auf users
- Neues Package de.fhdw.webshop.agb: AgbVersion Entity, Repository, Service, Controller, DTOs
- AgbDataInitializer: schreibt initiale AGB automatisch beim Start, falls DB leer
- GET /api/agb/latest public, POST /api/admin/agb nur für ADMIN
- OrderService.placeOrder: AGB-Timestamp-Vergleich, agbAcceptedAt wird bei Akzeptanz gesetzt
- UserProfileResponse um agbAcceptedAt erweitert (AccountLinkService, AdminController, CustomerController angepasst)
- SecurityConfig: GET /api/agb/latest als öffentlicher Endpunkt freigegeben
- OrderServiceTest: Mocks für UserRepository und AgbService ergänzt