### PR TITLE
Resolves #102 db-integrationstests-testcontainers

### DIFF
--- a/README-Linux.md
+++ b/README-Linux.md
@@ -220,6 +220,10 @@ Das Backend ist dann erreichbar unter: `http://localhost:8080`
 | `./dev.sh restart --keep-db` | Backend-Neustart ohne PostgreSQL-Neustart |
 | `./dev.sh rebuild` | Docker-Image neu bauen + starten (kein Layer-Cache) |
 | `./dev.sh rebuild --keep-db` | Rebuild ohne PostgreSQL-Neustart |
+| `./dev.sh test` | Test-Suite in einem Maven-Container ausführen (kein lokales Java/Maven nötig) |
+| `./dev.sh test <Filter>` | Nur bestimmte Tests, z.B. `./dev.sh test CartFlowIntegrationTest` oder `'*IntegrationTest'` |
+
+> **Tests:** `./dev.sh test` führt die Tests in einem Maven-Container aus. Die Integrationstests (`*IntegrationTest`) starten via **Testcontainers** ein echtes PostgreSQL (`postgres:16-alpine`), gegen das Flyway die echten Migrationen ausführt — Docker muss laufen. Die Unit-Tests (Mockito) brauchen keine Datenbank. Beim ersten Lauf werden Abhängigkeiten in ein Cache-Volume geladen und das `postgres:16-alpine`-Image gezogen.
 
 ### Schritt 3 — Ollama-Modell ziehen (einmalig, nur für Shoppi KI-Assistent)
 ```bash

--- a/README-Mac.md
+++ b/README-Mac.md
@@ -221,6 +221,10 @@ Das Backend ist dann erreichbar unter: `http://localhost:8080`
 | `./dev.sh restart --keep-db` | Backend-Neustart ohne PostgreSQL-Neustart |
 | `./dev.sh rebuild` | Docker-Image neu bauen + starten (kein Layer-Cache) |
 | `./dev.sh rebuild --keep-db` | Rebuild ohne PostgreSQL-Neustart |
+| `./dev.sh test` | Test-Suite in einem Maven-Container ausführen (kein lokales Java/Maven nötig) |
+| `./dev.sh test <Filter>` | Nur bestimmte Tests, z.B. `./dev.sh test CartFlowIntegrationTest` oder `'*IntegrationTest'` |
+
+> **Tests:** `./dev.sh test` führt die Tests in einem Maven-Container aus. Die Integrationstests (`*IntegrationTest`) starten via **Testcontainers** ein echtes PostgreSQL (`postgres:16-alpine`), gegen das Flyway die echten Migrationen ausführt — Docker muss laufen. Die Unit-Tests (Mockito) brauchen keine Datenbank. Beim ersten Lauf werden Abhängigkeiten in ein Cache-Volume geladen und das `postgres:16-alpine`-Image gezogen.
 
 ### Schritt 4 — Ollama-Modell ziehen (einmalig, nur für Shoppi KI-Assistent)
 ```bash

--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ Das Backend ist dann erreichbar unter: `http://localhost:8080`
 | `./dev.bat restart --keep-db` | Neustart ohne PostgreSQL-Neustart |
 | `./dev.bat rebuild` | Alle Container neu bauen (kein Layer-Cache) + PostgreSQL-Volume löschen (frische DB) |
 | `./dev.bat rebuild --keep-db` | Rebuild Backend ohne PostgreSQL-Neustart, Volume bleibt erhalten |
+| `./dev.bat test` | Test-Suite in einem Maven-Container ausführen (kein lokales Java/Maven nötig) |
+| `./dev.bat test <Filter>` | Nur bestimmte Tests, z.B. `./dev.bat test CartFlowIntegrationTest` oder `'*IntegrationTest'` |
 
 > **Wann `./dev.bat rebuild` statt `./dev.bat restart`?**
 > Nach Änderungen am `Dockerfile` oder wenn der Layer-Cache einen veralteten Stand hat.
