### PR TITLE
feat(#233): track shared wishlist gift purchases

### DIFF
--- a/src/main/java/de/fhdw/webshop/cart/CartItem.java
+++ b/src/main/java/de/fhdw/webshop/cart/CartItem.java
@@ -11,10 +11,7 @@ import java.math.BigDecimal;
 import java.time.Instant;
 
 @Entity
-@Table(
-    name = "cart_items",
-    uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "product_id"})
-)
+@Table(name = "cart_items")
 @Getter
 @Setter
 @NoArgsConstructor
@@ -46,6 +43,12 @@ public class CartItem {
 
     @Column(name = "gift_card_message", length = 1000)
     private String giftCardMessage;
+
+    @Column(name = "shared_wishlist_token", length = 80)
+    private String sharedWishlistToken;
+
+    @Column(name = "shared_wishlist_list_id", length = 140)
+    private String sharedWishlistListId;
 
     @Column(name = "added_at", nullable = false, updatable = false)
     private Instant addedAt = Instant.now();

--- a/src/main/java/de/fhdw/webshop/cart/CartRepository.java
+++ b/src/main/java/de/fhdw/webshop/cart/CartRepository.java
@@ -24,6 +24,17 @@ public interface CartRepository extends JpaRepository<CartItem, Long> {
             String giftCardMessage
     );
 
+    Optional<CartItem> findByUserIdAndProductIdAndPersonalizationTextAndGiftCardAmountAndGiftCardRecipientEmailAndGiftCardMessageAndSharedWishlistTokenAndSharedWishlistListId(
+            Long userId,
+            Long productId,
+            String personalizationText,
+            java.math.BigDecimal giftCardAmount,
+            String giftCardRecipientEmail,
+            String giftCardMessage,
+            String sharedWishlistToken,
+            String sharedWishlistListId
+    );
+
     void deleteByUserId(Long userId);
 
     void deleteByUserIdAndProductId(Long userId, Long productId);

--- a/src/main/java/de/fhdw/webshop/cart/CartService.java
+++ b/src/main/java/de/fhdw/webshop/cart/CartService.java
@@ -22,6 +22,7 @@ import de.fhdw.webshop.product.ProductType;
 import de.fhdw.webshop.product.ProductService;
 import de.fhdw.webshop.user.User;
 import de.fhdw.webshop.user.UserType;
+import de.fhdw.webshop.wishlist.WishlistService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -52,6 +53,7 @@ public class CartService {
     private final OrderItemRepository orderItemRepository;
     private final CouponRepository couponRepository;
     private final VolumeDiscountService volumeDiscountService;
+    private final WishlistService wishlistService;
 
     private static final BigDecimal TAX_RATE      = BigDecimal.valueOf(0.19);
     private static final BigDecimal SHIPPING_COST = new BigDecimal("4.99");
@@ -155,15 +157,22 @@ public class CartService {
         BigDecimal giftCardAmount = resolveGiftCardAmount(product, addToCartRequest.giftCardAmount());
         String giftCardRecipientEmail = normalizeEmail(addToCartRequest.giftCardRecipientEmail());
         String giftCardMessage = normalizeGiftCardMessage(addToCartRequest.giftCardMessage());
+        String sharedWishlistToken = trimToNull(addToCartRequest.sharedWishlistToken());
+        String sharedWishlistListId = trimToNull(addToCartRequest.sharedWishlistListId());
+        if ((sharedWishlistToken == null) != (sharedWishlistListId == null)) {
+            throw new IllegalArgumentException("Die geteilte Liste konnte nicht eindeutig zugeordnet werden.");
+        }
 
         CartItem cartItem = cartRepository
-                .findByUserIdAndProductIdAndPersonalizationTextAndGiftCardAmountAndGiftCardRecipientEmailAndGiftCardMessage(
+                .findByUserIdAndProductIdAndPersonalizationTextAndGiftCardAmountAndGiftCardRecipientEmailAndGiftCardMessageAndSharedWishlistTokenAndSharedWishlistListId(
                         user.getId(),
                         addToCartRequest.productId(),
                         personalizationText,
                         giftCardAmount,
                         giftCardRecipientEmail,
-                        giftCardMessage)
+                        giftCardMessage,
+                        sharedWishlistToken,
+                        sharedWishlistListId)
                 .orElseGet(() -> {
                     CartItem newCartItem = new CartItem();
                     newCartItem.setUser(user);
@@ -173,9 +182,17 @@ public class CartService {
                     newCartItem.setGiftCardAmount(giftCardAmount);
                     newCartItem.setGiftCardRecipientEmail(giftCardRecipientEmail);
                     newCartItem.setGiftCardMessage(giftCardMessage);
+                    newCartItem.setSharedWishlistToken(sharedWishlistToken);
+                    newCartItem.setSharedWishlistListId(sharedWishlistListId);
                     return newCartItem;
                 });
 
+        wishlistService.validateGiftPurchase(
+                sharedWishlistToken,
+                sharedWishlistListId,
+                product.getId(),
+                cartItem.getQuantity() + addToCartRequest.quantity()
+        );
         cartItem.setQuantity(cartItem.getQuantity() + addToCartRequest.quantity());
         cartRepository.save(cartItem);
         return getCart(user.getId());
@@ -240,13 +257,15 @@ public class CartService {
                 continue;
             }
             CartItem cartItem = cartRepository
-                    .findByUserIdAndProductIdAndPersonalizationTextAndGiftCardAmountAndGiftCardRecipientEmailAndGiftCardMessage(
+                    .findByUserIdAndProductIdAndPersonalizationTextAndGiftCardAmountAndGiftCardRecipientEmailAndGiftCardMessageAndSharedWishlistTokenAndSharedWishlistListId(
                             user.getId(),
                             product.getId(),
                             orderItem.getPersonalizationText(),
                             orderItem.getGiftCardAmount(),
                             orderItem.getGiftCardRecipientEmail(),
-                            orderItem.getGiftCardMessage())
+                            orderItem.getGiftCardMessage(),
+                            null,
+                            null)
                     .orElseGet(() -> {
                         CartItem newCartItem = new CartItem();
                         newCartItem.setUser(user);
@@ -300,9 +319,11 @@ public class CartService {
 
             Product product = productService.loadProduct(row.productId());
             CartItem cartItem = cartRepository
-                    .findByUserIdAndProductIdAndPersonalizationTextAndGiftCardAmountAndGiftCardRecipientEmailAndGiftCardMessage(
+                    .findByUserIdAndProductIdAndPersonalizationTextAndGiftCardAmountAndGiftCardRecipientEmailAndGiftCardMessageAndSharedWishlistTokenAndSharedWishlistListId(
                             user.getId(),
                             product.getId(),
+                            null,
+                            null,
                             null,
                             null,
                             null,
@@ -362,6 +383,8 @@ public class CartService {
                 cartItem.getGiftCardAmount(),
                 cartItem.getGiftCardRecipientEmail(),
                 cartItem.getGiftCardMessage(),
+                cartItem.getSharedWishlistToken(),
+                cartItem.getSharedWishlistListId(),
                 cartItem.getProduct().getImageUrl(),
                 effectiveUnitPrice,
                 co2EmissionKg,

--- a/src/main/java/de/fhdw/webshop/cart/dto/AddToCartRequest.java
+++ b/src/main/java/de/fhdw/webshop/cart/dto/AddToCartRequest.java
@@ -10,5 +10,7 @@ public record AddToCartRequest(
         String personalizationText,
         BigDecimal giftCardAmount,
         String giftCardRecipientEmail,
-        String giftCardMessage
+        String giftCardMessage,
+        String sharedWishlistToken,
+        String sharedWishlistListId
 ) {}

--- a/src/main/java/de/fhdw/webshop/cart/dto/CartItemResponse.java
+++ b/src/main/java/de/fhdw/webshop/cart/dto/CartItemResponse.java
@@ -13,6 +13,8 @@ public record CartItemResponse(
         BigDecimal giftCardAmount,
         String giftCardRecipientEmail,
         String giftCardMessage,
+        String sharedWishlistToken,
+        String sharedWishlistListId,
         String imageUrl,
         BigDecimal unitPrice,
         BigDecimal co2EmissionKg,

--- a/src/main/java/de/fhdw/webshop/order/OrderItem.java
+++ b/src/main/java/de/fhdw/webshop/order/OrderItem.java
@@ -58,4 +58,10 @@ public class OrderItem {
 
     @Column(name = "gift_card_redeemed_order_number", length = 30)
     private String giftCardRedeemedOrderNumber;
+
+    @Column(name = "shared_wishlist_token", length = 80)
+    private String sharedWishlistToken;
+
+    @Column(name = "shared_wishlist_list_id", length = 140)
+    private String sharedWishlistListId;
 }

--- a/src/main/java/de/fhdw/webshop/order/OrderService.java
+++ b/src/main/java/de/fhdw/webshop/order/OrderService.java
@@ -41,6 +41,7 @@ import de.fhdw.webshop.user.UserRole;
 import de.fhdw.webshop.user.UserType;
 import de.fhdw.webshop.user.dto.DeliveryAddressRequest;
 import de.fhdw.webshop.user.dto.PaymentMethodRequest;
+import de.fhdw.webshop.wishlist.WishlistService;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import java.math.BigDecimal;
@@ -107,6 +108,7 @@ public class OrderService {
     private final AccountLinkRepository accountLinkRepository;
     private final PickupStoreRepository pickupStoreRepository;
     private final PickupStoreService pickupStoreService;
+    private final WishlistService wishlistService;
 
     @Value("${app.frontend.base-url:http://localhost:5173}")
     private String frontendBaseUrl;
@@ -179,6 +181,12 @@ public class OrderService {
             if (!giftCard && orderItem.getQuantity() > product.getStock()) {
                 throw new IllegalArgumentException("Only " + product.getStock() + " units of " + product.getName() + " are available");
             }
+            wishlistService.validateGiftPurchase(
+                    orderItem.getSharedWishlistToken(),
+                    orderItem.getSharedWishlistListId(),
+                    product.getId(),
+                    orderItem.getQuantity()
+            );
             if (giftCard) {
                 ensureGiftCardCode(orderItem);
             } else {
@@ -193,6 +201,7 @@ public class OrderService {
         order.setApprovalRejectionReason(null);
         Order savedOrder = orderRepository.save(order);
         productRepository.saveAll(updatedProducts);
+        wishlistService.recordGiftPurchases(savedOrder.getItems());
         markCheckoutCodeAsUsedByCode(savedOrder, manager);
         auditLogService.record(manager, "APPROVE_ORDER_REQUEST", "Order", savedOrder.getId(),
                 AuditInitiator.USER,
@@ -322,7 +331,9 @@ public class OrderService {
                                 cartItem.getPersonalizationText(),
                                 cartItem.getGiftCardAmount(),
                                 cartItem.getGiftCardRecipientEmail(),
-                                cartItem.getGiftCardMessage()))
+                                cartItem.getGiftCardMessage(),
+                                cartItem.getSharedWishlistToken(),
+                                cartItem.getSharedWishlistListId()))
                         .toList(),
                 deliveryAddress,
                 shippingMethod,
@@ -364,7 +375,9 @@ public class OrderService {
                         item.personalizationText(),
                         item.giftCardAmount(),
                         item.giftCardRecipientEmail(),
-                        item.giftCardMessage()))
+                        item.giftCardMessage(),
+                        item.sharedWishlistToken(),
+                        item.sharedWishlistListId()))
                 .toList();
 
         return prepareOrder(
@@ -444,6 +457,17 @@ public class OrderService {
             BigDecimal giftCardAmount = resolveGiftCardAmount(product, requestedItem.giftCardAmount());
             String giftCardRecipientEmail = normalizeEmail(requestedItem.giftCardRecipientEmail());
             String giftCardMessage = normalizeGiftCardMessage(requestedItem.giftCardMessage());
+            String sharedWishlistToken = trimToNull(requestedItem.sharedWishlistToken());
+            String sharedWishlistListId = trimToNull(requestedItem.sharedWishlistListId());
+            if ((sharedWishlistToken == null) != (sharedWishlistListId == null)) {
+                throw new IllegalArgumentException("Die geteilte Liste konnte nicht eindeutig zugeordnet werden.");
+            }
+            wishlistService.validateGiftPurchase(
+                    sharedWishlistToken,
+                    sharedWishlistListId,
+                    product.getId(),
+                    requestedItem.quantity()
+            );
 
             BigDecimal discountPercent = discountCustomerId != null
                     ? discountLookupPort.findBestActiveDiscountPercent(discountCustomerId, product.getId())
@@ -462,6 +486,8 @@ public class OrderService {
                     giftCardAmount,
                     giftCardRecipientEmail,
                     giftCardMessage,
+                    sharedWishlistToken,
+                    sharedWishlistListId,
                     unitPrice,
                     lineTotal));
         }
@@ -643,12 +669,15 @@ public class OrderService {
             orderItem.setQuantity(preparedItem.quantity());
             orderItem.setPersonalizationText(preparedItem.personalizationText());
             applyGiftCardDetails(orderItem, preparedItem, true);
+            orderItem.setSharedWishlistToken(preparedItem.sharedWishlistToken());
+            orderItem.setSharedWishlistListId(preparedItem.sharedWishlistListId());
             orderItem.setPriceAtOrderTime(preparedItem.unitPrice());
             order.getItems().add(orderItem);
         }
 
         Order savedOrder = orderRepository.save(order);
         productRepository.saveAll(updatedProducts);
+        wishlistService.recordGiftPurchases(savedOrder.getItems());
         return savedOrder;
     }
 
@@ -679,6 +708,8 @@ public class OrderService {
             orderItem.setQuantity(preparedItem.quantity());
             orderItem.setPersonalizationText(preparedItem.personalizationText());
             applyGiftCardDetails(orderItem, preparedItem, false);
+            orderItem.setSharedWishlistToken(preparedItem.sharedWishlistToken());
+            orderItem.setSharedWishlistListId(preparedItem.sharedWishlistListId());
             orderItem.setPriceAtOrderTime(preparedItem.unitPrice());
             order.getItems().add(orderItem);
         }
@@ -1321,6 +1352,8 @@ public class OrderService {
                 orderItem.getGiftCardRecipientEmail(),
                 orderItem.getGiftCardMessage(),
                 orderItem.getGiftCardCode(),
+                orderItem.getSharedWishlistToken(),
+                orderItem.getSharedWishlistListId(),
                 orderItem.getProduct().isPurchasable(),
                 orderItem.getQuantity(),
                 orderItem.getPriceAtOrderTime(),
@@ -1486,7 +1519,9 @@ public class OrderService {
             String personalizationText,
             BigDecimal giftCardAmount,
             String giftCardRecipientEmail,
-            String giftCardMessage
+            String giftCardMessage,
+            String sharedWishlistToken,
+            String sharedWishlistListId
     ) {}
 
     private record PreparedOrderItem(
@@ -1496,6 +1531,8 @@ public class OrderService {
             BigDecimal giftCardAmount,
             String giftCardRecipientEmail,
             String giftCardMessage,
+            String sharedWishlistToken,
+            String sharedWishlistListId,
             BigDecimal unitPrice,
             BigDecimal lineTotal
     ) {}

--- a/src/main/java/de/fhdw/webshop/order/dto/OrderItemResponse.java
+++ b/src/main/java/de/fhdw/webshop/order/dto/OrderItemResponse.java
@@ -14,6 +14,8 @@ public record OrderItemResponse(
         String giftCardRecipientEmail,
         String giftCardMessage,
         String giftCardCode,
+        String sharedWishlistToken,
+        String sharedWishlistListId,
         boolean productPurchasable,
         int quantity,
         BigDecimal priceAtOrderTime,

--- a/src/main/java/de/fhdw/webshop/order/dto/PlaceOrderItemRequest.java
+++ b/src/main/java/de/fhdw/webshop/order/dto/PlaceOrderItemRequest.java
@@ -10,5 +10,7 @@ public record PlaceOrderItemRequest(
         String personalizationText,
         BigDecimal giftCardAmount,
         String giftCardRecipientEmail,
-        String giftCardMessage
+        String giftCardMessage,
+        String sharedWishlistToken,
+        String sharedWishlistListId
 ) {}

--- a/src/main/java/de/fhdw/webshop/wishlist/WishlistService.java
+++ b/src/main/java/de/fhdw/webshop/wishlist/WishlistService.java
@@ -2,6 +2,7 @@ package de.fhdw.webshop.wishlist;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import de.fhdw.webshop.order.OrderItem;
 import de.fhdw.webshop.user.User;
 import de.fhdw.webshop.user.UserRepository;
 import de.fhdw.webshop.wishlist.dto.SharedWishlistResponse;
@@ -127,6 +128,49 @@ public class WishlistService {
                 ));
     }
 
+    public void validateGiftPurchase(String shareToken, String listId, Long productId, int quantity) {
+        if (!hasGiftReference(shareToken, listId)) {
+            return;
+        }
+        if (productId == null || quantity <= 0) {
+            throw new IllegalArgumentException("Der Geschenkartikel ist ungueltig.");
+        }
+
+        SharedGiftTarget target = findSharedGiftTarget(shareToken, listId, productId);
+        int remainingQuantity = remainingGiftQuantity(target.item());
+        if (quantity > remainingQuantity) {
+            throw new IllegalArgumentException(
+                    target.item().name() + " wurde bereits ausreichend aus dieser geteilten Liste gekauft."
+            );
+        }
+    }
+
+    @Transactional
+    public void recordGiftPurchases(List<OrderItem> orderItems) {
+        if (orderItems == null || orderItems.isEmpty()) {
+            return;
+        }
+
+        Map<GiftPurchaseKey, Integer> purchasedQuantities = new LinkedHashMap<>();
+        for (OrderItem orderItem : orderItems) {
+            if (orderItem == null || orderItem.getProduct() == null) {
+                continue;
+            }
+            if (!hasGiftReference(orderItem.getSharedWishlistToken(), orderItem.getSharedWishlistListId())) {
+                continue;
+            }
+
+            GiftPurchaseKey key = new GiftPurchaseKey(
+                    orderItem.getSharedWishlistToken().trim(),
+                    orderItem.getSharedWishlistListId().trim(),
+                    orderItem.getProduct().getId()
+            );
+            purchasedQuantities.merge(key, Math.max(0, orderItem.getQuantity()), Integer::sum);
+        }
+
+        purchasedQuantities.forEach(this::recordGiftPurchase);
+    }
+
     private WishlistStateDto createDefaultWishlistState() {
         return new WishlistStateDto(
                 List.of(new WishlistListDto(DEFAULT_WISHLIST_ID, DEFAULT_WISHLIST_NAME, Instant.now().toString(), false, null, null)),
@@ -185,7 +229,9 @@ public class WishlistService {
                     item.stock(),
                     item.inventory(),
                     normalizeText(item.savedAt(), Instant.now().toString()),
-                    normalizeText(item.note(), "")
+                    normalizeText(item.note(), ""),
+                    normalizeDesiredQuantity(item.desiredQuantity()),
+                    normalizePurchasedQuantity(item.purchasedQuantity(), normalizeDesiredQuantity(item.desiredQuantity()))
             ));
         }
 
@@ -198,6 +244,100 @@ public class WishlistService {
             return fallback;
         }
         return value.trim();
+    }
+
+    private Integer normalizeDesiredQuantity(Integer value) {
+        if (value == null || value < 1) {
+            return 1;
+        }
+        return value;
+    }
+
+    private Integer normalizePurchasedQuantity(Integer value, Integer desiredQuantity) {
+        int normalizedValue = value == null ? 0 : Math.max(0, value);
+        return Math.min(normalizedValue, normalizeDesiredQuantity(desiredQuantity));
+    }
+
+    private int remainingGiftQuantity(WishlistItemDto item) {
+        int desiredQuantity = normalizeDesiredQuantity(item.desiredQuantity());
+        int purchasedQuantity = normalizePurchasedQuantity(item.purchasedQuantity(), desiredQuantity);
+        return Math.max(0, desiredQuantity - purchasedQuantity);
+    }
+
+    private boolean hasGiftReference(String shareToken, String listId) {
+        return shareToken != null && !shareToken.isBlank()
+                && listId != null && !listId.isBlank();
+    }
+
+    private SharedGiftTarget findSharedGiftTarget(String shareToken, String listId, Long productId) {
+        String normalizedToken = normalizeNullableText(shareToken);
+        String normalizedListId = normalizeNullableText(listId);
+        if (normalizedToken == null || normalizedListId == null) {
+            throw new IllegalArgumentException("Die geteilte Liste konnte nicht zugeordnet werden.");
+        }
+
+        return userRepository.findByWishlistStateContaining(normalizedToken).stream()
+                .map(owner -> {
+                    WishlistStateDto state = getWishlistState(owner);
+                    boolean listShared = state.lists().stream()
+                            .anyMatch(list -> normalizedListId.equals(list.id())
+                                    && Boolean.TRUE.equals(list.shared())
+                                    && normalizedToken.equals(list.shareToken()));
+                    if (!listShared) {
+                        return null;
+                    }
+
+                    return state.items().stream()
+                            .filter(item -> normalizedListId.equals(item.listId()))
+                            .filter(item -> productId.equals(item.productId()))
+                            .findFirst()
+                            .map(item -> new SharedGiftTarget(owner, state, item))
+                            .orElse(null);
+                })
+                .filter(target -> target != null)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Der Geschenkartikel ist auf der geteilten Liste nicht mehr verfuegbar."
+                ));
+    }
+
+    private void recordGiftPurchase(GiftPurchaseKey key, Integer purchasedQuantity) {
+        if (purchasedQuantity == null || purchasedQuantity <= 0) {
+            return;
+        }
+
+        SharedGiftTarget target = findSharedGiftTarget(key.shareToken(), key.listId(), key.productId());
+        WishlistStateDto state = target.state();
+        List<WishlistItemDto> updatedItems = state.items().stream()
+                .map(item -> {
+                    if (!key.listId().equals(item.listId()) || !key.productId().equals(item.productId())) {
+                        return item;
+                    }
+
+                    int desiredQuantity = normalizeDesiredQuantity(item.desiredQuantity());
+                    int currentPurchasedQuantity = normalizePurchasedQuantity(item.purchasedQuantity(), desiredQuantity);
+                    int nextPurchasedQuantity = Math.min(desiredQuantity, currentPurchasedQuantity + purchasedQuantity);
+                    return new WishlistItemDto(
+                            item.listId(),
+                            item.productId(),
+                            item.name(),
+                            item.description(),
+                            item.category(),
+                            item.imageUrl(),
+                            item.recommendedRetailPrice(),
+                            item.purchasable(),
+                            item.promoted(),
+                            item.stock(),
+                            item.inventory(),
+                            item.savedAt(),
+                            item.note(),
+                            desiredQuantity,
+                            nextPurchasedQuantity
+                    );
+                })
+                .toList();
+
+        saveWishlistState(target.owner(), new WishlistStateDto(state.lists(), state.activeListId(), updatedItems));
     }
 
     private String normalizeNullableText(String value) {
@@ -253,5 +393,17 @@ public class WishlistService {
                 sharedItems
         );
     }
+
+    private record SharedGiftTarget(
+            User owner,
+            WishlistStateDto state,
+            WishlistItemDto item
+    ) {}
+
+    private record GiftPurchaseKey(
+            String shareToken,
+            String listId,
+            Long productId
+    ) {}
 
 }

--- a/src/main/java/de/fhdw/webshop/wishlist/dto/WishlistItemDto.java
+++ b/src/main/java/de/fhdw/webshop/wishlist/dto/WishlistItemDto.java
@@ -15,6 +15,8 @@ public record WishlistItemDto(
         Integer stock,
         Integer inventory,
         String savedAt,
-        String note
+        String note,
+        Integer desiredQuantity,
+        Integer purchasedQuantity
 ) {
 }

--- a/src/main/resources/db/migration/V71__add_shared_wishlist_gift_tracking.sql
+++ b/src/main/resources/db/migration/V71__add_shared_wishlist_gift_tracking.sql
@@ -1,0 +1,13 @@
+ALTER TABLE cart_items
+    ADD COLUMN IF NOT EXISTS shared_wishlist_token VARCHAR(80),
+    ADD COLUMN IF NOT EXISTS shared_wishlist_list_id VARCHAR(140);
+
+CREATE INDEX IF NOT EXISTS ix_cart_items_shared_wishlist
+    ON cart_items (shared_wishlist_token, shared_wishlist_list_id);
+
+ALTER TABLE order_items
+    ADD COLUMN IF NOT EXISTS shared_wishlist_token VARCHAR(80),
+    ADD COLUMN IF NOT EXISTS shared_wishlist_list_id VARCHAR(140);
+
+CREATE INDEX IF NOT EXISTS ix_order_items_shared_wishlist
+    ON order_items (shared_wishlist_token, shared_wishlist_list_id);

--- a/src/test/java/de/fhdw/webshop/order/OrderServiceTest.java
+++ b/src/test/java/de/fhdw/webshop/order/OrderServiceTest.java
@@ -31,6 +31,7 @@ import de.fhdw.webshop.user.UserType;
 import de.fhdw.webshop.user.dto.DeliveryAddressRequest;
 import de.fhdw.webshop.user.dto.PaymentMethodRequest;
 import de.fhdw.webshop.notification.EmailService;
+import de.fhdw.webshop.wishlist.WishlistService;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
@@ -234,6 +235,7 @@ class OrderServiceTest {
         AccountLinkRepository accountLinkRepository = mock(AccountLinkRepository.class);
         PickupStoreRepository pickupStoreRepository = mock(PickupStoreRepository.class);
         PickupStoreService pickupStoreService = mock(PickupStoreService.class);
+        WishlistService wishlistService = mock(WishlistService.class);
 
         OrderService service = new OrderService(
                 orderRepository,
@@ -255,7 +257,8 @@ class OrderServiceTest {
                 addressLookupService,
                 accountLinkRepository,
                 pickupStoreRepository,
-                pickupStoreService);
+                pickupStoreService,
+                wishlistService);
 
         User customer = businessCustomer(10L, "employee");
         User manager = businessCustomer(11L, "manager");


### PR DESCRIPTION
# Pull Request

## 📝 Beschreibung

Diese PR erweitert Backend, Warenkorb und Checkout um die Nachverfolgung von Geschenk-Käufen aus geteilten Merklisten. Beim Checkout wird geprüft, ob ein Wunsch noch offen ist. Nach erfolgreicher Bestellung wird die gekaufte Menge in der öffentlichen Liste aktualisiert.

## 🎯 Ticket

Resolves #233

## 📋 Änderungen

- [x] Neue Features hinzugefügt
- [ ] Bugs behoben
- [ ] Code refaktoriert
- [x] Code ist selbsterklärend mit Kommentaren
- [x] Tests geschrieben/aktualisiert
- [ ] Dokumentation aktualisiert

## 🔗 Related Issues

- Relates to #233
