### PR TITLE
#146 Mengenrabatte automatisch berechnen

### DIFF
--- a/src/main/java/de/fhdw/webshop/cart/CartService.java
+++ b/src/main/java/de/fhdw/webshop/cart/CartService.java
@@ -5,6 +5,8 @@ import de.fhdw.webshop.cart.dto.CartItemResponse;
 import de.fhdw.webshop.cart.dto.CartResponse;
 import de.fhdw.webshop.discount.Coupon;
 import de.fhdw.webshop.discount.CouponRepository;
+import de.fhdw.webshop.discount.VolumeDiscountPolicy;
+import de.fhdw.webshop.discount.VolumeDiscountPolicy.VolumeDiscountResult;
 import de.fhdw.webshop.order.Order;
 import de.fhdw.webshop.order.OrderItem;
 import de.fhdw.webshop.order.OrderRepository;
@@ -59,7 +61,17 @@ public class CartService {
                 .setScale(2, RoundingMode.HALF_UP);
 
         Coupon coupon = resolveCoupon(couponCode, userId);
-        BigDecimal discountAmount = calculateDiscount(itemSubtotal, coupon);
+        int totalItemCount = itemResponses.stream()
+                .mapToInt(CartItemResponse::quantity)
+                .sum();
+        VolumeDiscountResult volumeDiscount = VolumeDiscountPolicy.resolve(itemSubtotal, totalItemCount, coupon != null);
+        BigDecimal discountAmount = coupon != null
+                ? calculateDiscount(itemSubtotal, coupon)
+                : volumeDiscount.amount();
+        String discountType = resolveDiscountType(coupon, volumeDiscount);
+        String discountLabel = resolveDiscountLabel(coupon, volumeDiscount);
+        BigDecimal discountPercent = resolveDiscountPercent(coupon, volumeDiscount);
+        List<String> discountMessages = resolveDiscountMessages(volumeDiscount);
         BigDecimal subtotal = itemSubtotal.subtract(discountAmount)
                 .max(BigDecimal.ZERO)
                 .setScale(2, RoundingMode.HALF_UP);
@@ -96,7 +108,11 @@ public class CartService {
                 co2EmissionCoveredItemCount,
                 co2EmissionTotalItemCount,
                 coupon != null ? coupon.getCode() : null,
-                messages
+                messages,
+                discountType,
+                discountLabel,
+                discountPercent,
+                discountMessages
         );
     }
 
