### PR TITLE
Resolves #231 artikel-personalisierung-kundensicht

### DIFF
--- a/src/main/java/de/fhdw/webshop/cart/CartController.java
+++ b/src/main/java/de/fhdw/webshop/cart/CartController.java
@@ -42,6 +42,14 @@ public class CartController {
         return ResponseEntity.ok(cartService.removeItem(currentUser, productId));
     }
 
+    /** Issue #231 - Remove an exact cart line, including personalization text. */
+    @DeleteMapping("/line-items/{cartItemId}")
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public ResponseEntity<CartResponse> removeLineItem(@AuthenticationPrincipal User currentUser,
+                                                       @PathVariable Long cartItemId) {
+        return ResponseEntity.ok(cartService.removeItemByCartItemId(currentUser, cartItemId));
+    }
+
     /** US #73 — Update the quantity of a cart item; quantity 0 removes it. */
     @PutMapping("/items/{productId}")
     @PreAuthorize("hasRole('CUSTOMER')")
@@ -49,6 +57,15 @@ public class CartController {
                                                            @PathVariable Long productId,
                                                            @Valid @RequestBody UpdateCartItemQuantityRequest request) {
         return ResponseEntity.ok(cartService.updateItemQuantity(currentUser, productId, request.quantity()));
+    }
+
+    /** Issue #231 - Update an exact cart line, including personalization text. */
+    @PutMapping("/line-items/{cartItemId}")
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public ResponseEntity<CartResponse> updateLineItemQuantity(@AuthenticationPrincipal User currentUser,
+                                                               @PathVariable Long cartItemId,
+                                                               @Valid @RequestBody UpdateCartItemQuantityRequest request) {
+        return ResponseEntity.ok(cartService.updateItemQuantityByCartItemId(currentUser, cartItemId, request.quantity()));
     }
 
     /** US #76 — Clear the full cart. */

--- a/src/main/java/de/fhdw/webshop/cart/CartItem.java
+++ b/src/main/java/de/fhdw/webshop/cart/CartItem.java
@@ -34,6 +34,9 @@ public class CartItem {
     @Column(nullable = false)
     private int quantity = 1;
 
+    @Column(name = "personalization_text", length = 1000)
+    private String personalizationText;
+
     @Column(name = "added_at", nullable = false, updatable = false)
     private Instant addedAt = Instant.now();
 }