@@ -215,6 +217,21 @@ Das Backend ist dann erreichbar unter: `http://localhost:8080`
 >
 > **Achtung:** `rebuild` (ohne `--keep-db`) löscht das PostgreSQL-Volume → alle Daten gehen verloren.
 > Testdaten danach erneut einspielen (Schritt 4).
+
+**Tests ausführen:**
+
+```bat
+./dev.bat test                          REM komplette Suite (Unit + Integration)
+./dev.bat test CartFlowIntegrationTest  REM nur eine Klasse
+./dev.bat test "*IntegrationTest"       REM nur die Integrationstests
+```
+
+`./dev.bat test` führt die Tests in einem Maven-Container aus — kein lokales Java/Maven nötig. Es gibt zwei Arten von Tests:
+
+- **Unit-Tests** (Mockito, keine Datenbank) — schnell, brauchen kein Docker zur Laufzeit der Tests selbst.
+- **Integrationstests** (`*IntegrationTest`) — starten via **Testcontainers** ein echtes PostgreSQL (`postgres:16-alpine`), gegen das Flyway die echten Migrationen ausführt. Dadurch werden auch PostgreSQL-spezifische Konstrukte (Enum-Typen etc.) getestet, die mit H2 nicht abbildbar wären. **Docker muss laufen.**
+
+> Beim ersten Lauf lädt Maven die Abhängigkeiten in ein Cache-Volume und zieht das `postgres:16-alpine`-Image — Folgeläufe sind deutlich schneller.
 
 ### Schritt 3 — Ollama-Modell ziehen (einmalig, nur für Shoppi KI-Assistent)
 ```bash

--- a/deepdive.md
+++ b/deepdive.md
@@ -169,6 +169,7 @@ Das eigentliche Steuerungsskript. Alles läuft über Docker — kein Java lokal 
 | `dev stop --keep-db` | Nur Backend-Container stoppen, PostgreSQL bleibt laufen |
 | `dev restart` | Backend-Container stoppen + neu starten |
 | `dev rebuild` | `docker compose up --build --force-recreate` (kein Layer-Cache) |
+| `dev test` | Test-Suite in einem Maven-Container ausführen (optional mit `-Dtest`-Filter) |
 
 ---
 
@@ -1027,6 +1028,37 @@ Get-Content src/main/resources/db/dev-seed.sql | docker exec -i webshop-postgres
 - `pom.xml` geändert und der Layer-Cache hat einen alten Stand
 - Build-Fehler die sich nicht durch `restart` beheben lassen
 - Saubere Datenbank für Tests gewünscht
+
+### dev test
+
+```
+dev.ps1 test [Filter]
+  └── docker run --rm                                  (Maven läuft im Container, kein lokales Maven)
+        -v <projekt>:/app
+        -v webshop-mvn-repo:/root/.m2                  (Dependency-Cache über Läufe hinweg)
+        -v /var/run/docker.sock:/var/run/docker.sock   (Testcontainers startet Geschwister-Container)
+        -e TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal
+        mvn -B test [-Dtest=<Filter>]
+```
+
+Es gibt zwei Arten von Tests:
+
+- **Unit-Tests** (`src/test/...`, Mockito) — mocken alle Repositories, fassen keine Datenbank an. Schnell.
+- **Integrationstests** (`*IntegrationTest`, erben von `AbstractIntegrationTest`) — `@SpringBootTest` mit einem
+  echten **PostgreSQL via Testcontainers** (`@ServiceConnection`). Flyway führt beim Kontext-Start die echten
+  Migrationen gegen den Container aus, sodass das reale Schema (inkl. PostgreSQL-Enum-Typen) getestet wird.
+  Ein Singleton-Container wird einmal pro JVM-Lauf gestartet und wiederverwendet.
+
+**Warum der gemountete Docker-Socket?** Der Maven-Container selbst hat keine Datenbank. Testcontainers spricht über
+den gemounteten Socket den Host-Docker-Daemon an und startet dort ein **Geschwister**-PostgreSQL. Damit der
+Maven-Container den auf dem Host gemappten DB-Port erreicht, zeigt `TESTCONTAINERS_HOST_OVERRIDE` auf
+`host.docker.internal`. Voraussetzung: Docker läuft.
+
+```bash
+dev test                          # komplette Suite (Unit + Integration)
+dev test CartFlowIntegrationTest  # nur eine Klasse
+dev test '*IntegrationTest'       # nur die Integrationstests
+```
 
 ---
 

--- a/dev.ps1
+++ b/dev.ps1
@@ -19,7 +19,8 @@
 
 param(
     [string]$Command = "",
-    [switch]$KeepDb
+    [switch]$KeepDb,
+    [string]$TestFilter = ""
 )
 
 $Root = $PSScriptRoot
@@ -91,6 +92,9 @@ function Show-Usage {
     Write-Host "  restart  Stop backend, then start backend"
     Write-Host "  rebuild  Force full rebuild - also deletes the PostgreSQL volume (fresh DB)"
     Write-Host "           Use --keep-db to skip the volume deletion and keep existing data"
+    Write-Host "  test     Run the backend test suite in a Maven container (no local Maven needed)"
+    Write-Host "           Integration tests spin up PostgreSQL via Testcontainers (Docker required)"
+    Write-Host "           Optional filter: ./dev.bat test CartFlowIntegrationTest"
     Write-Host ""
     Write-Host "Options:"
     Write-Host "  --keep-db   Keep PostgreSQL data (combine with stop/restart/rebuild)"
@@ -99,9 +103,9 @@ function Show-Usage {
 
 function Read-CommandInteractive {
     Show-Usage
-    $inputCommand = (Read-Host "Enter command (start/stop/restart/rebuild)").Trim().ToLower()
+    $inputCommand = (Read-Host "Enter command (start/stop/restart/rebuild/test)").Trim().ToLower()
 
-    if ($inputCommand -notin @("start", "stop", "restart", "rebuild")) {
+    if ($inputCommand -notin @("start", "stop", "restart", "rebuild", "test")) {
         Write-Host "ERROR: Unknown command '$inputCommand'."
         exit 1
     }
@@ -289,13 +293,54 @@ function Rebuild-Backend {
     }
 }
 
+# --- test --------------------------------------------------------------------
+
+function Invoke-Tests {
+    if (-not (Test-DockerRunning)) { return }
+
+    Write-Host "Running backend tests in a Maven container (no local Java/Maven needed)..."
+    Write-Host "Integration tests start a PostgreSQL container via Testcontainers using the host Docker daemon."
+    if ($TestFilter) {
+        Write-Host "Filter: -Dtest=$TestFilter"
+    }
+    Write-Host "(First run downloads dependencies into the cached volume and pulls the postgres image.)"
+    Write-Host "-------------------------------------------------------------------------------"
+
+    # Built as an argument array and splatted, so the '!' in the project path is passed
+    # literally to docker.exe (no shell re-parsing). The mounted Docker socket lets
+    # Testcontainers start sibling containers; TESTCONTAINERS_HOST_OVERRIDE makes the
+    # Maven container reach the mapped database port on the host.
+    $dockerArguments = @(
+        "run", "--rm",
+        "-v", "${Root}:/app",
+        "-v", "webshop-mvn-repo:/root/.m2",
+        "-v", "//var/run/docker.sock:/var/run/docker.sock",
+        "-e", "TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal",
+        "-w", "/app",
+        "maven:3.9-eclipse-temurin-21-alpine",
+        "mvn", "-B", "test"
+    )
+    if ($TestFilter) {
+        $dockerArguments += "-Dtest=$TestFilter"
+    }
+
+    & docker @dockerArguments
+
+    Write-Host "-------------------------------------------------------------------------------"
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "ERROR: Tests failed (exit code $LASTEXITCODE)."
+        return
+    }
+    Write-Host "All tests passed."
+}
+
 # --- dispatch ----------------------------------------------------------------
 
 if (-not $Command) {
     $Command = Read-CommandInteractive
 }
 
-if ($Command -notin @("start", "stop", "restart", "rebuild")) {
+if ($Command -notin @("start", "stop", "restart", "rebuild", "test")) {
     Write-Host "ERROR: Unknown command '$Command'. Run './dev.bat' without arguments for help."
     exit 1
 }
@@ -305,4 +350,5 @@ switch ($Command) {
     "stop"    { Stop-Backend }
     "restart" { Stop-Backend; Start-Sleep -Seconds 1; Start-Backend }
     "rebuild" { Rebuild-Backend }
+    "test"    { Invoke-Tests }
 }

--- a/dev.sh
+++ b/dev.sh
@@ -25,12 +25,18 @@ HEALTH_URL="http://localhost:$PORT/api/health"
 
 COMMAND="${1:-}"
 KEEP_DB=false
+TEST_FILTER=""
 COMPOSE_FILES=()
 
-# Shift past the command arg, then scan remaining args for flags
+# Shift past the command arg, then scan remaining args for flags.
+# The first non-flag argument is treated as the test filter (for the 'test' command).
 [[ $# -gt 0 ]] && shift
 for arg in "$@"; do
-    [[ "$arg" == "--keep-db" ]] && KEEP_DB=true
+    if [[ "$arg" == "--keep-db" ]]; then
+        KEEP_DB=true
+    else
+        TEST_FILTER="$arg"
+    fi
 done
 
 # --- helpers -----------------------------------------------------------------
@@ -209,6 +215,9 @@ show_usage() {
     echo "  stop     Stop all containers"
     echo "  restart  Stop backend, then start backend"
     echo "  rebuild  Force full rebuild (recreates containers)"
+    echo "  test     Run the backend test suite in a Maven container (no local Maven needed)"
+    echo "           Integration tests spin up PostgreSQL via Testcontainers (Docker required)"
+    echo "           Optional filter: ./dev.sh test CartFlowIntegrationTest"
     echo ""
     echo "Options:"
     echo "  --keep-db   Keep PostgreSQL running (combine with stop/restart/rebuild)"
@@ -222,7 +231,7 @@ read_command_interactive() {
     input_command="$(echo "$input_command" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
 
     case "$input_command" in
-        start|stop|restart|rebuild) ;;
+        start|stop|restart|rebuild|test) ;;
         *)
             echo "ERROR: Unknown command '$input_command'."
             exit 1
@@ -321,6 +330,42 @@ rebuild_backend() {
     fi
 }
 
+# --- test --------------------------------------------------------------------
+
+run_tests() {
+    test_docker_running || return 1
+
+    echo "Running backend tests in a Maven container (no local Java/Maven needed)..."
+    echo "Integration tests start a PostgreSQL container via Testcontainers using the host Docker daemon."
+    [[ -n "$TEST_FILTER" ]] && echo "Filter: -Dtest=$TEST_FILTER"
+    echo "(First run downloads dependencies into the cached volume and pulls the postgres image.)"
+    echo "-------------------------------------------------------------------------------"
+
+    local maven_args=("-B" "test")
+    [[ -n "$TEST_FILTER" ]] && maven_args+=("-Dtest=$TEST_FILTER")
+
+    # The mounted Docker socket lets Testcontainers start sibling containers;
+    # the host-gateway mapping plus TESTCONTAINERS_HOST_OVERRIDE let the Maven container
+    # reach the mapped database port on the host (works on Docker Desktop and native Linux).
+    docker run --rm \
+        -v "$ROOT:/app" \
+        -v webshop-mvn-repo:/root/.m2 \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        --add-host=host.docker.internal:host-gateway \
+        -e TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal \
+        -w /app \
+        maven:3.9-eclipse-temurin-21-alpine \
+        mvn "${maven_args[@]}"
+
+    local exit_code=$?
+    echo "-------------------------------------------------------------------------------"
+    if [[ $exit_code -ne 0 ]]; then
+        echo "ERROR: Tests failed (exit code $exit_code)."
+        return 1
+    fi
+    echo "All tests passed."
+}
+
 # --- dispatch ----------------------------------------------------------------
 
 if [[ -z "$COMMAND" ]]; then
@@ -341,6 +386,9 @@ case "$COMMAND" in
         ;;
     rebuild)
         rebuild_backend
+        ;;
+    test)
+        run_tests
         ;;
     *)
         echo "ERROR: Unknown command '$COMMAND'. Run './dev.sh' without arguments for help."

--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,24 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Testcontainers – integration tests against a real PostgreSQL database.
+             Versions are managed by the Spring Boot BOM. -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/de/fhdw/webshop/AbstractIntegrationTest.java
+++ b/src/test/java/de/fhdw/webshop/AbstractIntegrationTest.java
@@ -1,0 +1,27 @@
+package de.fhdw.webshop;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+/**
+ * Base class for integration tests that run against a real PostgreSQL database
+ * provided by Testcontainers (not H2 or mocks). A single container is started once
+ * and reused for the whole JVM test run (singleton-container pattern), which keeps the
+ * suite fast. Spring Boot wires the datasource from the container via {@link ServiceConnection},
+ * and Flyway applies the real migrations on context startup — so tests exercise the actual
+ * schema, including PostgreSQL-specific constructs such as the enum types.
+ *
+ * <p>Requires a running Docker environment (available locally and on the CI runner).
+ */
+@SpringBootTest
+public abstract class AbstractIntegrationTest {
+
+    @ServiceConnection
+    static final PostgreSQLContainer<?> POSTGRES_CONTAINER =
+            new PostgreSQLContainer<>("postgres:16-alpine");
+
+    static {
+        POSTGRES_CONTAINER.start();
+    }
+}

--- a/src/test/java/de/fhdw/webshop/cart/CartFlowIntegrationTest.java
+++ b/src/test/java/de/fhdw/webshop/cart/CartFlowIntegrationTest.java
@@ -1,0 +1,79 @@
+package de.fhdw.webshop.cart;
+
+import de.fhdw.webshop.AbstractIntegrationTest;
+import de.fhdw.webshop.cart.dto.CartResponse;
+import de.fhdw.webshop.product.Product;
+import de.fhdw.webshop.product.ProductRepository;
+import de.fhdw.webshop.user.User;
+import de.fhdw.webshop.user.UserRepository;
+import de.fhdw.webshop.user.UserRole;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for the cart flow against a real PostgreSQL database. Creates its own
+ * customer and a plain standard product (controlled test data, not seed data), persists a
+ * cart item, then verifies that the cart service loads it and computes the totals
+ * (subtotal, tax, shipping). Runs in a transaction that is rolled back after the test,
+ * so it leaves no data behind.
+ */
+@Transactional
+class CartFlowIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private CartService cartService;
+
+    @Autowired
+    private CartRepository cartRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void addingProductToCartPersistsAndComputesTotals() {
+        User customer = createCustomer();
+        Product product = createPurchasableProduct();
+
+        CartItem cartItem = new CartItem();
+        cartItem.setUser(customer);
+        cartItem.setProduct(product);
+        cartItem.setQuantity(2);
+        cartRepository.save(cartItem);
+
+        CartResponse cart = cartService.getCart(customer.getId());
+
+        assertThat(cart.items()).hasSize(1);
+        assertThat(cart.items())
+                .anyMatch(item -> item.productName().equals(product.getName()));
+        assertThat(cart.total()).isGreaterThan(BigDecimal.ZERO);
+    }
+
+    private User createCustomer() {
+        // Unique values avoid collisions with seed data and with the unique constraints.
+        String uniqueSuffix = String.valueOf(System.nanoTime());
+        User customer = new User();
+        customer.setUsername("integration-test-user-" + uniqueSuffix);
+        customer.setEmail("integration-test-" + uniqueSuffix + "@example.test");
+        customer.setPasswordHash("integration-test-hash");
+        customer.getRoles().add(UserRole.CUSTOMER);
+        return userRepository.save(customer);
+    }
+
+    private Product createPurchasableProduct() {
+        // A plain STANDARD product (default product type) so the cart calculation needs no
+        // extra attributes such as a gift card amount.
+        Product product = new Product();
+        product.setName("Integration Test Produkt");
+        product.setRecommendedRetailPrice(new BigDecimal("49.99"));
+        product.setPurchasable(true);
+        return productRepository.save(product);
+    }
+}

--- a/src/test/java/de/fhdw/webshop/product/ProductCatalogIntegrationTest.java
+++ b/src/test/java/de/fhdw/webshop/product/ProductCatalogIntegrationTest.java
@@ -1,0 +1,38 @@
+package de.fhdw.webshop.product;
+
+import de.fhdw.webshop.AbstractIntegrationTest;
+import de.fhdw.webshop.product.dto.ProductResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test verifying that the product catalog works end to end against a real
+ * PostgreSQL database: Flyway migrations (including seed data) applied, JPA mapping correct,
+ * and the customer-facing query returns only purchasable products.
+ */
+class ProductCatalogIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private ProductService productService;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Test
+    void flywayMigrationsSeedProductsIntoRealDatabase() {
+        // Proves the full stack: Testcontainers PostgreSQL + Flyway migrations + JPA mapping.
+        assertThat(productRepository.count()).isPositive();
+    }
+
+    @Test
+    void listProductsReturnsOnlyPurchasableProductsForCustomers() {
+        List<ProductResponse> purchasableProducts = productService.listProducts(true, null, null);
+
+        assertThat(purchasableProducts).isNotEmpty();
+        assertThat(purchasableProducts).allMatch(ProductResponse::purchasable);
+    }
+}


### PR DESCRIPTION
# Pull Request

## 📝 Beschreibung

Richtet DB-/Integrationstests mit echtem PostgreSQL via Testcontainers ein (kein H2/Mock), ergänzt einen `test`-Befehl in beiden Dev-Scripts und dokumentiert das Ganze.

- `pom.xml`: Testcontainers-Dependencies (`spring-boot-testcontainers`, `org.testcontainers:postgresql`, `junit-jupiter`) — Versionen über die Spring-Boot-BOM
- `AbstractIntegrationTest`: Singleton-`PostgreSQLContainer` (`postgres:16-alpine`, gleiche Version wie Produktion) per `@ServiceConnection`; Flyway läuft die echten Migrationen gegen den Container → realer Schema-Test inkl. der PostgreSQL-Enum-Typen
- `ProductCatalogIntegrationTest`: Flyway-Seed lädt Produkte; `listProducts(true,…)` liefert nur kaufbare
- `CartFlowIntegrationTest`: Warenkorb-Flow mit selbst angelegten Testdaten (CartItem persistieren → `CartService.getCart` → Summen geprüft), transaktional zurückgerollt
- `dev.ps1` **und** `dev.sh`: neuer Befehl `./dev.bat test [Filter]` / `./dev.sh test [Filter]` führt die Tests in einem Maven-Container aus (kein lokales Java/Maven nötig); Docker-Socket gemountet, damit Testcontainers PostgreSQL starten kann
- Doku: `README.md`, `README-Linux.md`, `README-Mac.md` (Befehlstabellen + Test-Hinweis) und `deepdive.md` (neuer `dev test`-Abschnitt) aktualisiert
- Bestehende Unit-Tests bleiben unverändert

## 🎯 Ticket

Resolves #102 db-integrationstests-testcontainers

## 📋 Änderungen
*Hake an, welche Änderungen erfolgt sind:*

- [x] Neue Features hinzugefügt
- [ ] Bugs behoben
- [ ] Code refaktoriert
- [x] Code ist selbsterklärend mit Kommentaren
- [x] Tests geschrieben/aktualisiert
- [x] Dokumentation aktualisiert

## 🔗 Related Issues

*Sollte mehr als ein Ticket betroffen sein, verlinke diese hier:*

- Part of SEPBFWS124A/Webshop#299 (Frontend-User-Story, Strang A)
- Relates to SEPBFWS124A/Webshop-Backend#103 (Strang B: Last-/Ressourcentest)

---

**Wichtig:** Dieser PR wird automatisch den Ticket schließen, wenn er gemergt wird (via "Resolves #...").
Dieser PR geht gegen `main` (das Backend-Repo nutzt kein `develop`).