@@ -298,6 +314,34 @@ public class CartService {
 
         BigDecimal multiplier = coupon.getDiscountPercent().divide(BigDecimal.valueOf(100), 4, RoundingMode.HALF_UP);
         return subtotal.multiply(multiplier).setScale(2, RoundingMode.HALF_UP);
+    }
+
+    private String resolveDiscountType(Coupon coupon, VolumeDiscountResult volumeDiscount) {
+        if (coupon != null) {
+            return "COUPON";
+        }
+        return volumeDiscount.applied() ? VolumeDiscountPolicy.DISCOUNT_TYPE : null;
+    }
+
+    private String resolveDiscountLabel(Coupon coupon, VolumeDiscountResult volumeDiscount) {
+        if (coupon != null) {
+            return "Gutschein " + coupon.getCode();
+        }
+        return volumeDiscount.label();
+    }
+
+    private BigDecimal resolveDiscountPercent(Coupon coupon, VolumeDiscountResult volumeDiscount) {
+        if (coupon != null) {
+            return coupon.getDiscountPercent();
+        }
+        return volumeDiscount.percent();
+    }
+
+    private List<String> resolveDiscountMessages(VolumeDiscountResult volumeDiscount) {
+        if (volumeDiscount.exclusionMessage() == null || volumeDiscount.exclusionMessage().isBlank()) {
+            return List.of();
+        }
+        return List.of(volumeDiscount.exclusionMessage());
     }
 
     private BigDecimal calculateShippingCost(BigDecimal subtotal, boolean emptyCart) {

--- a/src/main/java/de/fhdw/webshop/cart/dto/CartResponse.java
+++ b/src/main/java/de/fhdw/webshop/cart/dto/CartResponse.java
@@ -14,5 +14,9 @@ public record CartResponse(
         int co2EmissionCoveredItemCount,
         int co2EmissionTotalItemCount,
         String appliedCouponCode,
-        List<String> messages
+        List<String> messages,
+        String discountType,
+        String discountLabel,
+        BigDecimal discountPercent,
+        List<String> discountMessages
 ) {}

--- a/src/main/java/de/fhdw/webshop/discount/VolumeDiscountPolicy.java
+++ b/src/main/java/de/fhdw/webshop/discount/VolumeDiscountPolicy.java
@@ -1,0 +1,73 @@
+package de.fhdw.webshop.discount;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+public final class VolumeDiscountPolicy {
+
+    public static final String DISCOUNT_TYPE = "VOLUME";
+
+    private static final List<VolumeDiscountTier> TIERS = List.of(
+            new VolumeDiscountTier(25, new BigDecimal("1000.00"), new BigDecimal("10.00")),
+            new VolumeDiscountTier(10, new BigDecimal("500.00"), new BigDecimal("5.00"))
+    );
+
+    private VolumeDiscountPolicy() {
+    }
+
+    public static VolumeDiscountResult resolve(BigDecimal itemSubtotal, int itemCount, boolean couponApplied) {
+        BigDecimal safeSubtotal = itemSubtotal == null
+                ? BigDecimal.ZERO
+                : itemSubtotal.setScale(2, RoundingMode.HALF_UP);
+        VolumeDiscountTier matchedTier = TIERS.stream()
+                .filter(tier -> tier.matches(safeSubtotal, itemCount))
+                .findFirst()
+                .orElse(null);
+
+        if (matchedTier == null || safeSubtotal.compareTo(BigDecimal.ZERO) <= 0) {
+            return VolumeDiscountResult.none();
+        }
+
+        String label = "Mengenrabatt " + matchedTier.percent().stripTrailingZeros().toPlainString() + "%";
+        if (couponApplied) {
+            return new VolumeDiscountResult(
+                    false,
+                    matchedTier.percent(),
+                    BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP),
+                    label,
+                    "Mengenrabatt waere moeglich, wurde aber nicht mit dem Gutschein kombiniert."
+            );
+        }
+
+        BigDecimal amount = safeSubtotal
+                .multiply(matchedTier.percent().divide(BigDecimal.valueOf(100), 4, RoundingMode.HALF_UP))
+                .setScale(2, RoundingMode.HALF_UP);
+
+        return new VolumeDiscountResult(true, matchedTier.percent(), amount, label, null);
+    }
+
+    private record VolumeDiscountTier(int minItemCount, BigDecimal minSubtotal, BigDecimal percent) {
+        private boolean matches(BigDecimal subtotal, int itemCount) {
+            return itemCount >= minItemCount || subtotal.compareTo(minSubtotal) >= 0;
+        }
+    }
+
+    public record VolumeDiscountResult(
+            boolean applied,
+            BigDecimal percent,
+            BigDecimal amount,
+            String label,
+            String exclusionMessage
+    ) {
+        public static VolumeDiscountResult none() {
+            return new VolumeDiscountResult(
+                    false,
+                    null,
+                    BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP),
+                    null,
+                    null
+            );
+        }
+    }
+}

--- a/src/main/java/de/fhdw/webshop/order/OrderService.java
+++ b/src/main/java/de/fhdw/webshop/order/OrderService.java
@@ -12,6 +12,8 @@ import de.fhdw.webshop.cart.CartService;
 import de.fhdw.webshop.cart.CartRepository;
 import de.fhdw.webshop.discount.Coupon;
 import de.fhdw.webshop.discount.CouponRepository;
