### PR TITLE
#142 Click-and-Collect Store-Auswahl im Backend

### DIFF
--- a/src/main/java/de/fhdw/webshop/config/SecurityConfig.java
+++ b/src/main/java/de/fhdw/webshop/config/SecurityConfig.java
@@ -45,6 +45,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/products").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/products/{id}").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/advertisements/active").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/pickup-stores").permitAll()
                         .requestMatchers("/api/address-lookup").permitAll()
                         .requestMatchers("/api/address-lookup/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/orders/checkout").permitAll()

--- a/src/main/java/de/fhdw/webshop/order/Order.java
+++ b/src/main/java/de/fhdw/webshop/order/Order.java
@@ -8,6 +8,7 @@ import lombok.Setter;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
+import de.fhdw.webshop.pickup.PickupStore;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -108,6 +109,10 @@ public class Order {
 
     @Column(name = "truck_identifier", length = 50)
     private String truckIdentifier;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pickup_store_id")
+    private PickupStore pickupStore;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt = Instant.now();

--- a/src/main/java/de/fhdw/webshop/order/OrderService.java
+++ b/src/main/java/de/fhdw/webshop/order/OrderService.java
@@ -18,6 +18,9 @@ import de.fhdw.webshop.order.dto.OrderPreviewItemResponse;
 import de.fhdw.webshop.order.dto.OrderPreviewResponse;
 import de.fhdw.webshop.order.dto.OrderResponse;
 import de.fhdw.webshop.order.dto.PlaceOrderRequest;
+import de.fhdw.webshop.pickup.PickupStore;
+import de.fhdw.webshop.pickup.PickupStoreRepository;
+import de.fhdw.webshop.pickup.PickupStoreService;
 import de.fhdw.webshop.product.Product;
 import de.fhdw.webshop.product.ProductRepository;
 import de.fhdw.webshop.product.ProductService;
@@ -82,6 +85,8 @@ public class OrderService {
     private final EmailService emailService;
     private final AddressLookupService addressLookupService;
     private final AccountLinkRepository accountLinkRepository;
+    private final PickupStoreRepository pickupStoreRepository;
+    private final PickupStoreService pickupStoreService;
 
     @Value("${app.frontend.base-url:http://localhost:5173}")
     private String frontendBaseUrl;
@@ -232,6 +237,7 @@ public class OrderService {
         PaymentMethodSnapshot paymentMethod = resolvePaymentMethod(customer, paymentMethodRequest);
         String couponCode = placeOrderRequest != null ? placeOrderRequest.couponCode() : null;
         Coupon coupon = resolveCoupon(couponCode, customer);
+        PickupStore pickupStore = resolvePickupStore(placeOrderRequest);
         String orderNumber = placeOrderRequest != null ? placeOrderRequest.previewOrderNumber() : null;
         boolean carbonCompensationSelected = placeOrderRequest != null && Boolean.TRUE.equals(placeOrderRequest.carbonCompensationSelected());
         BigDecimal approvalBudgetLimit = resolveApprovalBudgetLimit(customer);
@@ -258,7 +264,8 @@ public class OrderService {
                 customer.getId(),
                 placeOrderRequest != null && Boolean.TRUE.equals(placeOrderRequest.allowUnverifiedAddress()),
                 carbonCompensationSelected,
-                approvalBudgetLimit
+                approvalBudgetLimit,
+                pickupStore
         );
     }
 
@@ -301,7 +308,8 @@ public class OrderService {
                 null,
                 Boolean.TRUE.equals(placeOrderRequest.allowUnverifiedAddress()),
                 Boolean.TRUE.equals(placeOrderRequest.carbonCompensationSelected()),
-                null
+                null,
+                resolvePickupStore(placeOrderRequest)
         );
     }
 
@@ -317,7 +325,8 @@ public class OrderService {
                                        Long discountCustomerId,
                                        boolean allowUnverifiedAddress,
                                        boolean carbonCompensationSelected,
-                                       BigDecimal approvalBudgetLimit) {
+                                       BigDecimal approvalBudgetLimit,
+                                       PickupStore pickupStore) {
         Order order = new Order();
         DeliveryAddressSnapshot validatedDeliveryAddress = validateDeliveryAddress(deliveryAddress, allowUnverifiedAddress);
         order.setCustomer(customer);
@@ -336,6 +345,7 @@ public class OrderService {
         order.setPaymentMethodType(paymentMethod.methodType());
         order.setPaymentMaskedDetails(paymentMethod.maskedDetails());
         order.setCouponCode(coupon != null ? coupon.getCode() : null);
+        order.setPickupStore(pickupStore);
 
         BigDecimal itemSubtotal = BigDecimal.ZERO;
         BigDecimal totalCo2EmissionKg = BigDecimal.ZERO;
@@ -441,6 +451,15 @@ public class OrderService {
             return ShippingMethod.STANDARD;
         }
         return placeOrderRequest.shippingMethod();
+    }
+
+    private PickupStore resolvePickupStore(PlaceOrderRequest placeOrderRequest) {
+        if (placeOrderRequest == null || placeOrderRequest.pickupStoreId() == null) {
+            return null;
+        }
+
+        return pickupStoreRepository.findByIdAndActiveTrue(placeOrderRequest.pickupStoreId())
+                .orElseThrow(() -> new IllegalArgumentException("Der ausgewaehlte Abhol-Store ist nicht verfuegbar"));
     }
 
     private void validateLegalAcceptance(PlaceOrderRequest placeOrderRequest) {
@@ -810,6 +829,7 @@ public class OrderService {
                 estimateDeliveryAt(order),
                 order.getApprovalReason(),
                 order.getApprovalBudgetLimit(),
+                pickupStoreService.toResponse(order.getPickupStore()),
                 null);
     }
 
@@ -882,6 +902,7 @@ public class OrderService {
                 estimateDeliveryAt(order),
                 order.getApprovalReason(),
                 order.getApprovalBudgetLimit(),
+                pickupStoreService.toResponse(order.getPickupStore()),
                 confirmationEmailSent);
     }
 
@@ -955,11 +976,23 @@ public class OrderService {
         StringBuilder body = new StringBuilder()
                 .append("Vielen Dank fuer deine Bestellung.\n\n")
                 .append("Bestellnummer: ").append(order.getOrderNumber()).append('\n')
-                .append("Gesamtbetrag: ").append(order.getTotalPrice()).append(" EUR\n")
-                .append("Versand an: ").append(order.getDeliveryStreet()).append(", ")
-                .append(order.getDeliveryPostalCode()).append(' ')
-                .append(order.getDeliveryCity()).append(", ")
-                .append(order.getDeliveryCountry()).append('\n');
+                .append("Gesamtbetrag: ").append(order.getTotalPrice()).append(" EUR\n");
+
+        if (order.getPickupStore() != null) {
+            PickupStore pickupStore = order.getPickupStore();
+            body.append("Abholung im Store: ")
+                    .append(pickupStore.getName()).append(", ")
+                    .append(pickupStore.getStreet()).append(", ")
+                    .append(pickupStore.getPostalCode()).append(' ')
+                    .append(pickupStore.getCity()).append('\n')
+                    .append("Oeffnungszeiten: ")
+                    .append(pickupStore.getOpeningHours()).append('\n');
+        } else {
+            body.append("Versand an: ").append(order.getDeliveryStreet()).append(", ")
+                    .append(order.getDeliveryPostalCode()).append(' ')
+                    .append(order.getDeliveryCity()).append(", ")
+                    .append(order.getDeliveryCountry()).append('\n');
+        }
 
         if (order.getClimateContributionAmount() != null
                 && order.getClimateContributionAmount().compareTo(BigDecimal.ZERO) > 0) {

--- a/src/main/java/de/fhdw/webshop/order/dto/OrderResponse.java
+++ b/src/main/java/de/fhdw/webshop/order/dto/OrderResponse.java
@@ -2,6 +2,7 @@ package de.fhdw.webshop.order.dto;
 
 import de.fhdw.webshop.order.OrderStatus;
 import de.fhdw.webshop.order.ShippingMethod;
+import de.fhdw.webshop.pickup.dto.PickupStoreResponse;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -27,5 +28,6 @@ public record OrderResponse(
         Instant estimatedDeliveryAt,
         String approvalReason,
         BigDecimal approvalBudgetLimit,
+        PickupStoreResponse pickupStore,
         Boolean confirmationEmailSent
 ) {}

--- a/src/main/java/de/fhdw/webshop/order/dto/PlaceOrderRequest.java
+++ b/src/main/java/de/fhdw/webshop/order/dto/PlaceOrderRequest.java
@@ -22,6 +22,7 @@ public record PlaceOrderRequest(
         Boolean saveDeliveryAddress,
         Boolean savePaymentMethod,
         Boolean carbonCompensationSelected,
+        Long pickupStoreId,
         String approvalReason,
         List<@Valid PlaceOrderItemRequest> items
 ) {}

--- a/src/main/java/de/fhdw/webshop/pickup/PickupStore.java
+++ b/src/main/java/de/fhdw/webshop/pickup/PickupStore.java
@@ -1,0 +1,44 @@
+package de.fhdw.webshop.pickup;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "pickup_stores")
+@Getter
+@Setter
+@NoArgsConstructor
+public class PickupStore {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 160)
+    private String name;
+
+    @Column(nullable = false, length = 255)
+    private String street;
+
+    @Column(name = "postal_code", nullable = false, length = 20)
+    private String postalCode;
+
+    @Column(nullable = false, length = 100)
+    private String city;
+
+    @Column(nullable = false, length = 100)
+    private String country;
+
+    @Column(name = "opening_hours", nullable = false, length = 255)
+    private String openingHours;
+
+    @Column(nullable = false)
+    private boolean active = true;
+}

--- a/src/main/java/de/fhdw/webshop/pickup/PickupStoreController.java
+++ b/src/main/java/de/fhdw/webshop/pickup/PickupStoreController.java
@@ -1,0 +1,22 @@
+package de.fhdw.webshop.pickup;
+
+import de.fhdw.webshop.pickup.dto.PickupStoreResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/pickup-stores")
+@RequiredArgsConstructor
+public class PickupStoreController {
+
+    private final PickupStoreService pickupStoreService;
+
+    @GetMapping
+    public ResponseEntity<List<PickupStoreResponse>> listAvailableStores() {
+        return ResponseEntity.ok(pickupStoreService.listAvailableStores());
+    }
+}

--- a/src/main/java/de/fhdw/webshop/pickup/PickupStoreRepository.java
+++ b/src/main/java/de/fhdw/webshop/pickup/PickupStoreRepository.java
@@ -1,0 +1,12 @@
+package de.fhdw.webshop.pickup;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PickupStoreRepository extends JpaRepository<PickupStore, Long> {
+
+    List<PickupStore> findByActiveTrueOrderByNameAsc();
+
+    Optional<PickupStore> findByIdAndActiveTrue(Long id);
+}

--- a/src/main/java/de/fhdw/webshop/pickup/PickupStoreService.java
+++ b/src/main/java/de/fhdw/webshop/pickup/PickupStoreService.java
@@ -1,0 +1,35 @@
+package de.fhdw.webshop.pickup;
+
+import de.fhdw.webshop.pickup.dto.PickupStoreResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PickupStoreService {
+
+    private final PickupStoreRepository pickupStoreRepository;
+
+    public List<PickupStoreResponse> listAvailableStores() {
+        return pickupStoreRepository.findByActiveTrueOrderByNameAsc().stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    public PickupStoreResponse toResponse(PickupStore pickupStore) {
+        if (pickupStore == null) {
+            return null;
+        }
+
+        return new PickupStoreResponse(
+                pickupStore.getId(),
+                pickupStore.getName(),
+                pickupStore.getStreet(),
+                pickupStore.getPostalCode(),
+                pickupStore.getCity(),
+                pickupStore.getCountry(),
+                pickupStore.getOpeningHours()
+        );
+    }
+}

--- a/src/main/java/de/fhdw/webshop/pickup/dto/PickupStoreResponse.java
+++ b/src/main/java/de/fhdw/webshop/pickup/dto/PickupStoreResponse.java
@@ -1,0 +1,11 @@
+package de.fhdw.webshop.pickup.dto;
+
+public record PickupStoreResponse(
+        Long id,
+        String name,
+        String street,
+        String postalCode,
+        String city,
+        String country,
+        String openingHours
+) {}

--- a/src/main/resources/db/migration/V50__create_pickup_stores.sql
+++ b/src/main/resources/db/migration/V50__create_pickup_stores.sql
@@ -1,0 +1,26 @@
+CREATE TABLE pickup_stores (
+    id            BIGSERIAL    PRIMARY KEY,
+    name          VARCHAR(160) NOT NULL,
+    street        VARCHAR(255) NOT NULL,
+    postal_code   VARCHAR(20)  NOT NULL,
+    city          VARCHAR(100) NOT NULL,
+    country       VARCHAR(100) NOT NULL,
+    opening_hours VARCHAR(255) NOT NULL,
+    active        BOOLEAN      NOT NULL DEFAULT TRUE
+);
+
+INSERT INTO pickup_stores (name, street, postal_code, city, country, opening_hours, active)
+VALUES
+    ('Webshop Store Bielefeld Mitte', 'Bahnhofstrasse 12', '33602', 'Bielefeld', 'Germany', 'Mo-Fr 09:00-18:00, Sa 10:00-16:00', TRUE),
+    ('Webshop Store Paderborn', 'Westernstrasse 31', '33098', 'Paderborn', 'Germany', 'Mo-Fr 09:30-18:30, Sa 10:00-15:00', TRUE),
+    ('Webshop Store Guetersloh', 'Berliner Strasse 45', '33330', 'Guetersloh', 'Germany', 'Mo-Fr 10:00-18:00', TRUE);
+
+ALTER TABLE orders
+    ADD COLUMN pickup_store_id BIGINT;
+
+ALTER TABLE orders
+    ADD CONSTRAINT fk_orders_pickup_store
+        FOREIGN KEY (pickup_store_id)
+        REFERENCES pickup_stores(id);
+
+CREATE INDEX idx_orders_pickup_store_id ON orders(pickup_store_id);

--- a/src/test/java/de/fhdw/webshop/order/OrderServiceTest.java
+++ b/src/test/java/de/fhdw/webshop/order/OrderServiceTest.java
@@ -12,6 +12,8 @@ import de.fhdw.webshop.discount.CouponRepository;
 import de.fhdw.webshop.order.dto.OrderPreviewResponse;
 import de.fhdw.webshop.order.dto.OrderResponse;
 import de.fhdw.webshop.order.dto.PlaceOrderRequest;
+import de.fhdw.webshop.pickup.PickupStoreRepository;
+import de.fhdw.webshop.pickup.PickupStoreService;
 import de.fhdw.webshop.product.Product;
 import de.fhdw.webshop.product.ProductRepository;
 import de.fhdw.webshop.product.ProductService;
@@ -160,6 +162,8 @@ class OrderServiceTest {
         EmailService emailService = mock(EmailService.class);
         AddressLookupService addressLookupService = mock(AddressLookupService.class);
         AccountLinkRepository accountLinkRepository = mock(AccountLinkRepository.class);
+        PickupStoreRepository pickupStoreRepository = mock(PickupStoreRepository.class);
+        PickupStoreService pickupStoreService = mock(PickupStoreService.class);
 
         OrderService service = new OrderService(
                 orderRepository,
@@ -175,7 +179,9 @@ class OrderServiceTest {
                 auditLogService,
                 emailService,
                 addressLookupService,
-                accountLinkRepository);
+                accountLinkRepository,
+                pickupStoreRepository,
+                pickupStoreService);
 
         User customer = businessCustomer(10L, "employee");
         User manager = businessCustomer(11L, "manager");
@@ -219,6 +225,7 @@ class OrderServiceTest {
                 false,
                 false,
                 false,
+                null,
                 approvalReason,
                 null);
     }


### PR DESCRIPTION
# Pull Request

## 📝 Beschreibung

Diese PR ergänzt die Backend-Unterstützung für Click & Collect. Verfügbare Abhol-Stores werden über einen eigenen Endpunkt bereitgestellt, Bestellungen können optional einen ausgewählten Store speichern und die Store-Information wird in der Bestellantwort zurückgegeben.

## 🎯 Ticket

Resolves #142

## 📋 Änderungen
*Hake an, welche Änderungen erfolgt sind:*

- [x] Neue Features hinzugefügt
- [x] Bugs behoben
- [ ] Code refaktoriert
- [x] Code ist selbsterklärend mit Kommentaren
- [x] Tests geschrieben/aktualisiert
- [ ] Dokumentation aktualisiert

## 🔗 Related Issues

- Relates to #142