--- a/src/main/java/de/fhdw/webshop/cart/CartRepository.java
+++ b/src/main/java/de/fhdw/webshop/cart/CartRepository.java
@@ -11,6 +11,10 @@ public interface CartRepository extends JpaRepository<CartItem, Long> {
 
     Optional<CartItem> findByUserIdAndProductId(Long userId, Long productId);
 
+    Optional<CartItem> findByIdAndUserId(Long id, Long userId);
+
+    Optional<CartItem> findByUserIdAndProductIdAndPersonalizationText(Long userId, Long productId, String personalizationText);
+
     void deleteByUserId(Long userId);
 
     void deleteByUserIdAndProductId(Long userId, Long productId);

--- a/src/main/java/de/fhdw/webshop/cart/CartService.java
+++ b/src/main/java/de/fhdw/webshop/cart/CartService.java
@@ -107,14 +107,19 @@ public class CartService {
         if (!product.isPurchasable() || getAvailableStock(product) <= 0) {
             throw new IllegalArgumentException("Product is not available for purchase: " + product.getId());
         }
+        String personalizationText = normalizePersonalizationText(product, addToCartRequest.personalizationText());
 
         CartItem cartItem = cartRepository
-                .findByUserIdAndProductId(user.getId(), addToCartRequest.productId())
+                .findByUserIdAndProductIdAndPersonalizationText(
+                        user.getId(),
+                        addToCartRequest.productId(),
+                        personalizationText)
                 .orElseGet(() -> {
                     CartItem newCartItem = new CartItem();
                     newCartItem.setUser(user);
                     newCartItem.setProduct(product);
                     newCartItem.setQuantity(0);
+                    newCartItem.setPersonalizationText(personalizationText);
                     return newCartItem;
                 });
 
@@ -132,6 +137,14 @@ public class CartService {
         return getCart(user.getId());
     }
 
+    @Transactional
+    public CartResponse removeItemByCartItemId(User user, Long cartItemId) {
+        CartItem cartItem = cartRepository.findByIdAndUserId(cartItemId, user.getId())
+                .orElseThrow(() -> new EntityNotFoundException("Item not in cart: cartItemId=" + cartItemId));
+        cartRepository.delete(cartItem);
+        return getCart(user.getId());
+    }
+
     /** US #73 — Set a new quantity; quantity 0 removes the item entirely. */
     @Transactional
     public CartResponse updateItemQuantity(User user, Long productId, int quantity) {
@@ -141,6 +154,19 @@ public class CartService {
 
         CartItem cartItem = cartRepository.findByUserIdAndProductId(user.getId(), productId)
                 .orElseThrow(() -> new EntityNotFoundException("Item not in cart: productId=" + productId));
+        cartItem.setQuantity(quantity);
+        cartRepository.save(cartItem);
+        return getCart(user.getId());
+    }
+
+    @Transactional
+    public CartResponse updateItemQuantityByCartItemId(User user, Long cartItemId, int quantity) {
+        if (quantity <= 0) {
+            return removeItemByCartItemId(user, cartItemId);
+        }
+
+        CartItem cartItem = cartRepository.findByIdAndUserId(cartItemId, user.getId())
+                .orElseThrow(() -> new EntityNotFoundException("Item not in cart: cartItemId=" + cartItemId));
         cartItem.setQuantity(quantity);
         cartRepository.save(cartItem);
         return getCart(user.getId());
@@ -161,12 +187,16 @@ public class CartService {
                 continue;
             }
             CartItem cartItem = cartRepository
-                    .findByUserIdAndProductId(user.getId(), product.getId())
+                    .findByUserIdAndProductIdAndPersonalizationText(
+                            user.getId(),
+                            product.getId(),
+                            orderItem.getPersonalizationText())
                     .orElseGet(() -> {
                         CartItem newCartItem = new CartItem();
                         newCartItem.setUser(user);
                         newCartItem.setProduct(product);
                         newCartItem.setQuantity(0);
+                        newCartItem.setPersonalizationText(orderItem.getPersonalizationText());
                         return newCartItem;
                     });
             cartItem.setQuantity(cartItem.getQuantity() + orderItem.getQuantity());
@@ -210,6 +240,7 @@ public class CartService {
                 cartItem.getProduct().getId(),
                 cartItem.getProduct().getName(),
                 toVariantValues(cartItem.getProduct()),
+                cartItem.getPersonalizationText(),
                 cartItem.getProduct().getImageUrl(),
                 effectiveUnitPrice,
                 co2EmissionKg,
@@ -283,6 +314,31 @@ public class CartService {
 
     private int getAvailableStock(Product product) {
         return product.isPurchasable() ? Math.max(product.getStock(), 0) : 0;
+    }
+
+    private String normalizePersonalizationText(Product product, String personalizationText) {
+        String normalizedText = trimToNull(personalizationText);
+        if (!product.isPersonalizable()) {
+            if (normalizedText != null) {
+                throw new IllegalArgumentException("Dieser Artikel ist nicht personalisierbar.");
+            }
+            return null;
+        }
+        if (normalizedText == null) {
+            return null;
+        }
+        Integer maxLength = product.getPersonalizationMaxLength();
+        if (maxLength != null && normalizedText.length() > maxLength) {
+            throw new IllegalArgumentException("Der Wunschtext darf maximal " + maxLength + " Zeichen lang sein.");
+        }
+        return normalizedText;
+    }
+
+    private String trimToNull(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return null;
+        }
+        return value.trim();
     }
 
     private Map<String, String> toVariantValues(Product product) {

--- a/src/main/java/de/fhdw/webshop/cart/dto/AddToCartRequest.java
+++ b/src/main/java/de/fhdw/webshop/cart/dto/AddToCartRequest.java
@@ -5,5 +5,6 @@ import jakarta.validation.constraints.NotNull;
 
 public record AddToCartRequest(
         @NotNull Long productId,
-        @Min(1) int quantity
+        @Min(1) int quantity,
+        String personalizationText
 ) {}

--- a/src/main/java/de/fhdw/webshop/cart/dto/CartItemResponse.java
+++ b/src/main/java/de/fhdw/webshop/cart/dto/CartItemResponse.java
@@ -9,6 +9,7 @@ public record CartItemResponse(
         Long productId,
         String productName,
         Map<String, String> variantValues,
+        String personalizationText,
         String imageUrl,
         BigDecimal unitPrice,
         BigDecimal co2EmissionKg,

--- a/src/main/java/de/fhdw/webshop/order/OrderItem.java
+++ b/src/main/java/de/fhdw/webshop/order/OrderItem.java
@@ -33,4 +33,7 @@ public class OrderItem {
     /** Price captured at the moment the order was placed — immune to future price changes. */
     @Column(name = "price_at_order_time", nullable = false, precision = 10, scale = 2)
     private BigDecimal priceAtOrderTime;
+
+    @Column(name = "personalization_text", length = 1000)
+    private String personalizationText;
 }

--- a/src/main/java/de/fhdw/webshop/order/OrderService.java
+++ b/src/main/java/de/fhdw/webshop/order/OrderService.java
@@ -251,7 +251,10 @@ public class OrderService {
                 confirmationEmail,
                 displayName,
                 cartItems.stream()
-                        .map(cartItem -> new RequestedOrderItem(cartItem.getProduct(), cartItem.getQuantity()))
+                        .map(cartItem -> new RequestedOrderItem(
+                                cartItem.getProduct(),
+                                cartItem.getQuantity(),
+                                cartItem.getPersonalizationText()))
                         .toList(),
                 deliveryAddress,
                 shippingMethod,
@@ -282,7 +285,10 @@ public class OrderService {
         }
 
         List<RequestedOrderItem> requestedItems = placeOrderRequest.items().stream()
-                .map(item -> new RequestedOrderItem(productService.loadProduct(item.productId()), item.quantity()))
+                .map(item -> new RequestedOrderItem(
+                        productService.loadProduct(item.productId()),
+                        item.quantity(),
+                        item.personalizationText()))
                 .toList();
 
         return prepareOrder(
@@ -350,6 +356,7 @@ public class OrderService {
             if (requestedItem.quantity() > product.getStock()) {
                 throw new IllegalArgumentException("Only " + product.getStock() + " units of " + product.getName() + " are available");
             }
+            String personalizationText = normalizePersonalizationText(product, requestedItem.personalizationText());
 
             BigDecimal discountPercent = discountCustomerId != null
                     ? discountLookupPort.findBestActiveDiscountPercent(discountCustomerId, product.getId())
@@ -361,7 +368,7 @@ public class OrderService {
                 totalCo2EmissionKg = totalCo2EmissionKg.add(
                         product.getCo2EmissionKg().multiply(BigDecimal.valueOf(requestedItem.quantity())));
             }
-            preparedItems.add(new PreparedOrderItem(product, requestedItem.quantity(), unitPrice, lineTotal));
+            preparedItems.add(new PreparedOrderItem(product, requestedItem.quantity(), personalizationText, unitPrice, lineTotal));
         }
         totalCo2EmissionKg = totalCo2EmissionKg.setScale(3, RoundingMode.HALF_UP);
 
@@ -505,6 +512,7 @@ public class OrderService {
             orderItem.setOrder(order);
             orderItem.setProduct(product);
             orderItem.setQuantity(preparedItem.quantity());
+            orderItem.setPersonalizationText(preparedItem.personalizationText());
             orderItem.setPriceAtOrderTime(preparedItem.unitPrice());
             order.getItems().add(orderItem);
         }
@@ -537,6 +545,7 @@ public class OrderService {
             orderItem.setOrder(order);
             orderItem.setProduct(product);
             orderItem.setQuantity(preparedItem.quantity());
+            orderItem.setPersonalizationText(preparedItem.personalizationText());
             orderItem.setPriceAtOrderTime(preparedItem.unitPrice());
             order.getItems().add(orderItem);
         }
@@ -786,6 +795,7 @@ public class OrderService {
                         orderItem.getProduct().getId(),
                         orderItem.getProduct().getName(),
                         toVariantValues(orderItem.getProduct()),
+                        orderItem.getPersonalizationText(),
                         orderItem.getProduct().isPurchasable(),
                         orderItem.getQuantity(),
                         orderItem.getPriceAtOrderTime(),
@@ -824,6 +834,7 @@ public class OrderService {
                         orderItem.getProduct().getId(),
                         orderItem.getProduct().getName(),
                         toVariantValues(orderItem.getProduct()),
+                        orderItem.getPersonalizationText(),
                         orderItem.getProduct().isPurchasable(),
                         orderItem.getQuantity(),
                         orderItem.getPriceAtOrderTime(),
@@ -860,6 +871,7 @@ public class OrderService {
                         orderItem.getProduct().getId(),
                         orderItem.getProduct().getName(),
                         toVariantValues(orderItem.getProduct()),
+                        orderItem.getPersonalizationText(),
                         orderItem.getProduct().isPurchasable(),
                         orderItem.getQuantity(),
                         orderItem.getPriceAtOrderTime(),
@@ -934,6 +946,7 @@ public class OrderService {
                         item.product().getId(),
                         item.product().getName(),
                         toVariantValues(item.product()),
+                        item.personalizationText(),
                         item.quantity(),
                         item.unitPrice(),
                         item.lineTotal()
@@ -984,6 +997,11 @@ public class OrderService {
                     .append(" = ")
                     .append(item.getPriceAtOrderTime().multiply(BigDecimal.valueOf(item.getQuantity())))
                     .append(" EUR\n");
+            if (item.getPersonalizationText() != null && !item.getPersonalizationText().isBlank()) {
+                body.append("  Wunschtext: ")
+                        .append(item.getPersonalizationText())
+                        .append('\n');
+            }
         }
 
         return emailService.sendEmail(
@@ -999,6 +1017,31 @@ public class OrderService {
                 .sorted((left, right) -> Integer.compare(left.getDisplayOrder(), right.getDisplayOrder()))
                 .forEach(option -> values.put(option.getAttributeName(), option.getAttributeValue()));
         return values;
+    }
+
+    private String normalizePersonalizationText(Product product, String personalizationText) {
+        String normalizedText = trimToNull(personalizationText);
+        if (!product.isPersonalizable()) {
+            if (normalizedText != null) {
+                throw new IllegalArgumentException("Dieser Artikel ist nicht personalisierbar.");
+            }
+            return null;
+        }
+        if (normalizedText == null) {
+            return null;
+        }
+        Integer maxLength = product.getPersonalizationMaxLength();
+        if (maxLength != null && normalizedText.length() > maxLength) {
+            throw new IllegalArgumentException("Der Wunschtext darf maximal " + maxLength + " Zeichen lang sein.");
+        }
+        return normalizedText;
+    }
+
+    private String trimToNull(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return null;
+        }
+        return value.trim();
     }
 
     private String buildApprovalRequestEmailBody(Order order, User manager) {
@@ -1066,12 +1109,14 @@ public class OrderService {
 
     private record RequestedOrderItem(
             Product product,
-            int quantity
+            int quantity,
+            String personalizationText
     ) {}
 
     private record PreparedOrderItem(
             Product product,
             int quantity,
+            String personalizationText,
             BigDecimal unitPrice,
             BigDecimal lineTotal
     ) {}

--- a/src/main/java/de/fhdw/webshop/order/dto/OrderItemResponse.java
+++ b/src/main/java/de/fhdw/webshop/order/dto/OrderItemResponse.java
@@ -8,6 +8,7 @@ public record OrderItemResponse(
         Long productId,
         String productName,
         Map<String, String> variantValues,
+        String personalizationText,
         boolean productPurchasable,
         int quantity,
         BigDecimal priceAtOrderTime,

--- a/src/main/java/de/fhdw/webshop/order/dto/OrderPreviewItemResponse.java
+++ b/src/main/java/de/fhdw/webshop/order/dto/OrderPreviewItemResponse.java
@@ -7,6 +7,7 @@ public record OrderPreviewItemResponse(
         Long productId,
         String productName,
         Map<String, String> variantValues,
+        String personalizationText,
         int quantity,
         BigDecimal unitPrice,
         BigDecimal lineTotal

--- a/src/main/java/de/fhdw/webshop/order/dto/PlaceOrderItemRequest.java
+++ b/src/main/java/de/fhdw/webshop/order/dto/PlaceOrderItemRequest.java
@@ -5,5 +5,6 @@ import jakarta.validation.constraints.NotNull;
 
 public record PlaceOrderItemRequest(
         @NotNull Long productId,
-        @Min(1) int quantity
+        @Min(1) int quantity,
+        String personalizationText
 ) {}

--- a/src/main/java/de/fhdw/webshop/product/Product.java
+++ b/src/main/java/de/fhdw/webshop/product/Product.java
@@ -52,6 +52,12 @@ public class Product {
     @Column(name = "has_variants", nullable = false)
     private boolean hasVariants = false;
 
+    @Column(nullable = false)
+    private boolean personalizable = false;
+
+    @Column(name = "personalization_max_length")
+    private Integer personalizationMaxLength;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_product_id")
     private Product parentProduct;

--- a/src/main/java/de/fhdw/webshop/product/ProductService.java
+++ b/src/main/java/de/fhdw/webshop/product/ProductService.java
@@ -208,6 +208,8 @@ public class ProductService {
                 product.getSku(),
                 product.isPurchasable(),
                 product.isPromoted(),
+                product.isPersonalizable(),
+                product.getPersonalizationMaxLength(),
                 product.isHasVariants(),
                 product.getParentProduct() == null ? null : product.getParentProduct().getId(),
                 toVariantValues(product),
@@ -232,6 +234,9 @@ public class ProductService {
         if (productRequest.purchasable() != null) {
             product.setPurchasable(productRequest.purchasable());
         }
+        boolean personalizable = Boolean.TRUE.equals(productRequest.personalizable());
+        product.setPersonalizable(personalizable);
+        product.setPersonalizationMaxLength(resolvePersonalizationMaxLength(personalizable, productRequest.personalizationMaxLength()));
         product.setHasVariants(productRequest.hasVariants());
     }
 
@@ -315,6 +320,8 @@ public class ProductService {
         variant.setSku(firstNonBlank(variantRequest.sku(), buildGeneratedSku(parent, index)));
         variant.setPurchasable(parent.isPurchasable());
         variant.setPromoted(false);
+        variant.setPersonalizable(parent.isPersonalizable());
+        variant.setPersonalizationMaxLength(parent.getPersonalizationMaxLength());
         variant.setHasVariants(false);
 
         variant.getVariantOptions().clear();
@@ -474,6 +481,19 @@ public class ProductService {
             return null;
         }
         return value.trim();
+    }
+
+    private Integer resolvePersonalizationMaxLength(boolean personalizable, Integer personalizationMaxLength) {
+        if (!personalizable) {
+            return null;
+        }
+        if (personalizationMaxLength == null || personalizationMaxLength <= 0) {
+            throw new IllegalArgumentException("Die maximale Zeichenlaenge fuer Personalisierung muss groesser als 0 sein.");
+        }
+        if (personalizationMaxLength > 1000) {
+            throw new IllegalArgumentException("Die maximale Zeichenlaenge fuer Personalisierung darf hoechstens 1000 betragen.");
+        }
+        return personalizationMaxLength;
     }
 
     private void recordProductAction(User actingUser, String action, Product product, String details) {

--- a/src/main/java/de/fhdw/webshop/product/dto/ProductRequest.java
+++ b/src/main/java/de/fhdw/webshop/product/dto/ProductRequest.java
@@ -21,6 +21,8 @@ public record ProductRequest(
         @PositiveOrZero Integer stock,
         String sku,
         Boolean purchasable,
+        Boolean personalizable,
+        @PositiveOrZero Integer personalizationMaxLength,
         boolean hasVariants,
         List<ProductVariantAttributeRequest> variantAttributes,
         List<ProductVariantRequest> variants

--- a/src/main/java/de/fhdw/webshop/product/dto/ProductResponse.java
+++ b/src/main/java/de/fhdw/webshop/product/dto/ProductResponse.java
@@ -20,6 +20,8 @@ public record ProductResponse(
         String sku,
         boolean purchasable,
         boolean promoted,
+        boolean personalizable,
+        Integer personalizationMaxLength,
         boolean hasVariants,
         Long parentProductId,
         Map<String, String> variantValues,

--- a/src/main/java/de/fhdw/webshop/warehouse/WarehouseService.java
+++ b/src/main/java/de/fhdw/webshop/warehouse/WarehouseService.java
@@ -358,6 +358,7 @@ public class WarehouseService {
                 .map(orderItem -> new WarehouseOrderItemResponse(
                         orderItem.getProduct().getId(),
                         orderItem.getProduct().getName(),
+                        orderItem.getPersonalizationText(),
                         orderItem.getQuantity(),
                         orderItem.getProduct().getStock(),
                         orderItem.getProduct().getWarehousePosition()

--- a/src/main/java/de/fhdw/webshop/warehouse/dto/WarehouseOrderItemResponse.java
+++ b/src/main/java/de/fhdw/webshop/warehouse/dto/WarehouseOrderItemResponse.java
@@ -3,6 +3,7 @@ package de.fhdw.webshop.warehouse.dto;
 public record WarehouseOrderItemResponse(
         Long productId,
         String productName,
+        String personalizationText,
         int quantity,
         int availableStock,
         String warehousePosition

--- a/src/main/resources/db/migration/V52__add_product_personalization.sql
+++ b/src/main/resources/db/migration/V52__add_product_personalization.sql
@@ -1,0 +1,17 @@
+ALTER TABLE products
+    ADD COLUMN personalizable BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN personalization_max_length INTEGER,
+    ADD CONSTRAINT chk_products_personalization_length
+        CHECK (personalizable = FALSE OR personalization_max_length > 0);
+
+ALTER TABLE cart_items
+    ADD COLUMN personalization_text VARCHAR(1000);
+
+ALTER TABLE cart_items
+    DROP CONSTRAINT IF EXISTS cart_items_user_id_product_id_key;
+
+CREATE INDEX ix_cart_items_user_product_personalization
+    ON cart_items (user_id, product_id, personalization_text);
+
+ALTER TABLE order_items
+    ADD COLUMN personalization_text VARCHAR(1000);

--- a/src/test/java/de/fhdw/webshop/product/ProductServiceVariantTest.java
+++ b/src/test/java/de/fhdw/webshop/product/ProductServiceVariantTest.java
@@ -102,6 +102,8 @@ class ProductServiceVariantTest {
                 20,
                 "TEAM-SHIRT",
                 true,
+                false,
+                null,
                 true,
                 List.of(
                         new ProductVariantAttributeRequest("Farbe", List.of("Rot", "Blau")),


### PR DESCRIPTION
## Summary
- adds database-backed product personalization settings
- stores personalization text on cart and order items
- validates personalization text in backend order and cart flows
- exposes personalization text to order responses and warehouse/logistics views

## Validation
- .\\mvnw.cmd -Dtest=ProductServiceVariantTest,OrderServiceTest test

Note: full backend test run still has unrelated AdminNavigationServiceTest failures already present outside this issue, and this branch is based on the current #230 product variant branch so dependent #230 commits may appear until merged.