+import de.fhdw.webshop.discount.VolumeDiscountPolicy;
+import de.fhdw.webshop.discount.VolumeDiscountPolicy.VolumeDiscountResult;
 import de.fhdw.webshop.notification.EmailService;
 import de.fhdw.webshop.order.dto.OrderItemResponse;
 import de.fhdw.webshop.order.dto.OrderApprovalResponse;
@@ -418,7 +420,13 @@ public class OrderService {
         }
         totalCo2EmissionKg = totalCo2EmissionKg.setScale(3, RoundingMode.HALF_UP);
 
-        BigDecimal discountAmount = calculateCouponDiscount(itemSubtotal, coupon);
+        int totalItemCount = preparedItems.stream()
+                .mapToInt(PreparedOrderItem::quantity)
+                .sum();
+        VolumeDiscountResult volumeDiscount = VolumeDiscountPolicy.resolve(itemSubtotal, totalItemCount, coupon != null);
+        BigDecimal discountAmount = coupon != null
+                ? calculateCouponDiscount(itemSubtotal, coupon)
+                : volumeDiscount.amount();
         BigDecimal subtotal = itemSubtotal.subtract(discountAmount).max(BigDecimal.ZERO).setScale(2, RoundingMode.HALF_UP);
         BigDecimal shippingCost = calculateShippingCost(subtotal, shippingMethod);
         BigDecimal taxAmount = subtotal.multiply(TAX_RATE).setScale(2, RoundingMode.HALF_UP);
@@ -437,6 +445,10 @@ public class OrderService {
                 preparedItems,
                 coupon,
                 discountAmount,
+                resolveDiscountType(coupon, volumeDiscount),
+                resolveDiscountLabel(coupon, volumeDiscount),
+                resolveDiscountPercent(coupon, volumeDiscount),
+                resolveDiscountMessages(volumeDiscount),
                 taxAmount,
                 subtotal,
                 shippingCost,
@@ -715,6 +727,53 @@ public class OrderService {
         return subtotal.multiply(multiplier).setScale(2, RoundingMode.HALF_UP);
     }
 
+    private String resolveDiscountType(Coupon coupon, VolumeDiscountResult volumeDiscount) {
+        if (coupon != null) {
+            return "COUPON";
+        }
+        return volumeDiscount.applied() ? VolumeDiscountPolicy.DISCOUNT_TYPE : null;
+    }
+
+    private String resolveDiscountLabel(Coupon coupon, VolumeDiscountResult volumeDiscount) {
+        if (coupon != null) {
+            return "Gutschein " + coupon.getCode();
+        }
+        return volumeDiscount.label();
+    }
+
+    private BigDecimal resolveDiscountPercent(Coupon coupon, VolumeDiscountResult volumeDiscount) {
+        if (coupon != null) {
+            return coupon.getDiscountPercent();
+        }
+        return volumeDiscount.percent();
+    }
+
+    private List<String> resolveDiscountMessages(VolumeDiscountResult volumeDiscount) {
+        if (volumeDiscount.exclusionMessage() == null || volumeDiscount.exclusionMessage().isBlank()) {
+            return List.of();
+        }
+        return List.of(volumeDiscount.exclusionMessage());
+    }
+
+    private String resolvePersistedDiscountType(Order order) {
+        if (order.getDiscountAmount() == null || order.getDiscountAmount().compareTo(BigDecimal.ZERO) <= 0) {
+            return null;
+        }
+        return order.getCouponCode() != null && !order.getCouponCode().isBlank()
+                ? "COUPON"
+                : VolumeDiscountPolicy.DISCOUNT_TYPE;
+    }
+
+    private String resolvePersistedDiscountLabel(Order order) {
+        if (order.getDiscountAmount() == null || order.getDiscountAmount().compareTo(BigDecimal.ZERO) <= 0) {
+            return null;
+        }
+        if (order.getCouponCode() != null && !order.getCouponCode().isBlank()) {
+            return "Gutschein " + order.getCouponCode();
+        }
+        return "Mengenrabatt";
+    }
+
     private BigDecimal calculateClimateContributionAmount(BigDecimal totalCo2EmissionKg, boolean selected) {
         if (!selected || totalCo2EmissionKg == null || totalCo2EmissionKg.compareTo(BigDecimal.ZERO) <= 0) {
             return BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
@@ -908,7 +967,11 @@ public class OrderService {
                 order.getApprovalReason(),
                 order.getApprovalBudgetLimit(),
                 pickupStoreService.toResponse(order.getPickupStore()),
-                null);
+                null,
+                resolvePersistedDiscountType(order),
+                resolvePersistedDiscountLabel(order),
+                null,
+                List.of());
     }
 
     private OrderApprovalResponse toApprovalResponse(Order order, Boolean confirmationEmailSent) {
@@ -985,7 +1048,11 @@ public class OrderService {
                 order.getApprovalReason(),
                 order.getApprovalBudgetLimit(),
                 pickupStoreService.toResponse(order.getPickupStore()),
-                confirmationEmailSent);
+                confirmationEmailSent,
+                resolvePersistedDiscountType(order),
+                resolvePersistedDiscountLabel(order),
+                null,
+                List.of());
     }
 
     private Instant estimateDeliveryAt(Order order) {
@@ -1052,7 +1119,11 @@ public class OrderService {
                 preparedOrder.order().getCouponCode(),
                 preparedOrder.approvalRequired(),
                 preparedOrder.approvalBudgetLimit(),
-                itemResponses
+                itemResponses,
+                preparedOrder.discountType(),
+                preparedOrder.discountLabel(),
+                preparedOrder.discountPercent(),
+                preparedOrder.discountMessages()
         );
     }
 
