### PR TITLE
#248 add employee number handling and user filtering by role

### DIFF
--- a/src/main/java/de/fhdw/webshop/accountlink/AccountLinkService.java
+++ b/src/main/java/de/fhdw/webshop/accountlink/AccountLinkService.java
@@ -215,9 +215,10 @@ public class AccountLinkService {
                 user.getUsername(),
                 user.getEmail(),
                 user.getRoles(),
+                user.isActive(),
+                user.getEmployeeNumber(),
                 user.getUserType(),
                 user.getCustomerNumber(),
-                user.isActive(),
                 user.getAgbAcceptedAt());
     }
 }

--- a/src/main/java/de/fhdw/webshop/admin/AdminController.java
+++ b/src/main/java/de/fhdw/webshop/admin/AdminController.java
@@ -23,7 +23,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
-
+import java.util.EnumSet;
 import java.util.Set;
 
 import java.util.List;
@@ -47,7 +47,8 @@ public class AdminController {
     @GetMapping("/users")
     public ResponseEntity<List<UserProfileResponse>> listAllUsers(
             @RequestParam(required = false) String search,
-            @RequestParam(defaultValue = "false") boolean activeOnly) {
+            @RequestParam(required = false) AdminUserFilterType userType,
+            @RequestParam(defaultValue = "true") boolean activeOnly) {
         String searchTerm = search == null ? "" : search.trim();
         Long searchId = parseIdSearch(searchTerm);
         List<User> matchingUsers = searchId == null
@@ -58,12 +59,30 @@ public class AdminController {
                         .toList();
 
         List<UserProfileResponse> users = matchingUsers.stream()
-                .map(user -> new UserProfileResponse(
-                        user.getId(), user.getUsername(), user.getEmail(),
-                        user.getRoles(), user.getUserType(), user.getCustomerNumber(),
-                        user.isActive(), user.getAgbAcceptedAt()))
+                .filter(user -> matchesRequestedUserType(user, userType))
+                .map(this::toProfileResponse)
                 .toList();
         return ResponseEntity.ok(users);
+    }
+
+    private boolean matchesRequestedUserType(User user, AdminUserFilterType userType) {
+        if (userType == null) {
+            return true;
+        }
+
+        return switch (userType) {
+            case INTERNAL -> user.getRoles().stream().anyMatch(this::isInternalRole);
+            case CUSTOMER -> user.hasRole(UserRole.CUSTOMER);
+        };
+    }
+
+    private boolean isInternalRole(UserRole role) {
+        return EnumSet.of(
+                UserRole.EMPLOYEE,
+                UserRole.SALES_EMPLOYEE,
+                UserRole.WAREHOUSE_EMPLOYEE,
+                UserRole.ADMIN
+        ).contains(role);
     }
 
     private Long parseIdSearch(String searchTerm) {
@@ -98,11 +117,7 @@ public class AdminController {
         newUser.setUserType(request.userType());
         newUser.getRoles().add(effectiveRole);
 
-        if (effectiveRole == UserRole.CUSTOMER) {
-            Long nextSequenceValue = jdbcTemplate.queryForObject(
-                    "SELECT nextval('customer_number_sequence')", Long.class);
-            newUser.setCustomerNumber(String.valueOf(nextSequenceValue));
-        }
+        synchronizeUserBusinessIdentifiers(newUser, effectiveRole);
 
         User savedUser = userRepository.save(newUser);
         auditLogService.record(adminUser, "CREATE_USER", "User", savedUser.getId(),
@@ -156,13 +171,7 @@ public class AdminController {
         targetUser.getRoles().clear();
         targetUser.getRoles().addAll(newRoles);
 
-        if (effectiveRole == UserRole.CUSTOMER && targetUser.getCustomerNumber() == null) {
-            Long nextSequenceValue = jdbcTemplate.queryForObject(
-                    "SELECT nextval('customer_number_sequence')", Long.class);
-            targetUser.setCustomerNumber(String.valueOf(nextSequenceValue));
-        } else if (effectiveRole != UserRole.CUSTOMER) {
-            targetUser.setCustomerNumber(null);
-        }
+        synchronizeUserBusinessIdentifiers(targetUser, effectiveRole);
 
         userRepository.save(targetUser);
 
@@ -188,10 +197,42 @@ public class AdminController {
                 user.getUsername(),
                 user.getEmail(),
                 user.getRoles(),
+                user.isActive(),
+                user.getEmployeeNumber(),
                 user.getUserType(),
                 user.getCustomerNumber(),
-                user.isActive(),
                 user.getAgbAcceptedAt());
+    }
+
+    private void synchronizeUserBusinessIdentifiers(User user, UserRole effectiveRole) {
+        if (effectiveRole == UserRole.CUSTOMER) {
+            if (user.getCustomerNumber() == null) {
+                user.setCustomerNumber(nextCustomerNumber());
+            }
+            user.setEmployeeNumber(null);
+            return;
+        }
+
+        user.setCustomerNumber(null);
+        if (user.getEmployeeNumber() == null) {
+            user.setEmployeeNumber(nextEmployeeNumber());
+        }
+    }
+
+    private String nextCustomerNumber() {
+        Long nextSequenceValue = jdbcTemplate.queryForObject(
+                "SELECT nextval('customer_number_sequence')", Long.class);
+        return String.valueOf(nextSequenceValue);
+    }
+
+    private String nextEmployeeNumber() {
+        Long nextSequenceValue = jdbcTemplate.queryForObject(
+                "SELECT nextval('employee_number_sequence')", Long.class);
+        return formatEmployeeNumber(nextSequenceValue);
+    }
+
+    private String formatEmployeeNumber(long sequenceValue) {
+        return "MA-" + String.format("%05d", sequenceValue);
     }
 
     @PatchMapping("/users/{id}/deactivate")

--- a/src/main/java/de/fhdw/webshop/admin/AdminUserFilterType.java
+++ b/src/main/java/de/fhdw/webshop/admin/AdminUserFilterType.java
@@ -1,0 +1,7 @@
+package de.fhdw.webshop.admin;
+
+public enum AdminUserFilterType {
+    INTERNAL,
+    CUSTOMER
+}
+

--- a/src/main/java/de/fhdw/webshop/customer/CustomerController.java
+++ b/src/main/java/de/fhdw/webshop/customer/CustomerController.java
@@ -39,6 +39,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -66,26 +67,20 @@ public class CustomerController {
     @GetMapping
     @PreAuthorize("hasAnyRole('EMPLOYEE', 'SALES_EMPLOYEE', 'ADMIN')")
     public ResponseEntity<List<UserProfileResponse>> listCustomers(
-            @RequestParam(required = false) String search) {
+            @RequestParam(required = false) String search,
+            @RequestParam(defaultValue = "false") boolean includeInactive) {
         String searchTerm = search == null ? "" : search.trim();
         Long searchId = parseIdSearch(searchTerm);
         List<User> matchingCustomers = searchId == null
-                ? userRepository.findActiveCustomers(searchTerm, UserRole.CUSTOMER)
+                ? userRepository.findCustomers(searchTerm, includeInactive, UserRole.CUSTOMER)
                 : userRepository.findById(searchId)
-                        .filter(user -> user.isActive() && user.getRoles().contains(UserRole.CUSTOMER))
+                        .filter(this::isCustomer)
+                        .filter(user -> includeInactive || user.isActive())
                         .stream()
                         .toList();
 
         List<UserProfileResponse> customers = matchingCustomers.stream()
-                .map(user -> new UserProfileResponse(
-                        user.getId(),
-                        user.getUsername(),
-                        user.getEmail(),
-                        user.getRoles(),
-                        user.getUserType(),
-                        user.getCustomerNumber(),
-                        user.isActive(),
-                        user.getAgbAcceptedAt()))
+                .map(this::toProfileResponse)
                 .toList();
         return ResponseEntity.ok(customers);
     }
@@ -106,16 +101,26 @@ public class CustomerController {
     @GetMapping("/{id}")
     @PreAuthorize("hasAnyRole('EMPLOYEE', 'SALES_EMPLOYEE', 'ADMIN')")
     public ResponseEntity<UserProfileResponse> getCustomer(@PathVariable Long id) {
-        User customer = userService.loadById(id);
-        return ResponseEntity.ok(new UserProfileResponse(
-                customer.getId(),
-                customer.getUsername(),
-                customer.getEmail(),
-                customer.getRoles(),
-                customer.getUserType(),
-                customer.getCustomerNumber(),
-                customer.isActive(),
-                customer.getAgbAcceptedAt()));
+        User customer = loadCustomerById(id);
+        return ResponseEntity.ok(toProfileResponse(customer));
+    }
+
+    @PatchMapping("/{id}/deactivate")
+    @PreAuthorize("hasAnyRole('EMPLOYEE', 'SALES_EMPLOYEE', 'ADMIN')")
+    public ResponseEntity<UserProfileResponse> deactivateCustomer(@PathVariable Long id) {
+        User customer = loadCustomerById(id);
+        customer.setActive(false);
+        userRepository.save(customer);
+        return ResponseEntity.ok(toProfileResponse(customer));
+    }
+
+    @PatchMapping("/{id}/activate")
+    @PreAuthorize("hasAnyRole('EMPLOYEE', 'SALES_EMPLOYEE', 'ADMIN')")
+    public ResponseEntity<UserProfileResponse> activateCustomer(@PathVariable Long id) {
+        User customer = loadCustomerById(id);
+        customer.setActive(true);
+        userRepository.save(customer);
+        return ResponseEntity.ok(toProfileResponse(customer));
     }
 
     /** US #11 - View a customer's cart on their behalf. */
@@ -286,9 +291,10 @@ public class CustomerController {
                 customer.getUsername(),
                 customer.getEmail(),
                 customer.getRoles(),
+                customer.isActive(),
+                customer.getEmployeeNumber(),
                 customer.getUserType(),
                 customer.getCustomerNumber(),
-                customer.isActive(),
                 customer.getAgbAcceptedAt());
 
         CartResponse cart = cartService.getCart(id);
@@ -353,6 +359,31 @@ public class CustomerController {
 
     private String defaultString(String value) {
         return value != null ? value : "";
+    }
+
+    private User loadCustomerById(Long id) {
+        User customer = userService.loadById(id);
+        if (!isCustomer(customer)) {
+            throw new IllegalArgumentException("Dieser Endpunkt gilt nur fuer Kundenkonten.");
+        }
+        return customer;
+    }
+
+    private boolean isCustomer(User user) {
+        return user.getRoles() != null && user.getRoles().contains(UserRole.CUSTOMER);
+    }
+
+    private UserProfileResponse toProfileResponse(User user) {
+        return new UserProfileResponse(
+                user.getId(),
+                user.getUsername(),
+                user.getEmail(),
+                user.getRoles(),
+                user.isActive(),
+                user.getEmployeeNumber(),
+                user.getUserType(),
+                user.getCustomerNumber(),
+                user.getAgbAcceptedAt());
     }
 
     private List<String> buildAlerts(

--- a/src/main/java/de/fhdw/webshop/user/User.java
+++ b/src/main/java/de/fhdw/webshop/user/User.java
@@ -55,6 +55,9 @@ public class User implements UserDetails {
     @Column(name = "customer_number", unique = true, length = 20)
     private String customerNumber;
 
+    @Column(name = "employee_number", unique = true, length = 20)
+    private String employeeNumber;
+
     @Column(nullable = false)
     private boolean active = true;
 

--- a/src/main/java/de/fhdw/webshop/user/UserRepository.java
+++ b/src/main/java/de/fhdw/webshop/user/UserRepository.java
@@ -30,14 +30,15 @@ public interface UserRepository extends JpaRepository<User, Long> {
         @Query("""
                         SELECT u FROM User u
                         WHERE :customerRole MEMBER OF u.roles
-                          AND u.active = true
+                          AND (:includeInactive = true OR u.active = true)
                           AND (:searchTerm = ''
                                OR LOWER(u.username) LIKE LOWER(CONCAT('%', :searchTerm, '%'))
                                OR LOWER(u.email)    LIKE LOWER(CONCAT('%', :searchTerm, '%'))
                                OR LOWER(COALESCE(u.customerNumber, '')) LIKE LOWER(CONCAT('%', :searchTerm, '%')))
                         """)
-        List<User> findActiveCustomers(@Param("searchTerm") String searchTerm,
-                                       @Param("customerRole") UserRole customerRole);
+        List<User> findCustomers(@Param("searchTerm") String searchTerm,
+                                 @Param("includeInactive") boolean includeInactive,
+                                 @Param("customerRole") UserRole customerRole);
 
         /**
          * Returns all users, optionally filtered by text fields (admin view).
@@ -49,7 +50,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
                           AND (:searchTerm = ''
                                OR LOWER(u.username) LIKE LOWER(CONCAT('%', :searchTerm, '%'))
                                OR LOWER(u.email)    LIKE LOWER(CONCAT('%', :searchTerm, '%'))
-                               OR LOWER(COALESCE(u.customerNumber, '')) LIKE LOWER(CONCAT('%', :searchTerm, '%')))
+                               OR LOWER(COALESCE(u.customerNumber, '')) LIKE LOWER(CONCAT('%', :searchTerm, '%'))
+                               OR LOWER(COALESCE(u.employeeNumber, '')) LIKE LOWER(CONCAT('%', :searchTerm, '%')))
                         """)
         List<User> findAllUsers(@Param("searchTerm") String searchTerm, @Param("activeOnly") boolean activeOnly);
 

--- a/src/main/java/de/fhdw/webshop/user/UserService.java
+++ b/src/main/java/de/fhdw/webshop/user/UserService.java
@@ -107,9 +107,10 @@ public class UserService {
                 user.getUsername(),
                 user.getEmail(),
                 user.getRoles(),
+                user.isActive(),
+                user.getEmployeeNumber(),
                 user.getUserType(),
                 user.getCustomerNumber(),
-                user.isActive(),
                 user.getAgbAcceptedAt()
         );
     }

--- a/src/main/java/de/fhdw/webshop/user/dto/UserProfileResponse.java
+++ b/src/main/java/de/fhdw/webshop/user/dto/UserProfileResponse.java
@@ -11,8 +11,9 @@ public record UserProfileResponse(
         String username,
         String email,
         Set<UserRole> roles,
+        boolean active,
+        String employeeNumber,
         UserType userType,
         String customerNumber,
-        boolean active,
         Instant agbAcceptedAt
 ) {}

--- a/src/main/resources/db/dev-seed.sql
+++ b/src/main/resources/db/dev-seed.sql
@@ -6,13 +6,13 @@
 
 -- Users
 -- All passwords are: Password1!
-INSERT INTO users (username, email, password_hash, user_type, customer_number) VALUES
-  ('alice', 'alice@example.com', '$2a$10$yT.Ge6bLC.BWERriPv/wguUMUtBF4iA3W0Q5VNDklGalWYlGy3Zze', 'PRIVATE', nextval('customer_number_sequence')),
-  ('bob', 'bob@example.com', '$2a$10$yT.Ge6bLC.BWERriPv/wguUMUtBF4iA3W0Q5VNDklGalWYlGy3Zze', 'BUSINESS', nextval('customer_number_sequence')),
-  ('carol', 'carol@example.com', '$2a$10$yT.Ge6bLC.BWERriPv/wguUMUtBF4iA3W0Q5VNDklGalWYlGy3Zze', 'INTERNAL', NULL),
-  ('dave', 'dave@example.com', '$2a$10$yT.Ge6bLC.BWERriPv/wguUMUtBF4iA3W0Q5VNDklGalWYlGy3Zze', 'INTERNAL', NULL),
-  ('lager', 'lager@example.com', '$2a$10$yT.Ge6bLC.BWERriPv/wguUMUtBF4iA3W0Q5VNDklGalWYlGy3Zze', 'INTERNAL', NULL),
-  ('admin', 'admin@example.com', '$2a$10$yT.Ge6bLC.BWERriPv/wguUMUtBF4iA3W0Q5VNDklGalWYlGy3Zze', 'INTERNAL', NULL);
+INSERT INTO users (username, email, password_hash, user_type, customer_number, employee_number) VALUES
+  ('alice', 'alice@example.com', '$2a$10$yT.Ge6bLC.BWERriPv/wguUMUtBF4iA3W0Q5VNDklGalWYlGy3Zze', 'PRIVATE', 'K-' || to_char(nextval('customer_number_sequence'), 'FM000000'), NULL),
+  ('bob', 'bob@example.com', '$2a$10$yT.Ge6bLC.BWERriPv/wguUMUtBF4iA3W0Q5VNDklGalWYlGy3Zze', 'BUSINESS', 'K-' || to_char(nextval('customer_number_sequence'), 'FM000000'), NULL),
+  ('carol', 'carol@example.com', '$2a$10$yT.Ge6bLC.BWERriPv/wguUMUtBF4iA3W0Q5VNDklGalWYlGy3Zze', 'INTERNAL', NULL, 'MA-' || to_char(nextval('employee_number_sequence'), 'FM00000')),
+  ('dave', 'dave@example.com', '$2a$10$yT.Ge6bLC.BWERriPv/wguUMUtBF4iA3W0Q5VNDklGalWYlGy3Zze', 'INTERNAL', NULL, 'MA-' || to_char(nextval('employee_number_sequence'), 'FM00000')),
+  ('lager', 'lager@example.com', '$2a$10$yT.Ge6bLC.BWERriPv/wguUMUtBF4iA3W0Q5VNDklGalWYlGy3Zze', 'INTERNAL', NULL, 'MA-' || to_char(nextval('employee_number_sequence'), 'FM00000')),
+  ('admin', 'admin@example.com', '$2a$10$yT.Ge6bLC.BWERriPv/wguUMUtBF4iA3W0Q5VNDklGalWYlGy3Zze', 'INTERNAL', NULL, 'MA-' || to_char(nextval('employee_number_sequence'), 'FM00000'));
 
 -- Roles (m:n via user_roles pivot table, introduced in Migration V24)
 INSERT INTO user_roles (user_id, role)

--- a/src/main/resources/db/migration/V73__add_employee_numbers_to_users.sql
+++ b/src/main/resources/db/migration/V73__add_employee_numbers_to_users.sql
@@ -1,0 +1,27 @@
+CREATE SEQUENCE IF NOT EXISTS employee_number_sequence START 10001;
+
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS employee_number VARCHAR(20);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_users_employee_number
+    ON users(employee_number);
+
+WITH internal_users AS (
+    SELECT u.id, nextval('employee_number_sequence') AS next_employee_number
+    FROM users u
+    WHERE u.employee_number IS NULL
+      AND (
+          u.user_type = 'INTERNAL'
+          OR EXISTS (
+              SELECT 1
+              FROM user_roles ur
+              WHERE ur.user_id = u.id
+                AND ur.role IN ('EMPLOYEE', 'SALES_EMPLOYEE', 'WAREHOUSE_EMPLOYEE', 'ADMIN')
+          )
+      )
+)
+UPDATE users u
+SET employee_number = 'MA-' || to_char(internal_users.next_employee_number, 'FM00000')
+FROM internal_users
+WHERE u.id = internal_users.id;
+

--- a/src/test/java/de/fhdw/webshop/admin/AdminControllerTest.java
+++ b/src/test/java/de/fhdw/webshop/admin/AdminControllerTest.java
@@ -1,0 +1,257 @@
+package de.fhdw.webshop.admin;
+
+import de.fhdw.webshop.accountlink.AccountLinkService;
+import de.fhdw.webshop.alerting.BusinessEmailService;
+import de.fhdw.webshop.admin.dto.CreateAdminUserRequest;
+import de.fhdw.webshop.auth.JwtTokenProvider;
+import de.fhdw.webshop.user.User;
+import de.fhdw.webshop.user.UserRepository;
+import de.fhdw.webshop.user.UserRole;
+import de.fhdw.webshop.user.UserType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class AdminControllerTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private AuditLogRepository auditLogRepository;
+
+    @Mock
+    private AuditLogService auditLogService;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private BusinessEmailService businessEmailService;
+
+    @Mock
+    private AccountLinkService accountLinkService;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        AdminController controller = new AdminController(
+                userRepository,
+                auditLogRepository,
+                auditLogService,
+                jwtTokenProvider,
+                businessEmailService,
+                accountLinkService,
+                passwordEncoder,
+                jdbcTemplate
+        );
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Test
+    void listAllUsersUsesActiveOnlyTrueByDefaultAndIncludesEmployeeNumber() throws Exception {
+        User employee = user(
+                1L,
+                "max.mustermann",
+                "max@example.com",
+                Set.of(UserRole.EMPLOYEE),
+                UserType.INTERNAL,
+                true,
+                null,
+                "MA-10001"
+        );
+        when(userRepository.findAllUsers("", true)).thenReturn(List.of(employee));
+
+        mockMvc.perform(get("/api/admin/users"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].username").value("max.mustermann"))
+                .andExpect(jsonPath("$[0].email").value("max@example.com"))
+                .andExpect(jsonPath("$[0].roles[0]").value("EMPLOYEE"))
+                .andExpect(jsonPath("$[0].active").value(true))
+                .andExpect(jsonPath("$[0].employeeNumber").value("MA-10001"));
+
+        verify(userRepository).findAllUsers("", true);
+    }
+
+    @Test
+    void listAllUsersFiltersInternalUsersByRoleSet() throws Exception {
+        User employee = user(
+                1L,
+                "internal.user",
+                "internal@example.com",
+                Set.of(UserRole.SALES_EMPLOYEE),
+                UserType.INTERNAL,
+                true,
+                null,
+                "MA-10002"
+        );
+        User customer = user(
+                2L,
+                "customer.user",
+                "customer@example.com",
+                Set.of(UserRole.CUSTOMER),
+                UserType.PRIVATE,
+                true,
+                "100123",
+                null
+        );
+        when(userRepository.findAllUsers("", false)).thenReturn(List.of(employee, customer));
+
+        mockMvc.perform(get("/api/admin/users")
+                        .param("userType", "INTERNAL")
+                        .param("activeOnly", "false"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].username").value("internal.user"))
+                .andExpect(jsonPath("$[0].roles[0]").value("SALES_EMPLOYEE"))
+                .andExpect(jsonPath("$[0].employeeNumber").value("MA-10002"));
+
+        verify(userRepository).findAllUsers("", false);
+    }
+
+    @Test
+    void listAllUsersFiltersCustomersAndKeepsInactiveUsersWhenRequested() throws Exception {
+        User employee = user(
+                1L,
+                "internal.user",
+                "internal@example.com",
+                Set.of(UserRole.ADMIN),
+                UserType.INTERNAL,
+                true,
+                null,
+                "MA-10003"
+        );
+        User activeCustomer = user(
+                2L,
+                "active.customer",
+                "active.customer@example.com",
+                Set.of(UserRole.CUSTOMER),
+                UserType.BUSINESS,
+                true,
+                "100124",
+                null
+        );
+        User inactiveCustomer = user(
+                3L,
+                "inactive.customer",
+                "inactive.customer@example.com",
+                Set.of(UserRole.CUSTOMER),
+                UserType.PRIVATE,
+                false,
+                "100125",
+                null
+        );
+        when(userRepository.findAllUsers("", false)).thenReturn(List.of(employee, activeCustomer, inactiveCustomer));
+
+        mockMvc.perform(get("/api/admin/users")
+                        .param("userType", "CUSTOMER")
+                        .param("activeOnly", "false"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].username").value("active.customer"))
+                .andExpect(jsonPath("$[0].employeeNumber").isEmpty())
+                .andExpect(jsonPath("$[1].username").value("inactive.customer"))
+                .andExpect(jsonPath("$[1].employeeNumber").isEmpty())
+                .andExpect(jsonPath("$[1].active").value(false));
+
+        verify(userRepository).findAllUsers("", false);
+    }
+
+    @Test
+    void createUserAssignsEmployeeNumberForInternalUsers() {
+        User adminUser = user(
+                99L,
+                "admin",
+                "admin@example.com",
+                Set.of(UserRole.ADMIN),
+                UserType.INTERNAL,
+                true,
+                null,
+                "MA-99999"
+        );
+        CreateAdminUserRequest request = new CreateAdminUserRequest(
+                "warehouse.user",
+                "warehouse@example.com",
+                "Secret123!",
+                UserType.INTERNAL,
+                UserRole.WAREHOUSE_EMPLOYEE
+        );
+
+        when(userRepository.existsByUsername("warehouse.user")).thenReturn(false);
+        when(userRepository.existsByEmail("warehouse@example.com")).thenReturn(false);
+        when(passwordEncoder.encode("Secret123!")).thenReturn("encoded-password");
+        when(jdbcTemplate.queryForObject("SELECT nextval('employee_number_sequence')", Long.class)).thenReturn(10001L);
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
+            User savedUser = invocation.getArgument(0, User.class);
+            savedUser.setId(123L);
+            return savedUser;
+        });
+
+        var response = new AdminController(
+                userRepository,
+                auditLogRepository,
+                auditLogService,
+                jwtTokenProvider,
+                businessEmailService,
+                accountLinkService,
+                passwordEncoder,
+                jdbcTemplate
+        ).createUser(request, adminUser);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(201);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().employeeNumber()).isEqualTo("MA-10001");
+        assertThat(response.getBody().customerNumber()).isNull();
+        assertThat(response.getBody().roles()).containsExactly(UserRole.WAREHOUSE_EMPLOYEE);
+    }
+
+    private User user(
+            Long id,
+            String username,
+            String email,
+            Set<UserRole> roles,
+            UserType userType,
+            boolean active,
+            String customerNumber,
+            String employeeNumber
+    ) {
+        User user = new User();
+        user.setId(id);
+        user.setUsername(username);
+        user.setEmail(email);
+        user.setPasswordHash("secret");
+        user.setRoles(roles);
+        user.setUserType(userType);
+        user.setActive(active);
+        user.setCustomerNumber(customerNumber);
+        user.setEmployeeNumber(employeeNumber);
+        return user;
+    }
+}
+

--- a/src/test/java/de/fhdw/webshop/customer/CustomerControllerTest.java
+++ b/src/test/java/de/fhdw/webshop/customer/CustomerControllerTest.java
@@ -1,0 +1,189 @@
+package de.fhdw.webshop.customer;
+
+import de.fhdw.webshop.cart.CartService;
+import de.fhdw.webshop.cart.audit.CartChangeLogService;
+import de.fhdw.webshop.config.GlobalExceptionHandler;
+import de.fhdw.webshop.discount.DiscountService;
+import de.fhdw.webshop.notification.EmailService;
+import de.fhdw.webshop.order.OrderService;
+import de.fhdw.webshop.user.BusinessInfoRepository;
+import de.fhdw.webshop.user.User;
+import de.fhdw.webshop.user.UserRepository;
+import de.fhdw.webshop.user.UserRole;
+import de.fhdw.webshop.user.UserService;
+import de.fhdw.webshop.user.UserType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class CustomerControllerTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private CartService cartService;
+
+    @Mock
+    private CartChangeLogService cartChangeLogService;
+
+    @Mock
+    private OrderService orderService;
+
+    @Mock
+    private DiscountService discountService;
+
+    @Mock
+    private BusinessInfoRepository businessInfoRepository;
+
+    @Mock
+    private StatisticsService statisticsService;
+
+    @Mock
+    private EmailService emailService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        CustomerController controller = new CustomerController(
+                userRepository,
+                userService,
+                cartService,
+                cartChangeLogService,
+                orderService,
+                discountService,
+                businessInfoRepository,
+                statisticsService,
+                emailService
+        );
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void listCustomersReturnsOnlyActiveCustomersByDefault() throws Exception {
+        User activeCustomer = customer(5L, "max", "max@example.com", true, "K-100005");
+        when(userRepository.findCustomers("", false, UserRole.CUSTOMER)).thenReturn(List.of(activeCustomer));
+
+        mockMvc.perform(get("/api/customers"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].id").value(5))
+                .andExpect(jsonPath("$[0].username").value("max"))
+                .andExpect(jsonPath("$[0].email").value("max@example.com"))
+                .andExpect(jsonPath("$[0].active").value(true))
+                .andExpect(jsonPath("$[0].customerNumber").value("K-100005"));
+
+        verify(userRepository).findCustomers("", false, UserRole.CUSTOMER);
+    }
+
+    @Test
+    void listCustomersIncludesInactiveCustomersWhenRequested() throws Exception {
+        User activeCustomer = customer(5L, "max", "max@example.com", true, "K-100005");
+        User inactiveCustomer = customer(6L, "eva", "eva@example.com", false, "K-100006");
+        when(userRepository.findCustomers("", true, UserRole.CUSTOMER))
+                .thenReturn(List.of(activeCustomer, inactiveCustomer));
+
+        mockMvc.perform(get("/api/customers").param("includeInactive", "true"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].active").value(true))
+                .andExpect(jsonPath("$[1].active").value(false))
+                .andExpect(jsonPath("$[1].customerNumber").value("K-100006"));
+
+        verify(userRepository).findCustomers("", true, UserRole.CUSTOMER);
+    }
+
+    @Test
+    void deactivateCustomerUpdatesOnlyCustomerAccounts() throws Exception {
+        User customer = customer(5L, "max", "max@example.com", true, "K-100005");
+        when(userService.loadById(5L)).thenReturn(customer);
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0, User.class));
+
+        mockMvc.perform(patch("/api/customers/5/deactivate"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(5))
+                .andExpect(jsonPath("$.active").value(false))
+                .andExpect(jsonPath("$.customerNumber").value("K-100005"));
+
+        verify(userRepository).save(customer);
+    }
+
+    @Test
+    void activateCustomerReactivatesCustomerAccounts() throws Exception {
+        User customer = customer(5L, "max", "max@example.com", false, "K-100005");
+        when(userService.loadById(5L)).thenReturn(customer);
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0, User.class));
+
+        mockMvc.perform(patch("/api/customers/5/activate"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(5))
+                .andExpect(jsonPath("$.active").value(true))
+                .andExpect(jsonPath("$.customerNumber").value("K-100005"));
+
+        verify(userRepository).save(customer);
+    }
+
+    @Test
+    void deactivateCustomerRejectsInternalAccounts() throws Exception {
+        User employee = internalUser(9L, "employee", "employee@example.com", true, "MA-10001");
+        when(userService.loadById(9L)).thenReturn(employee);
+
+        mockMvc.perform(patch("/api/customers/9/deactivate"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Dieser Endpunkt gilt nur fuer Kundenkonten."));
+
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    private User customer(Long id, String username, String email, boolean active, String customerNumber) {
+        User user = new User();
+        user.setId(id);
+        user.setUsername(username);
+        user.setEmail(email);
+        user.setPasswordHash("secret");
+        user.setRoles(Set.of(UserRole.CUSTOMER));
+        user.setUserType(UserType.PRIVATE);
+        user.setActive(active);
+        user.setCustomerNumber(customerNumber);
+        user.setEmployeeNumber(null);
+        return user;
+    }
+
+    private User internalUser(Long id, String username, String email, boolean active, String employeeNumber) {
+        User user = new User();
+        user.setId(id);
+        user.setUsername(username);
+        user.setEmail(email);
+        user.setPasswordHash("secret");
+        user.setRoles(Set.of(UserRole.EMPLOYEE));
+        user.setUserType(UserType.INTERNAL);
+        user.setActive(active);
+        user.setCustomerNumber(null);
+        user.setEmployeeNumber(employeeNumber);
+        return user;
+    }
+}
+


### PR DESCRIPTION
Änderungen

- Admin-Benutzerverwaltung erweitert: GET /api/admin/users unterstützt jetzt zusätzlich den Filter userType (INTERNAL/CUSTOMER) sowie ein korrigiertes Standardverhalten für activeOnly (standardmäßig nur aktive Benutzer).
- Mitarbeiternummern eingeführt: Interne Benutzer erhalten eine eindeutige employeeNumber im Format MA-XXXXX; das Feld wird in den relevanten User-Responses mit ausgeliefert (bei Kunden null).
- Datenbankschema ergänzt: Neues Feld employee_number (unique, nullable) inkl. Sequence und Migration zur Nachvergabe für bestehende interne Benutzer ohne Nummer.
- Kundenaktivierung/-deaktivierung umgesetzt: Neue Endpunkte PATCH /api/customers/{id}/deactivate und PATCH /api/customers/{id}/activate setzen das active-Flag für Kundenkonten; interne Konten sind dafür ausgeschlossen (weiterhin Admin-Endpunkt nutzen).
- Kundenliste erweitert: GET /api/customers liefert das Feld active und unterstützt includeInactive=true, um optional auch deaktivierte Kunden anzuzeigen.
- Testdaten aktualisiert: dev-seed.sql wurde auf das aktuelle Schema angepasst (u. a. employee_number, formatiere Customer-/Mitarbeiternummern konsistent).