### PR TITLE
Feat/#239 user generated review images

### DIFF
--- a/src/main/java/de/fhdw/webshop/sellerreview/SellerReviewController.java
+++ b/src/main/java/de/fhdw/webshop/sellerreview/SellerReviewController.java
@@ -2,15 +2,18 @@ package de.fhdw.webshop.sellerreview;
 
 import de.fhdw.webshop.sellerreview.dto.CreateSellerReviewRequest;
 import de.fhdw.webshop.helpfulvote.dto.HelpfulVoteRequest;
+import de.fhdw.webshop.sellerreview.dto.SellerReviewImageResponse;
 import de.fhdw.webshop.sellerreview.dto.SellerReviewResponse;
 import de.fhdw.webshop.user.User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -34,7 +37,7 @@ public class SellerReviewController {
         return ResponseEntity.ok(sellerReviewService.listMyReviewsForOrder(orderId, currentUser));
     }
 
-    @PostMapping("/api/orders/{orderId}/seller-reviews")
+    @PostMapping(value = "/api/orders/{orderId}/seller-reviews", consumes = MediaType.APPLICATION_JSON_VALUE)
     @PreAuthorize("hasRole('CUSTOMER')")
     public ResponseEntity<SellerReviewResponse> createReview(
             @PathVariable Long orderId,
@@ -44,6 +47,20 @@ public class SellerReviewController {
                 .body(sellerReviewService.createReview(orderId, currentUser, request));
     }
 
+    @PostMapping(value = "/api/orders/{orderId}/seller-reviews", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public ResponseEntity<SellerReviewResponse> createReviewWithImages(
+            @PathVariable Long orderId,
+            @RequestParam String sellerName,
+            @RequestParam Integer rating,
+            @RequestParam(required = false) String comment,
+            @RequestPart(required = false) List<MultipartFile> images,
+            @AuthenticationPrincipal User currentUser) {
+        CreateSellerReviewRequest request = new CreateSellerReviewRequest(sellerName, rating, comment);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(sellerReviewService.createReview(orderId, currentUser, request, images));
+    }
+
     @PostMapping("/api/seller-reviews/{reviewId}/vote")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<SellerReviewResponse> voteReview(
@@ -51,5 +68,20 @@ public class SellerReviewController {
             @Valid @RequestBody HelpfulVoteRequest request,
             @AuthenticationPrincipal User currentUser) {
         return ResponseEntity.ok(sellerReviewService.voteReview(reviewId, currentUser, request.helpful()));
+    }
+
+    @GetMapping("/api/admin/seller-review-images")
+    @PreAuthorize("hasAnyRole('EMPLOYEE', 'SALES_EMPLOYEE', 'ADMIN')")
+    public ResponseEntity<List<SellerReviewImageResponse>> listReviewImagesForModeration() {
+        return ResponseEntity.ok(sellerReviewService.listImagesForModeration());
+    }
+
+    @DeleteMapping("/api/admin/seller-review-images/{imageId}")
+    @PreAuthorize("hasAnyRole('EMPLOYEE', 'SALES_EMPLOYEE', 'ADMIN')")
+    public ResponseEntity<Void> deleteReviewImage(
+            @PathVariable Long imageId,
+            @AuthenticationPrincipal User currentUser) {
+        sellerReviewService.deleteImage(imageId, currentUser);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/de/fhdw/webshop/sellerreview/SellerReviewImage.java
+++ b/src/main/java/de/fhdw/webshop/sellerreview/SellerReviewImage.java
@@ -1,0 +1,52 @@
+package de.fhdw.webshop.sellerreview;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "seller_review_images")
+@Getter
+@Setter
+@NoArgsConstructor
+public class SellerReviewImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "review_id", nullable = false)
+    private SellerReview review;
+
+    @Column(name = "original_filename", nullable = false, length = 255)
+    private String originalFilename;
+
+    @Column(name = "content_type", nullable = false, length = 80)
+    private String contentType;
+
+    @Column(name = "file_size_bytes", nullable = false)
+    private long fileSizeBytes;
+
+    @Column(name = "image_data", nullable = false, columnDefinition = "BYTEA")
+    private byte[] imageData;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    void onCreate() {
+        createdAt = Instant.now();
+    }
+}

--- a/src/main/java/de/fhdw/webshop/sellerreview/SellerReviewImageRepository.java
+++ b/src/main/java/de/fhdw/webshop/sellerreview/SellerReviewImageRepository.java
@@ -1,0 +1,13 @@
+package de.fhdw.webshop.sellerreview;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SellerReviewImageRepository extends JpaRepository<SellerReviewImage, Long> {
+
+    List<SellerReviewImage> findByReviewIdOrderByCreatedAtAsc(Long reviewId);
+
+    List<SellerReviewImage> findAllByOrderByCreatedAtDesc();
+
+    long countByReviewId(Long reviewId);
+}

--- a/src/main/java/de/fhdw/webshop/sellerreview/SellerReviewService.java
+++ b/src/main/java/de/fhdw/webshop/sellerreview/SellerReviewService.java
@@ -10,24 +10,33 @@ import de.fhdw.webshop.order.OrderItem;
 import de.fhdw.webshop.order.OrderRepository;
 import de.fhdw.webshop.order.OrderStatus;
 import de.fhdw.webshop.sellerreview.dto.CreateSellerReviewRequest;
+import de.fhdw.webshop.sellerreview.dto.SellerReviewImageResponse;
 import de.fhdw.webshop.sellerreview.dto.SellerReviewResponse;
 import de.fhdw.webshop.user.User;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
 public class SellerReviewService {
 
     private static final String DEFAULT_SELLER_NAME = "Webshop";
+    private static final int MAX_IMAGES_PER_REVIEW = 3;
+    private static final long MAX_IMAGE_SIZE_BYTES = 5L * 1024L * 1024L;
+    private static final Set<String> ALLOWED_IMAGE_TYPES = Set.of("image/jpeg", "image/png", "image/webp");
 
     private final SellerReviewRepository sellerReviewRepository;
+    private final SellerReviewImageRepository sellerReviewImageRepository;
     private final OrderRepository orderRepository;
     private final AuditLogService auditLogService;
     private final HelpfulVoteService helpfulVoteService;
@@ -64,6 +73,11 @@ public class SellerReviewService {
 
     @Transactional
     public SellerReviewResponse createReview(Long orderId, User currentUser, CreateSellerReviewRequest request) {
+        return createReview(orderId, currentUser, request, List.of());
+    }
+
+    @Transactional
+    public SellerReviewResponse createReview(Long orderId, User currentUser, CreateSellerReviewRequest request, List<MultipartFile> images) {
         Order order = orderRepository.findByIdAndCustomerId(orderId, currentUser.getId())
                 .orElseThrow(() -> new EntityNotFoundException("Order not found: " + orderId));
 
@@ -72,6 +86,8 @@ public class SellerReviewService {
         }
 
         String requestedSeller = normalizeRequired(request.sellerName(), "Bitte einen Verkaeufer aus der Bestellung auswaehlen.");
+        validateRating(request.rating());
+        validateReviewImages(images);
         Map<String, String> purchasedSellers = resolvePurchasedSellers(order);
         String canonicalSeller = purchasedSellers.get(requestedSeller.toLowerCase());
         if (canonicalSeller == null) {
@@ -90,6 +106,7 @@ public class SellerReviewService {
         review.setComment(normalizeNullable(request.comment()));
 
         SellerReview savedReview = sellerReviewRepository.save(review);
+        saveReviewImages(savedReview, images);
         auditLogService.record(currentUser, "CREATE_SELLER_REVIEW", "SellerReview", savedReview.getId(),
                 AuditInitiator.USER,
                 "Seller review created for " + canonicalSeller + " in order " + order.getOrderNumber());
@@ -103,6 +120,25 @@ public class SellerReviewService {
                 .orElseThrow(() -> new EntityNotFoundException("Review not found: " + reviewId));
         helpfulVoteService.toggleVote(HelpfulVoteTargetType.SELLER_REVIEW, reviewId, currentUser, helpful);
         return toResponse(review, currentUser);
+    }
+
+    @Transactional(readOnly = true)
+    public List<SellerReviewImageResponse> listImagesForModeration() {
+        return sellerReviewImageRepository.findAllByOrderByCreatedAtDesc()
+                .stream()
+                .map(this::toImageResponse)
+                .toList();
+    }
+
+    @Transactional
+    public void deleteImage(Long imageId, User currentUser) {
+        SellerReviewImage image = sellerReviewImageRepository.findById(imageId)
+                .orElseThrow(() -> new EntityNotFoundException("Review image not found: " + imageId));
+        Long reviewId = image.getReview().getId();
+        sellerReviewImageRepository.delete(image);
+        auditLogService.record(currentUser, "DELETE_SELLER_REVIEW_IMAGE", "SellerReviewImage", imageId,
+                AuditInitiator.USER,
+                "Review image removed from seller review " + reviewId);
     }
 
     private Map<String, String> resolvePurchasedSellers(Order order) {
@@ -133,6 +169,57 @@ public class SellerReviewService {
         return normalized;
     }
 
+    private void validateRating(Integer rating) {
+        if (rating == null || rating < 1 || rating > 5) {
+            throw new IllegalArgumentException("Bitte eine Sternebewertung zwischen 1 und 5 angeben.");
+        }
+    }
+
+    private void validateReviewImages(List<MultipartFile> images) {
+        if (images == null || images.isEmpty()) {
+            return;
+        }
+        if (images.size() > MAX_IMAGES_PER_REVIEW) {
+            throw new IllegalArgumentException("Es koennen maximal 3 Bilder pro Rezension hochgeladen werden.");
+        }
+        for (MultipartFile image : images) {
+            if (image == null || image.isEmpty()) {
+                throw new IllegalArgumentException("Leere Bilddateien koennen nicht hochgeladen werden.");
+            }
+            if (image.getSize() > MAX_IMAGE_SIZE_BYTES) {
+                throw new IllegalArgumentException("Ein Rezensionsbild darf maximal 5 MB gross sein.");
+            }
+            String contentType = normalizeNullable(image.getContentType());
+            if (contentType == null || !ALLOWED_IMAGE_TYPES.contains(contentType.toLowerCase())) {
+                throw new IllegalArgumentException("Bitte nur Bilder im Format JPG, PNG oder WebP hochladen.");
+            }
+        }
+    }
+
+    private void saveReviewImages(SellerReview review, List<MultipartFile> images) {
+        if (images == null || images.isEmpty()) {
+            return;
+        }
+        for (MultipartFile upload : images) {
+            SellerReviewImage image = new SellerReviewImage();
+            image.setReview(review);
+            image.setOriginalFilename(normalizeFilename(upload.getOriginalFilename()));
+            image.setContentType(upload.getContentType().toLowerCase());
+            image.setFileSizeBytes(upload.getSize());
+            try {
+                image.setImageData(upload.getBytes());
+            } catch (IOException ex) {
+                throw new IllegalArgumentException("Ein Rezensionsbild konnte nicht gelesen werden.");
+            }
+            sellerReviewImageRepository.save(image);
+        }
+    }
+
+    private String normalizeFilename(String filename) {
+        String normalized = normalizeNullable(filename);
+        return normalized != null ? normalized : "rezensionsbild";
+    }
+
     private String normalizeNullable(String value) {
         if (value == null) {
             return null;
@@ -147,6 +234,11 @@ public class SellerReviewService {
                 review.getId(),
                 currentUser
         );
+        List<SellerReviewImageResponse> images = sellerReviewImageRepository
+                .findByReviewIdOrderByCreatedAtAsc(review.getId())
+                .stream()
+                .map(this::toImageResponse)
+                .toList();
         return new SellerReviewResponse(
                 review.getId(),
                 review.getOrder().getId(),
@@ -158,7 +250,28 @@ public class SellerReviewService {
                 votes.helpfulCount(),
                 votes.notHelpfulCount(),
                 votes.helpfulScore(),
-                votes.currentUserVote()
+                votes.currentUserVote(),
+                images
+        );
+    }
+
+    private SellerReviewImageResponse toImageResponse(SellerReviewImage image) {
+        SellerReview review = image.getReview();
+        User customer = review.getCustomer();
+        String encoded = Base64.getEncoder().encodeToString(image.getImageData());
+        String dataUrl = "data:" + image.getContentType() + ";base64," + encoded;
+        return new SellerReviewImageResponse(
+                image.getId(),
+                review.getId(),
+                review.getSellerName(),
+                review.getOrder().getOrderNumber(),
+                customer != null ? customer.getUsername() : null,
+                customer != null ? customer.getEmail() : null,
+                image.getOriginalFilename(),
+                image.getContentType(),
+                image.getFileSizeBytes(),
+                image.getCreatedAt(),
+                dataUrl
         );
     }
 }

--- a/src/main/java/de/fhdw/webshop/sellerreview/dto/SellerReviewImageResponse.java
+++ b/src/main/java/de/fhdw/webshop/sellerreview/dto/SellerReviewImageResponse.java
@@ -1,0 +1,18 @@
+package de.fhdw.webshop.sellerreview.dto;
+
+import java.time.Instant;
+
+public record SellerReviewImageResponse(
+        Long id,
+        Long reviewId,
+        String sellerName,
+        String orderNumber,
+        String customerName,
+        String customerEmail,
+        String originalFilename,
+        String contentType,
+        long fileSizeBytes,
+        Instant createdAt,
+        String dataUrl
+) {
+}

--- a/src/main/java/de/fhdw/webshop/sellerreview/dto/SellerReviewResponse.java
+++ b/src/main/java/de/fhdw/webshop/sellerreview/dto/SellerReviewResponse.java
@@ -1,6 +1,7 @@
 package de.fhdw.webshop.sellerreview.dto;
 
 import java.time.Instant;
+import java.util.List;
 
 public record SellerReviewResponse(
         Long id,
@@ -13,6 +14,7 @@ public record SellerReviewResponse(
         long helpfulCount,
         long notHelpfulCount,
         long helpfulScore,
-        Boolean currentUserVote
+        Boolean currentUserVote,
+        List<SellerReviewImageResponse> images
 ) {
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,6 +23,10 @@ app.jwt.expiration-ms=${JWT_EXPIRATION_MS:86400000}
 app.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:5173}
 app.frontend.base-url=${FRONTEND_BASE_URL:http://localhost:5173}
 
+# Multipart uploads: review images allow max. 3 files with 5 MB each.
+spring.servlet.multipart.max-file-size=${MULTIPART_MAX_FILE_SIZE:5MB}
+spring.servlet.multipart.max-request-size=${MULTIPART_MAX_REQUEST_SIZE:16MB}
+
 # ── Mail ────────────────────────────────────────────────────────────────────
 # Gmail: MAIL_HOST=smtp.gmail.com, MAIL_PORT=587, MAIL_USERNAME/PASSWORD=<App-Passwort>
 # Local dev: defaults point to Mailpit on localhost:1025 (no auth needed)

--- a/src/main/resources/db/migration/V239__create_seller_review_images.sql
+++ b/src/main/resources/db/migration/V239__create_seller_review_images.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS seller_review_images (
+    id BIGSERIAL PRIMARY KEY,
+    review_id BIGINT NOT NULL REFERENCES seller_reviews(id) ON DELETE CASCADE,
+    original_filename VARCHAR(255) NOT NULL,
+    content_type VARCHAR(80) NOT NULL,
+    file_size_bytes BIGINT NOT NULL,
+    image_data BYTEA NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_seller_review_images_review_created
+    ON seller_review_images(review_id, created_at);


### PR DESCRIPTION
# Pull Request

## 📝 Beschreibung

Diese PR ergänzt das Backend für Bilder in Verkäuferrezensionen. Pro Rezension können bis zu drei Bilder gespeichert werden. Serverseitig werden Dateityp und Dateigröße geprüft: erlaubt sind JPG, PNG und WebP mit maximal 5 MB pro Bild.

Außerdem wurde ein Admin-Endpunkt ergänzt, über den Mitarbeiter hochgeladene Rezensionsbilder einsehen und bei unangemessenen Inhalten löschen können. Die Datenbank wird dafür um eine eigene Tabelle für Rezensionsbilder erweitert.

## 🎯 Ticket

Resolves #239

## 📋 Änderungen

- [x] Neue Features hinzugefügt
- [x] Bugs behoben
- [ ] Code refaktoriert
- [x] Code ist selbsterklärend mit Kommentaren
- [x] Tests geschrieben/aktualisiert
- [ ] Dokumentation aktualisiert

## 🔗 Related Issues

- Relates to #144