@@ -1224,6 +1295,10 @@ public class OrderService {
             List<PreparedOrderItem> items,
             Coupon coupon,
             BigDecimal discountAmount,
+            String discountType,
+            String discountLabel,
+            BigDecimal discountPercent,
+            List<String> discountMessages,
             BigDecimal taxAmount,
             BigDecimal subtotal,
             BigDecimal shippingCost,

--- a/src/main/java/de/fhdw/webshop/order/dto/OrderPreviewResponse.java
+++ b/src/main/java/de/fhdw/webshop/order/dto/OrderPreviewResponse.java
@@ -16,5 +16,9 @@ public record OrderPreviewResponse(
         String couponCode,
         Boolean approvalRequired,
         BigDecimal approvalBudgetLimit,
-        List<OrderPreviewItemResponse> items
+        List<OrderPreviewItemResponse> items,
+        String discountType,
+        String discountLabel,
+        BigDecimal discountPercent,
+        List<String> discountMessages
 ) {}

--- a/src/main/java/de/fhdw/webshop/order/dto/OrderResponse.java
+++ b/src/main/java/de/fhdw/webshop/order/dto/OrderResponse.java
@@ -29,5 +29,9 @@ public record OrderResponse(
         String approvalReason,
         BigDecimal approvalBudgetLimit,
         PickupStoreResponse pickupStore,
-        Boolean confirmationEmailSent
+        Boolean confirmationEmailSent,
+        String discountType,
+        String discountLabel,
+        BigDecimal discountPercent,
+        List<String> discountMessages
 ) {}


### PR DESCRIPTION
# Pull Request

## 📝 Beschreibung

Diese PR implementiert die automatische Berechnung von Mengenrabatten im Backend. Das System erkennt Mengen- und Umsatzgrenzen, berechnet den passenden Rabatt automatisch im Warenkorb und Checkout und gibt Rabattinformationen transparent an das Frontend zurück. Nicht kombinierbare Rabatte werden berücksichtigt, indem Gutscheine Vorrang vor Mengenrabatten haben.

## 🎯 Ticket

Resolves #146

## 📋 Änderungen

- [x] Neue Features hinzugefügt
- [ ] Bugs behoben
- [ ] Code refaktoriert
- [x] Code ist selbsterklärend mit Kommentaren
- [ ] Tests geschrieben/aktualisiert
- [ ] Dokumentation aktualisiert

## 🔗 Related Issues

- Relates to #146
