### PR TITLE
Resolves #103 lasttest-k6-grafana-prometheus

### DIFF
--- a/README-Linux.md
+++ b/README-Linux.md
@@ -222,8 +222,11 @@ Das Backend ist dann erreichbar unter: `http://localhost:8080`
 | `./dev.sh rebuild --keep-db` | Rebuild ohne PostgreSQL-Neustart |
 | `./dev.sh test` | Test-Suite in einem Maven-Container ausführen (kein lokales Java/Maven nötig) |
 | `./dev.sh test <Filter>` | Nur bestimmte Tests, z.B. `./dev.sh test CartFlowIntegrationTest` oder `'*IntegrationTest'` |
+| `./dev.sh loadtest` | Frische DB + Lastdaten einspielen + k6-Lasttest (destruktiv, mit Bestätigung; `--yes` überspringt) |
 
 > **Tests:** `./dev.sh test` führt die Tests in einem Maven-Container aus. Die Integrationstests (`*IntegrationTest`) starten via **Testcontainers** ein echtes PostgreSQL (`postgres:16-alpine`), gegen das Flyway die echten Migrationen ausführt — Docker muss laufen. Die Unit-Tests (Mockito) brauchen keine Datenbank. Beim ersten Lauf werden Abhängigkeiten in ein Cache-Volume geladen und das `postgres:16-alpine`-Image gezogen.
+>
+> **Last-/Ressourcentest:** `./dev.sh loadtest` baut eine frische DB, spielt Lastdaten ein und startet einen **k6**-Lasttest (beobachtbar in Grafana). Destruktiv (löscht die DB), fragt vorher nach. Details: [`docs/loadtest.md`](docs/loadtest.md).
 
 ### Schritt 3 — Ollama-Modell ziehen (einmalig, nur für Shoppi KI-Assistent)
 ```bash

--- a/README-Mac.md
+++ b/README-Mac.md
@@ -223,8 +223,11 @@ Das Backend ist dann erreichbar unter: `http://localhost:8080`
 | `./dev.sh rebuild --keep-db` | Rebuild ohne PostgreSQL-Neustart |
 | `./dev.sh test` | Test-Suite in einem Maven-Container ausführen (kein lokales Java/Maven nötig) |
 | `./dev.sh test <Filter>` | Nur bestimmte Tests, z.B. `./dev.sh test CartFlowIntegrationTest` oder `'*IntegrationTest'` |
+| `./dev.sh loadtest` | Frische DB + Lastdaten einspielen + k6-Lasttest (destruktiv, mit Bestätigung; `--yes` überspringt) |
 
 > **Tests:** `./dev.sh test` führt die Tests in einem Maven-Container aus. Die Integrationstests (`*IntegrationTest`) starten via **Testcontainers** ein echtes PostgreSQL (`postgres:16-alpine`), gegen das Flyway die echten Migrationen ausführt — Docker muss laufen. Die Unit-Tests (Mockito) brauchen keine Datenbank. Beim ersten Lauf werden Abhängigkeiten in ein Cache-Volume geladen und das `postgres:16-alpine`-Image gezogen.
+>
+> **Last-/Ressourcentest:** `./dev.sh loadtest` baut eine frische DB, spielt Lastdaten ein und startet einen **k6**-Lasttest (beobachtbar in Grafana). Destruktiv (löscht die DB), fragt vorher nach. Details: [`docs/loadtest.md`](docs/loadtest.md).
 
 ### Schritt 4 — Ollama-Modell ziehen (einmalig, nur für Shoppi KI-Assistent)
 ```bash

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Das Backend ist dann erreichbar unter: `http://localhost:8080`
 | `./dev.bat rebuild --keep-db` | Rebuild Backend ohne PostgreSQL-Neustart, Volume bleibt erhalten |
 | `./dev.bat test` | Test-Suite in einem Maven-Container ausführen (kein lokales Java/Maven nötig) |
 | `./dev.bat test <Filter>` | Nur bestimmte Tests, z.B. `./dev.bat test CartFlowIntegrationTest` oder `'*IntegrationTest'` |
+| `./dev.bat loadtest` | Frische DB + Lastdaten einspielen + k6-Lasttest (destruktiv, mit Bestätigung; `--yes` überspringt) |
 
 > **Wann `./dev.bat rebuild` statt `./dev.bat restart`?**
 > Nach Änderungen am `Dockerfile` oder wenn der Layer-Cache einen veralteten Stand hat.
@@ -232,6 +233,8 @@ Das Backend ist dann erreichbar unter: `http://localhost:8080`
 - **Integrationstests** (`*IntegrationTest`) — starten via **Testcontainers** ein echtes PostgreSQL (`postgres:16-alpine`), gegen das Flyway die echten Migrationen ausführt. Dadurch werden auch PostgreSQL-spezifische Konstrukte (Enum-Typen etc.) getestet, die mit H2 nicht abbildbar wären. **Docker muss laufen.**
 
 > Beim ersten Lauf lädt Maven die Abhängigkeiten in ein Cache-Volume und zieht das `postgres:16-alpine`-Image — Folgeläufe sind deutlich schneller.
+
+**Last-/Ressourcentest:** `./dev.bat loadtest` baut eine frische DB, spielt eine realistische Lastdatenmenge ein und startet einen **k6**-Lasttest (beobachtbar in Grafana). Der Befehl ist **destruktiv** (löscht die DB) und fragt vorher nach. Details, Auswertung und ein optionales Bestell-Lastszenario: [`docs/loadtest.md`](docs/loadtest.md).
 
 ### Schritt 3 — Ollama-Modell ziehen (einmalig, nur für Shoppi KI-Assistent)
 ```bash

--- a/dev.ps1
+++ b/dev.ps1
@@ -20,12 +20,14 @@
 param(
     [string]$Command = "",
     [switch]$KeepDb,
-    [string]$TestFilter = ""
+    [string]$TestFilter = "",
+    [switch]$Yes
 )
 
 $Root = $PSScriptRoot
 $Port = 8080
 $HealthUrl = "http://localhost:$Port/api/health"
+$IncludeMailpit = $false   # set by 'loadtest' so outgoing mail is captured by Mailpit
 
 # --- helpers -----------------------------------------------------------------
 
@@ -70,6 +72,11 @@ function Get-OllamaComposeFiles {
         }
     }
 
+    if ($script:IncludeMailpit) {
+        Write-Host "Mailpit override enabled - outgoing mail is captured locally (no real SMTP)."
+        $composeFiles += "`"$RootPath\docker-compose.mailpit.yml`""
+    }
+
     return ($composeFiles -join " -f ")
 }
 
@@ -95,17 +102,20 @@ function Show-Usage {
     Write-Host "  test     Run the backend test suite in a Maven container (no local Maven needed)"
     Write-Host "           Integration tests spin up PostgreSQL via Testcontainers (Docker required)"
     Write-Host "           Optional filter: ./dev.bat test CartFlowIntegrationTest"
+    Write-Host "  loadtest Rebuild (fresh DB) + seed load-test data + run the k6 load test"
+    Write-Host "           DESTRUCTIVE: deletes the database. Asks for confirmation (skip with --yes)"
     Write-Host ""
     Write-Host "Options:"
     Write-Host "  --keep-db   Keep PostgreSQL data (combine with stop/restart/rebuild)"
+    Write-Host "  --yes       Skip the loadtest confirmation prompt"
     Write-Host ""
 }
 
 function Read-CommandInteractive {
     Show-Usage
-    $inputCommand = (Read-Host "Enter command (start/stop/restart/rebuild/test)").Trim().ToLower()
+    $inputCommand = (Read-Host "Enter command (start/stop/restart/rebuild/test/loadtest)").Trim().ToLower()
 
-    if ($inputCommand -notin @("start", "stop", "restart", "rebuild", "test")) {
+    if ($inputCommand -notin @("start", "stop", "restart", "rebuild", "test", "loadtest")) {
         Write-Host "ERROR: Unknown command '$inputCommand'."
         exit 1
     }
@@ -334,21 +344,115 @@ function Invoke-Tests {
     Write-Host "All tests passed."
 }
 
+# --- loadtest ----------------------------------------------------------------
+
+function Import-SeedFile {
+    param([string]$RelativePath, [string]$Label)
+    $seedPath = Join-Path $Root $RelativePath
+    if (-not (Test-Path $seedPath)) {
+        Write-Host "ERROR: Seed file not found: $seedPath"
+        return
+    }
+    Write-Host "Seeding $Label ..."
+    Get-Content $seedPath | docker exec -i webshop-postgres psql -U webshop -d webshop
+}
+
+function Invoke-K6Script {
+    param([string]$ScriptName, [bool]$PlaceOrders = $false)
+
+    Write-Host "-------------------------------------------------------------------------------"
+    Write-Host "Running k6: $ScriptName  (real orders: $(if ($PlaceOrders) { 'yes' } else { 'no' }))"
+    Write-Host "Live k6 output follows. Watch Grafana http://localhost:3001, Mailpit http://localhost:8025"
+    Write-Host "-------------------------------------------------------------------------------"
+
+    # Foreground docker run → k6's progress and final report stream straight to this console.
+    $dockerArguments = @(
+        "run", "--rm",
+        "-e", "BASE_URL=http://host.docker.internal:$Port",
+        "-e", "LOGIN_USER_PREFIX=loaduser",
+        "-e", "LOGIN_USER_COUNT=1000"
+    )
+    if ($PlaceOrders) {
+        $dockerArguments += @("-e", "PLACE_ORDERS=true")
+    }
+    $dockerArguments += @("-v", "${Root}\loadtest:/scripts", "grafana/k6", "run", "/scripts/$ScriptName")
+
+    & docker @dockerArguments
+}
+
+function Invoke-LoadTest {
+    if (-not (Test-DockerRunning)) { return }
+
+    if (-not $Yes) {
+        Write-Host "WARNING: 'loadtest' rebuilds the stack and DELETES the PostgreSQL database,"
+        Write-Host "         then seeds load-test data."
+        $answer = (Read-Host "Continue? [y/N]").Trim().ToLower()
+        if ($answer -notin @("y", "j")) {
+            Write-Host "Aborted."
+            return
+        }
+    }
+
+    # Fresh database + Mailpit override (captures all outgoing mail locally; no real SMTP).
+    $script:KeepDb = $false
+    $script:IncludeMailpit = $true
+    Rebuild-Backend
+    if (-not (Wait-ForBackend)) {
+        Write-Host "ERROR: Backend did not become ready - aborting load test."
+        return
+    }
+
+    Import-SeedFile "src\main\resources\db\dev-seed.sql" "base data (dev-seed)"
+    Import-SeedFile "src\main\resources\db\loadtest-seed.sql" "load-test data"
+
+    Write-Host ""
+    Write-Host "Backend is ready and seeded."
+    $choice = (Read-Host "Lasttest jetzt starten? [j]a / [n]ein / [a] ja inkl. Bestellungen (max. Auslastung)").Trim().ToLower()
+
+    $ordersIncluded = $false
+    $readTestRan = $false
+    if ($choice -in @("a", "alles", "b", "ja-inkl")) {
+        Invoke-K6Script -ScriptName "load-test.js" -PlaceOrders $true
+        $ordersIncluded = $true
+        $readTestRan = $true
+    } elseif ($choice -in @("j", "ja", "y", "")) {
+        Invoke-K6Script -ScriptName "load-test.js" -PlaceOrders $false
+        $readTestRan = $true
+    } else {
+        Write-Host "Lasttest übersprungen."
+    }
+
+    # Offer a focused order-only run afterwards (only if a read-only test ran).
+    if ($readTestRan -and -not $ordersIncluded) {
+        $orderChoice = (Read-Host "Jetzt noch ein reines Bestell-Lastszenario ausführen? [j/N]").Trim().ToLower()
+        if ($orderChoice -in @("j", "ja", "y")) {
+            Invoke-K6Script -ScriptName "order-load-test.js" -PlaceOrders $false
+        }
+    }
+
+    Write-Host "-------------------------------------------------------------------------------"
+    Write-Host "Done. The stack is still running for inspection:"
+    Write-Host "  Grafana: http://localhost:3001  (admin / admin)"
+    Write-Host "  Mailpit: http://localhost:8025  (captured emails)"
+    Write-Host "Run './dev.bat stop' to shut down."
+}
+
 # --- dispatch ----------------------------------------------------------------
 
 if (-not $Command) {
     $Command = Read-CommandInteractive
 }
 
-if ($Command -notin @("start", "stop", "restart", "rebuild", "test")) {
+if ($Command -notin @("start", "stop", "restart", "rebuild", "test", "loadtest")) {
     Write-Host "ERROR: Unknown command '$Command'. Run './dev.bat' without arguments for help."
     exit 1
 }
 
 switch ($Command) {
-    "start"   { Start-Backend }
-    "stop"    { Stop-Backend }
-    "restart" { Stop-Backend; Start-Sleep -Seconds 1; Start-Backend }
-    "rebuild" { Rebuild-Backend }
-    "test"    { Invoke-Tests }
+    "start"    { Start-Backend }
+    "stop"     { Stop-Backend }
+    "restart"  { Stop-Backend; Start-Sleep -Seconds 1; Start-Backend }
+    "rebuild"  { Rebuild-Backend }
+    "test"     { Invoke-Tests }
+    "loadtest" { Invoke-LoadTest }
 }

--- a/dev.ps1
+++ b/dev.ps1
@@ -225,7 +225,9 @@ function Stop-Backend {
         docker compose -f "$Root\docker-compose.yml" stop backend
     } else {
         Write-Host "Stopping all containers..."
-        docker compose -f "$Root\docker-compose.yml" down
+        # --remove-orphans also tears down containers from overrides (e.g. mailpit) that
+        # were started alongside the base stack but are not in this compose file.
+        docker compose -f "$Root\docker-compose.yml" down --remove-orphans
     }
 }
 
@@ -280,7 +282,7 @@ function Rebuild-Backend {
         Write-Host "Keeping PostgreSQL data (--keep-db)."
         Invoke-Expression "docker compose -f $composeFiles up -d --build --force-recreate backend"
     } else {
-        Invoke-Expression "docker compose -f $composeFiles down"
+        Invoke-Expression "docker compose -f $composeFiles down --remove-orphans"
         $postgresVolume = docker volume ls --format "{{.Name}}" | Where-Object { $_ -match "postgres_data" }
         if ($postgresVolume) {
             Write-Host "Removing PostgreSQL volume ($postgresVolume) for a clean database..."

--- a/dev.sh
+++ b/dev.sh
@@ -268,7 +268,9 @@ stop_backend() {
         docker compose -f "$ROOT/docker-compose.yml" stop backend
     else
         echo "Stopping all containers..."
-        docker compose -f "$ROOT/docker-compose.yml" down
+        # --remove-orphans also tears down containers from overrides (e.g. mailpit) that
+        # were started alongside the base stack but are not in this compose file.
+        docker compose -f "$ROOT/docker-compose.yml" down --remove-orphans
     fi
 }
 
@@ -325,7 +327,7 @@ rebuild_backend() {
         echo "Keeping PostgreSQL data (--keep-db)."
         docker compose "${COMPOSE_FILES[@]}" up -d --build --force-recreate backend
     else
-        docker compose "${COMPOSE_FILES[@]}" down
+        docker compose "${COMPOSE_FILES[@]}" down --remove-orphans
         local postgres_volume
         postgres_volume="$(docker volume ls --format '{{.Name}}' | grep 'postgres_data' | head -1)"
         if [[ -n "$postgres_volume" ]]; then

--- a/dev.sh
+++ b/dev.sh
@@ -26,18 +26,20 @@ HEALTH_URL="http://localhost:$PORT/api/health"
 
 COMMAND="${1:-}"
 KEEP_DB=false
+ASSUME_YES=false
 TEST_FILTER=""
+INCLUDE_MAILPIT=false   # set by 'loadtest' so outgoing mail is captured by Mailpit
 COMPOSE_FILES=()
 
 # Shift past the command arg, then scan remaining args for flags.
 # The first non-flag argument is treated as the test filter (for the 'test' command).
 [[ $# -gt 0 ]] && shift
 for arg in "$@"; do
-    if [[ "$arg" == "--keep-db" ]]; then
-        KEEP_DB=true
-    else
-        TEST_FILTER="$arg"
-    fi
+    case "$arg" in
+        --keep-db) KEEP_DB=true ;;
+        --yes|-y)  ASSUME_YES=true ;;
+        *)         TEST_FILTER="$arg" ;;
+    esac
 done
 
 # --- helpers -----------------------------------------------------------------
@@ -94,6 +96,11 @@ setup_compose_files() {
             echo "No dedicated GPU detected - Ollama will run on CPU."
             ;;
     esac
+
+    if [[ "$INCLUDE_MAILPIT" == "true" ]]; then
+        echo "Mailpit override enabled - outgoing mail is captured locally (no real SMTP)."
+        COMPOSE_FILES+=("-f" "$ROOT/docker-compose.mailpit.yml")
+    fi
 }
 
 test_docker_running() {
@@ -220,9 +227,12 @@ show_usage() {
     echo "  test     Run the backend test suite in a Maven container (no local Maven needed)"
     echo "           Integration tests spin up PostgreSQL via Testcontainers (Docker required)"
     echo "           Optional filter: ./dev.sh test CartFlowIntegrationTest"
+    echo "  loadtest Rebuild (fresh DB) + seed load-test data + run the k6 load test"
+    echo "           DESTRUCTIVE: deletes the database. Asks for confirmation (skip with --yes)"
     echo ""
     echo "Options:"
     echo "  --keep-db   Keep PostgreSQL running (combine with stop/restart/rebuild)"
+    echo "  --yes       Skip the loadtest confirmation prompt"
     echo ""
 }
 
@@ -233,7 +243,7 @@ read_command_interactive() {
     input_command="$(echo "$input_command" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
 
     case "$input_command" in
-        start|stop|restart|rebuild|test) ;;
+        start|stop|restart|rebuild|test|loadtest) ;;
         *)
             echo "ERROR: Unknown command '$input_command'."
             exit 1
@@ -375,6 +385,109 @@ run_tests() {
     echo "All tests passed."
 }
 
+# --- loadtest ----------------------------------------------------------------
+
+import_seed_file() {
+    local relative_path="$1"
+    local label="$2"
+    local seed_path="$ROOT/$relative_path"
+    if [[ ! -f "$seed_path" ]]; then
+        echo "ERROR: Seed file not found: $seed_path"
+        return 1
+    fi
+    echo "Seeding $label ..."
+    docker exec -i webshop-postgres psql -U webshop -d webshop < "$seed_path"
+}
+
+run_k6_script() {
+    local script_name="$1"
+    local place_orders="$2"   # "true" / "false"
+
+    echo "-------------------------------------------------------------------------------"
+    echo "Running k6: $script_name  (real orders: $([[ "$place_orders" == "true" ]] && echo yes || echo no))"
+    echo "Live k6 output follows. Watch Grafana http://localhost:3001, Mailpit http://localhost:8025"
+    echo "-------------------------------------------------------------------------------"
+
+    local extra_env=()
+    [[ "$place_orders" == "true" ]] && extra_env=(-e PLACE_ORDERS=true)
+
+    # Foreground docker run → k6's progress and final report stream straight to this console.
+    docker run --rm \
+        -e "BASE_URL=http://host.docker.internal:$PORT" \
+        -e LOGIN_USER_PREFIX=loaduser \
+        -e LOGIN_USER_COUNT=1000 \
+        "${extra_env[@]}" \
+        --add-host=host.docker.internal:host-gateway \
+        -v "$ROOT/loadtest:/scripts" \
+        grafana/k6 run "/scripts/$script_name"
+}
+
+run_loadtest() {
+    test_docker_running || return 1
+
+    if [[ "$ASSUME_YES" != "true" ]]; then
+        echo "WARNING: 'loadtest' rebuilds the stack and DELETES the PostgreSQL database,"
+        echo "         then seeds load-test data."
+        printf "Continue? [y/N]: "
+        read -r answer
+        answer="$(echo "$answer" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+        if [[ "$answer" != "y" && "$answer" != "j" ]]; then
+            echo "Aborted."
+            return 0
+        fi
+    fi
+
+    # Fresh database + Mailpit override (captures all outgoing mail locally; no real SMTP).
+    KEEP_DB=false
+    INCLUDE_MAILPIT=true
+    rebuild_backend
+    if ! wait_for_backend; then
+        echo "ERROR: Backend did not become ready — aborting load test."
+        return 1
+    fi
+
+    import_seed_file "src/main/resources/db/dev-seed.sql" "base data (dev-seed)"
+    import_seed_file "src/main/resources/db/loadtest-seed.sql" "load-test data"
+
+    echo ""
+    echo "Backend is ready and seeded."
+    printf "Lasttest jetzt starten? [j]a / [n]ein / [a] ja inkl. Bestellungen (max. Auslastung): "
+    read -r choice
+    choice="$(echo "$choice" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+
+    local orders_included=false
+    local read_test_ran=false
+    case "$choice" in
+        a|alles|b|jainkl|ja-inkl)
+            run_k6_script "load-test.js" "true"
+            orders_included=true
+            read_test_ran=true
+            ;;
+        j|ja|y|"")
+            run_k6_script "load-test.js" "false"
+            read_test_ran=true
+            ;;
+        *)
+            echo "Lasttest uebersprungen."
+            ;;
+    esac
+
+    if [[ "$read_test_ran" == "true" && "$orders_included" != "true" ]]; then
+        printf "Jetzt noch ein reines Bestell-Lastszenario ausfuehren? [j/N]: "
+        read -r order_choice
+        order_choice="$(echo "$order_choice" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+        if [[ "$order_choice" == "j" || "$order_choice" == "ja" || "$order_choice" == "y" ]]; then
+            run_k6_script "order-load-test.js" "false"
+        fi
+    fi
+
+    echo "-------------------------------------------------------------------------------"
+    echo "Done. The stack is still running for inspection:"
+    echo "  Grafana: http://localhost:3001  (admin / admin)"
+    echo "  Mailpit: http://localhost:8025  (captured emails)"
+    echo "Run './dev.sh stop' to shut down."
+}
+
 # --- dispatch ----------------------------------------------------------------
 
 if [[ -z "$COMMAND" ]]; then
@@ -398,6 +511,9 @@ case "$COMMAND" in
         ;;
     test)
         run_tests
+        ;;
+    loadtest)
+        run_loadtest
         ;;
     *)
         echo "ERROR: Unknown command '$COMMAND'. Run './dev.sh' without arguments for help."

--- a/docker-compose.mailpit.yml
+++ b/docker-compose.mailpit.yml
@@ -1,0 +1,30 @@
+# Opt-in override that captures ALL outgoing mail in a local Mailpit container
+# instead of sending it via a real SMTP server. Used automatically by `dev loadtest`
+# so that load tests never send real emails — independent of any SMTP values in .env.
+#
+# Manual use:
+#   docker compose -f docker-compose.yml -f docker-compose.mailpit.yml up -d --build
+#
+# The literal SPRING_MAIL_* values below override the ${MAIL_*}-interpolated values from
+# the base docker-compose.yml (later compose file wins), so they take effect regardless
+# of what is configured in .env.
+#
+# Mailpit web UI (read captured mails): http://localhost:8025
+services:
+  mailpit:
+    image: axllent/mailpit:latest
+    container_name: webshop-mailpit
+    ports:
+      - "127.0.0.1:8025:8025"   # web UI only; SMTP (1025) stays on the internal Docker network
+    restart: unless-stopped
+
+  backend:
+    environment:
+      SPRING_MAIL_HOST: mailpit
+      SPRING_MAIL_PORT: 1025
+      SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH: "false"
+      SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE: "false"
+      SPRING_MAIL_PROPERTIES_MAIL_SMTP_SSL_ENABLE: "false"
+    depends_on:
+      mailpit:
+        condition: service_started

--- a/docs/loadtest.md
+++ b/docs/loadtest.md
@@ -1,0 +1,266 @@
+# Last-/Ressourcentest (k6 + Grafana/Prometheus)
+
+Dieser Test misst, wie viele Nutzer der Webshop **gleichzeitig** bedienen kann, bevor
+Latenz und Fehlerquote einbrechen ("Knie" der Lastkurve). Last wird mit **k6** erzeugt,
+beobachtet wird über den vorhandenen **Grafana/Prometheus**-Stack.
+
+- Lastskript: [`../loadtest/load-test.js`](../loadtest/load-test.js)
+- Lastdaten-Seed: [`../src/main/resources/db/loadtest-seed.sql`](../src/main/resources/db/loadtest-seed.sql)
+
+---
+
+## 1. Vorbereitung
+
+### 1.1 Stack frisch starten
+```bat
+./dev.bat rebuild
+```
+`rebuild` löscht das PostgreSQL-Volume → frische DB. Anschließend laufen Backend,
+PostgreSQL, Prometheus und Grafana.
+
+### 1.2 Lastdaten einspielen
+Eine realistische Datenmenge (Standard: 5.000 Produkte, 1.000 Kunden) einspielen:
+```bat
+Get-Content src\main\resources\db\loadtest-seed.sql | docker exec -i webshop-postgres psql -U webshop -d webshop
+```
+```bash
+docker exec -i webshop-postgres psql -U webshop -d webshop < src/main/resources/db/loadtest-seed.sql
+```
+Die Mengen lassen sich oben in der Seed-Datei über `\set product_count` / `\set customer_count` anpassen.
+
+Die generierten Kunden heißen `loaduser1` … `loaduser1000`, Passwort überall `Password1!`.
+
+### 1.3 Grafana öffnen
+```
+http://localhost:3001   (admin / admin)
+```
+Dashboards: **HTTP Requests** (Rate, Fehlerquote, Latenz-Perzentile), **JVM Overview**
+(Heap, GC, Threads), **Spring Boot Overview** (Status, DB-Connection-Pool).
+Prometheus scrapt `backend:8081` Docker-intern und ist von außen nicht erreichbar.
+
+---
+
+## 2. Lasttest ausführen
+
+> **Schnellweg (ein Befehl):** `./dev.bat loadtest` (bzw. `./dev.sh loadtest`) führt interaktiv
+> durch den ganzen Ablauf:
+> 1. Sicherheitsabfrage (die DB wird gelöscht) → bestätigen.
+> 2. Stack frisch hochfahren (inkl. Mailpit-Override, siehe Abschnitt 5) + Seed einspielen.
+> 3. Abfrage **„Lasttest jetzt starten? [j]a / [n]ein / [a] ja inkl. Bestellungen"**:
+>    - `j` → read-dominanter Lasttest (`load-test.js`)
+>    - `a` → derselbe Test **inkl. echter Bestellungen** (`PLACE_ORDERS`, max. Auslastung)
+>    - `n` → überspringen
+> 4. Lief nur der read-Test, folgt die Abfrage, ob noch ein **reines Bestell-Szenario**
+>    (`order-load-test.js`) laufen soll.
+>
+> Die k6-Ausgabe (Live-Fortschritt + Abschlussbericht) erscheint direkt in der Konsole. Der Stack
+> bleibt danach laufen, damit du Grafana (`:3001`) und Mailpit (`:8025`) ansehen kannst. Die
+> folgenden Schritte beschreiben denselben Ablauf manuell / mit mehr Kontrolle.
+
+k6 läuft containerisiert und erreicht das auf dem Host veröffentlichte Backend über
+`host.docker.internal:8080`:
+
+```bash
+docker run --rm \
+  -e BASE_URL=http://host.docker.internal:8080 \
+  -e LOGIN_USER_PREFIX=loaduser -e LOGIN_USER_COUNT=1000 \
+  -v "${PWD}/loadtest:/scripts" \
+  grafana/k6 run /scripts/load-test.js
+```
+
+PowerShell-Variante (Pfad-Mount mit absolutem Pfad):
+```powershell
+docker run --rm `
+  -e BASE_URL=http://host.docker.internal:8080 `
+  -e LOGIN_USER_PREFIX=loaduser -e LOGIN_USER_COUNT=1000 `
+  -v "${PWD}\loadtest:/scripts" `
+  grafana/k6 run /scripts/load-test.js
+```
+
+### Parameter (Environment-Variablen)
+
+| Variable | Default | Bedeutung |
+|---|---|---|
+| `BASE_URL` | `http://host.docker.internal:8080` | Backend-URL |
+| `LOGIN_PASSWORD` | `Password1!` | Passwort der Test-Nutzer |
+| `LOGIN_USER_PREFIX` | `alice` | Login-Benutzer(-Präfix) |
+| `LOGIN_USER_COUNT` | `0` | Anzahl Nutzer `<Präfix>1..N` (0 = Präfix unverändert nutzen) |
+| `AUTH_SHARE` | `0.3` | Anteil der Iterationen mit Login/Warenkorb/Bestellhistorie |
+
+### Lastprofil & Schwellenwerte
+
+Das Skript rampt virtuelle Nutzer (VUs) stufenweise hoch: 20 → 50 → 100 → 200, dann
+herunter. Pro Iteration: Katalog laden + Produktdetail (öffentlich) und mit
+`AUTH_SHARE`-Wahrscheinlichkeit eine authentifizierte Session (Login → Warenkorb →
+Artikel hinzufügen → Bestellhistorie).
+
+Definierte Schwellen (k6 markiert den Lauf als fehlgeschlagen, wenn überschritten):
+
+| Schwelle | Bedeutung |
+|---|---|
+| `http_req_failed < 1 %` | Anteil fehlgeschlagener HTTP-Requests |
+| `http_req_duration p95 < 800 ms` | 95. Perzentil der Antwortzeit |
+| `business_errors < 1 %` | fachliche Checks (Status/Token korrekt) |
+
+---
+
+## 3. Auswertung
+
+Während des Laufs im **HTTP Requests**-Dashboard beobachten, ab welcher VU-Stufe:
+- die p95/p99-Latenz deutlich ansteigt,
+- die 5xx-Fehlerquote über 0 steigt,
+- der HikariCP-Connection-Pool (Spring Boot Overview) ausgelastet ist,
+- der JVM-Heap (JVM Overview) an seine Grenze stößt.
+
+Der k6-Abschlussbericht liefert pro Endpunkt `http_req_duration` (avg/p90/p95/p99) und
+`http_req_failed`. Die niedrigste VU-Stufe, bei der eine Schwelle reißt, ist die
+**Belastungsgrenze**.
+
+---
+
+## 4. Optional: echte Bestellungen unter Last
+
+Der Standard-Lasttest ([`load-test.js`](../loadtest/load-test.js)) ist bewusst
+**read-dominant** (Katalog/Detail öffentlich, ein Teil authentifiziert mit Warenkorb +
+Bestell**historie**) und ruft **kein** `POST /api/orders` auf. Gründe:
+
+1. **Stock-Abbau:** Jede Bestellung reduziert den Lagerbestand. Bei vielen VUs ist der Bestand
+   schnell 0 → Folgebestellungen schlagen mit Validierungsfehlern fehl → die Schwelle
+   `http_req_failed < 1 %` würde durch **erwartete fachliche** Fehler gerissen, nicht durch echte
+   Performance-Probleme. Das verfälscht das Messsignal.
+2. **Datenexplosion + Seiteneffekte:** Tausende Bestellungen blähen die DB auf, und pro Bestellung
+   wird ein Mailversand getriggert (siehe Abschnitt 5).
+3. **Komplexer Request-Body:** `POST /api/orders` braucht einen vollständigen Body (Lieferadresse,
+   Zahlungsart, AGB-/Datenschutz-Flags) — sonst 400.
+4. **Freigabe-Flow:** Unternehmenskunden über Budget landen in `Pending_Approval` — zusätzliche
+   Verzweigung.
+
+Für **echte** Bestell-Last gibt es zwei Wege — beide nutzen den von `loadtest-seed.sql` angelegten
+**Hochlager-Artikel** „Load Test Bestell Artikel" (Stock praktisch unbegrenzt, damit nichts ausgeht)
+und sind dank Mailpit (Abschnitt 5) versand-sicher:
+
+1. **Gemischt / max. Auslastung** — beim `dev loadtest` die Option `a` („ja inkl. Bestellungen")
+   wählen, oder den Haupttest direkt mit `PLACE_ORDERS=true` starten. Dann platziert jede
+   authentifizierte Session zusätzlich eine echte Bestellung gegen den Hochlager-Artikel.
+   ```bash
+   docker run --rm \
+     -e BASE_URL=http://host.docker.internal:8080 \
+     -e LOGIN_USER_PREFIX=loaduser -e LOGIN_USER_COUNT=1000 \
+     -e PLACE_ORDERS=true \
+     -v "${PWD}/loadtest:/scripts" grafana/k6 run /scripts/load-test.js
+   ```
+2. **Fokussiert / nur Bestellungen** — das separate Szenario
+   ([`order-load-test.js`](../loadtest/order-load-test.js)) mit weniger VUs (sauberes Signal nur
+   für den Checkout-Pfad). Es loggt sich als `loaduser` ein, legt den Artikel in den Warenkorb und
+   platziert eine echte Bestellung.
+
+```bash
+docker run --rm \
+  -e BASE_URL=http://host.docker.internal:8080 \
+  -e LOGIN_USER_PREFIX=loaduser -e LOGIN_USER_COUNT=1000 \
+  -v "${PWD}/loadtest:/scripts" \
+  grafana/k6 run /scripts/order-load-test.js
+```
+
+---
+
+## 5. E-Mails abfangen (Mailpit)
+
+Bei echten Bestellungen versendet das Backend Bestätigungs-E-Mails. Damit beim Lasttest
+**keine echten** Mails rausgehen — auch nicht, wenn in der `.env` echte SMTP-Daten stehen —
+bindet `./dev.bat loadtest` automatisch das Override [`../docker-compose.mailpit.yml`](../docker-compose.mailpit.yml)
+ein. Darin überschreiben **literale** `SPRING_MAIL_*`-Werte die `${MAIL_*}`-Interpolation der
+Basis-`docker-compose.yml` (die zuletzt angegebene Compose-Datei gewinnt). Der gesamte
+Mailverkehr landet so im lokalen **Mailpit**-Container statt bei einem echten Server.
+
+- Mailpit-Web-UI (abgefangene Mails ansehen): **http://localhost:8025**
+- SMTP läuft Docker-intern auf `mailpit:1025` (nicht nach außen exponiert).
+- Unabhängig davon fängt der `EmailService` Sendefehler ohnehin ab (loggt nur, kein Crash) —
+  ohne Mailpit liefe die Last also auch durch, nur ohne dass man die Mails sehen könnte.
+
+> Hinweis: Der Standard-Lasttest (`load-test.js`) platziert keine Bestellungen, erzeugt also
+> kaum Mails. Sobald du gegen den laufenden Stack das **Bestell-Szenario** (Abschnitt 4) startest,
+> werden dessen Bestätigungs-Mails in Mailpit sichtbar.
+
+**Manuelle Nutzung** des Overrides (ohne `dev loadtest`):
+```bash
+docker compose -f docker-compose.yml -f docker-compose.mailpit.yml up -d --build
+```
+
+---
+
+## 6. Ergebnisse
+
+**Lauf:** read-dominanter Test (`load-test.js`), Profil 20 → 50 → 100 → 200 VUs.
+**Datenmenge:** 5.000 Produkte, 1.000 Kunden (loadtest-seed).
+**Umgebung:** Docker Desktop (Windows), **kompletter Stack + k6-Lastgenerator auf derselben Maschine**
+— die Zahlen sind dadurch indikativ (CPU-Konkurrenz), nicht repräsentativ für einen dedizierten Server.
+
+### Aggregat über den gesamten Lauf (k6)
+
+| Metrik | Wert |
+|---|---|
+| Requests gesamt / Rate | 1.046 / ~3,9 req/s |
+| Antwortzeit Median | 20,7 s |
+| Antwortzeit p90 / p95 | 36,6 s / 37,4 s |
+| Antwortzeit max | 59,7 s |
+| Fehlerquote (HTTP) | **17,0 %** (178 / 1.046) |
+| Iterationen (abgeschlossen) | 364 |
+| Daten empfangen | **~1,1 GB** |
+| max. gleichzeitige VUs | 200 |
+
+### Erfolgsquote je Endpunkt (k6-Checks)
+
+| Endpunkt | Status 200/2xx |
+|---|---|
+| `GET /api/products` (Katalog) | 76 % |
+| `GET /api/products/{id}` | 88 % |
+| `POST /api/auth/login` | 79 % |
+| `GET /api/cart` | 92 % |
+| `POST /api/cart/items` | 90 % |
+| `GET /api/orders` | 92 % |
+
+### Verdikt
+
+Alle drei Schwellen (`http_req_failed<1 %`, `http_req_duration p95<800 ms`, `business_errors<1 %`)
+wurden **deutlich gerissen**. Das System sättigt bei diesem Profil **weit unterhalb von 200 VUs** —
+die Latenz steigt in den **Sekunden-/Zehnersekunden-Bereich**, statt im Millisekundenbereich zu bleiben.
+
+### Hauptengpass
+
+**Der ungepagte Produktkatalog.** `GET /api/products?purchasable=true` liefert **alle 5.000 Produkte
+in einer Antwort** (~1 MB pro Aufruf → ~1,1 GB Gesamt-Transfer bei nur ~1.046 Requests). Unter Last ist
+das der dominierende Faktor: Serialisierung großer JSON-Antworten + Bandbreite + GC-Druck.
+(In einem Lauf führte das sogar dazu, dass der Backend-Container unter Volllast nicht mehr erreichbar war.)
+
+### Bestell-Szenario (`order-load-test.js`)
+
+Separater Lauf, Profil 10 → 25 → 50 VUs, gegen den Hochlager-Artikel; Mails von Mailpit abgefangen.
+
+| Metrik | Wert |
+|---|---|
+| Bestellungen platziert | 373 (369 erfolgreich, 4 Fehler) |
+| `POST /api/orders` Erfolg | 98 % |
+| Fehlerquote (HTTP) | 0,35 % ✓ |
+| order_errors | 0,53 % ✓ |
+| Antwortzeit Median / p95 / max | 3,2 s / **10,7 s** / 15,8 s |
+| Rate | ~5,9 req/s, ~2,0 Bestellungen/s |
+| Daten empfangen | ~1,4 MB |
+| max. VUs | 50 |
+
+**Befund:** Der Checkout ist **funktional robust** (Bestellungen gehen durch, <1 % Fehler), aber die
+**Latenz kippt** schon bei 50 VUs (p95 ~10,7 s, Schwelle 1,5 s gerissen). Anders als beim Katalog ist
+das **kein Payload-Problem** (nur ~1,4 MB), sondern die **synchrone Checkout-Verarbeitung**
+(DB-Schreibvorgänge, Bestandslogik, synchroner Mailversand im Request-Pfad).
+
+### Empfehlungen
+
+- **Pagination / Limit** für `GET /api/products` (z.B. `page`/`size`), statt den ganzen Katalog auszuliefern.
+- **Schlankere Katalog-DTOs** (Listenansicht ohne Volltext-Beschreibung; Details erst über `/{id}`).
+- **Checkout entlasten:** Mailversand aus dem Request-Pfad nehmen (asynchron/Queue), damit die
+  Bestell-Latenz nicht am synchronen SMTP-Call hängt.
+- Optional HTTP-Caching/ETag für den Katalog, Connection-Pool (HikariCP) und JVM-Heap unter Last in Grafana beobachten.
+- Für belastbare Zahlen: Last von einer **separaten Maschine** gegen einen dedizierten Backend-Host fahren.
+
+> Detaillierter Zeitverlauf (ab welcher VU-Stufe die Latenz kippt, Heap-/Pool-Auslastung) ist im
+> Grafana-Dashboard **HTTP Requests** / **JVM Overview** über das Lauf-Zeitfenster sichtbar.

--- a/loadtest/load-test.js
+++ b/loadtest/load-test.js
@@ -1,0 +1,189 @@
+// k6 load test for the Webshop backend.
+//
+// Simulates a realistic, read-dominant traffic mix (browsing the catalog) with a fraction of
+// authenticated sessions (login, cart, order history). Optionally — for a maximum-load run —
+// each authenticated session also places a REAL order against a dedicated high-stock product
+// (set PLACE_ORDERS=true). Ramps the number of virtual users up in stages to find the point
+// where latency / error rate degrade.
+//
+// Run while the full stack is up (./dev.bat start) and a load-test data volume is seeded
+// (see docs/loadtest.md). Watch the Grafana dashboards at http://localhost:3001 during the run.
+//
+// Example (k6 in Docker, reaching the backend published on the host):
+//   docker run --rm -e BASE_URL=http://host.docker.internal:8080 \
+//     -v "${PWD}/loadtest:/scripts" grafana/k6 run /scripts/load-test.js
+//
+// Tunables via environment variables:
+//   BASE_URL          backend base URL              (default http://host.docker.internal:8080)
+//   LOGIN_PASSWORD    password for the test users   (default Password1!)
+//   LOGIN_USER_PREFIX username prefix for login     (default alice — a single dev-seed account)
+//   LOGIN_USER_COUNT  number of users <prefix>1..N  (default 0 → use the prefix verbatim)
+//   AUTH_SHARE        fraction of iterations that authenticate (default 0.3)
+//   PLACE_ORDERS      'true' → authenticated sessions place a real order (max-load mode)
+//   ORDER_PRODUCT_SEARCH  search term for the high-stock order product (default 'Bestell Artikel')
+
+import http from 'k6/http';
+import { check, group, sleep } from 'k6';
+import { Rate } from 'k6/metrics';
+
+const BASE_URL = __ENV.BASE_URL || 'http://host.docker.internal:8080';
+const LOGIN_PASSWORD = __ENV.LOGIN_PASSWORD || 'Password1!';
+const LOGIN_USER_PREFIX = __ENV.LOGIN_USER_PREFIX || 'alice';
+const LOGIN_USER_COUNT = Number(__ENV.LOGIN_USER_COUNT || 0);
+const AUTH_SHARE = Number(__ENV.AUTH_SHARE || 0.3);
+const PLACE_ORDERS = (__ENV.PLACE_ORDERS || 'false') === 'true';
+const ORDER_PRODUCT_SEARCH = __ENV.ORDER_PRODUCT_SEARCH || 'Bestell Artikel';
+
+// Custom metric: share of business-flow steps that failed their functional check.
+const businessErrors = new Rate('business_errors');
+
+export const options = {
+  // Ramp virtual users up in stages so the breaking point is visible in the timeline.
+  stages: [
+    { duration: '30s', target: 20 },
+    { duration: '1m', target: 50 },
+    { duration: '1m', target: 100 },
+    { duration: '1m', target: 200 },
+    { duration: '30s', target: 0 },
+  ],
+  thresholds: {
+    // The run is considered healthy below these limits; crossing them marks the "knee".
+    http_req_failed: ['rate<0.01'],     // less than 1% failed HTTP requests
+    http_req_duration: ['p(95)<800'],   // 95% of requests faster than 800 ms
+    business_errors: ['rate<0.01'],
+  },
+};
+
+// Resolves the dedicated high-stock order product once (shared by all VUs) when placing orders.
+export function setup() {
+  if (!PLACE_ORDERS) {
+    return {};
+  }
+  const response = http.get(`${BASE_URL}/api/products?search=${encodeURIComponent(ORDER_PRODUCT_SEARCH)}`);
+  const products = response.status === 200 ? response.json() : [];
+  const orderProductId = Array.isArray(products) && products.length > 0 ? products[0].id : null;
+  if (orderProductId === null) {
+    console.warn(
+      `PLACE_ORDERS is set but no product matched "${ORDER_PRODUCT_SEARCH}". ` +
+      'Did you apply loadtest-seed.sql? Orders will be skipped.',
+    );
+  }
+  return { orderProductId };
+}
+
+function pickLoginUsername() {
+  if (LOGIN_USER_COUNT > 0) {
+    return `${LOGIN_USER_PREFIX}${1 + Math.floor(Math.random() * LOGIN_USER_COUNT)}`;
+  }
+  return LOGIN_USER_PREFIX;
+}
+
+function browseCatalog() {
+  let randomProductId = null;
+  group('browse catalog', () => {
+    const catalog = http.get(`${BASE_URL}/api/products?purchasable=true`, {
+      tags: { name: 'GET /api/products' },
+    });
+    const ok = check(catalog, {
+      'catalog status 200': (response) => response.status === 200,
+    });
+    businessErrors.add(!ok);
+
+    if (ok) {
+      const products = catalog.json();
+      if (Array.isArray(products) && products.length > 0) {
+        randomProductId = products[Math.floor(Math.random() * products.length)].id;
+      }
+    }
+
+    if (randomProductId !== null) {
+      const detail = http.get(`${BASE_URL}/api/products/${randomProductId}`, {
+        tags: { name: 'GET /api/products/{id}' },
+      });
+      businessErrors.add(!check(detail, {
+        'product detail status 200': (response) => response.status === 200,
+      }));
+    }
+  });
+  return randomProductId;
+}
+
+function placeOrder(authHeaders) {
+  const orderBody = JSON.stringify({
+    email: 'loadtest@example.test',
+    customerName: 'Load Test',
+    deliveryAddress: { street: 'Hauptstrasse 1', city: 'Bielefeld', postalCode: '33602', country: 'Germany' },
+    shippingMethod: 'STANDARD',
+    paymentMethod: { methodType: 'BANK_TRANSFER', maskedDetails: 'Rechnung' },
+    allowUnverifiedAddress: true,   // skip the external address-validation call under load
+    acceptedTermsAndConditions: true,
+    acceptedPrivacyPolicy: true,
+    items: null,                    // POST /api/orders builds the order from the cart
+  });
+  const order = http.post(`${BASE_URL}/api/orders`, orderBody, { ...authHeaders, tags: { name: 'POST /api/orders' } });
+  businessErrors.add(!check(order, {
+    'order placed 2xx': (response) => response.status >= 200 && response.status < 300,
+  }));
+}
+
+function authenticatedSession(browsedProductId, orderProductId) {
+  group('authenticated session', () => {
+    const loginResponse = http.post(
+      `${BASE_URL}/api/auth/login`,
+      JSON.stringify({ username: pickLoginUsername(), password: LOGIN_PASSWORD }),
+      { headers: { 'Content-Type': 'application/json' }, tags: { name: 'POST /api/auth/login' } },
+    );
+    const loggedIn = check(loginResponse, {
+      'login status 200': (response) => response.status === 200,
+      'login returns token': (response) => !!response.json('token'),
+    });
+    businessErrors.add(!loggedIn);
+    if (!loggedIn) {
+      return;
+    }
+
+    const authHeaders = {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${loginResponse.json('token')}`,
+      },
+    };
+
+    const cart = http.get(`${BASE_URL}/api/cart`, { ...authHeaders, tags: { name: 'GET /api/cart' } });
+    businessErrors.add(!check(cart, { 'cart status 200': (response) => response.status === 200 }));
+
+    // When placing orders, fill the cart with the high-stock product so nothing runs out of stock.
+    const placingOrder = PLACE_ORDERS && orderProductId;
+    const cartProductId = placingOrder ? orderProductId : browsedProductId;
+    if (cartProductId !== null && cartProductId !== undefined) {
+      const addToCart = http.post(
+        `${BASE_URL}/api/cart/items`,
+        JSON.stringify({ productId: cartProductId, quantity: 1 }),
+        { ...authHeaders, tags: { name: 'POST /api/cart/items' } },
+      );
+      businessErrors.add(!check(addToCart, {
+        'add to cart 2xx': (response) => response.status >= 200 && response.status < 300,
+      }));
+    }
+
+    const orderHistory = http.get(`${BASE_URL}/api/orders`, { ...authHeaders, tags: { name: 'GET /api/orders' } });
+    businessErrors.add(!check(orderHistory, {
+      'order history status 200': (response) => response.status === 200,
+    }));
+
+    if (placingOrder) {
+      placeOrder(authHeaders);
+    }
+  });
+}
+
+export default function (data) {
+  const browsedProductId = browseCatalog();
+
+  if (Math.random() < AUTH_SHARE) {
+    authenticatedSession(browsedProductId, data ? data.orderProductId : null);
+  }
+
+  // Short think-time between iterations, like a real user.
+  sleep(Math.random() * 2 + 1);
+}

--- a/loadtest/order-load-test.js
+++ b/loadtest/order-load-test.js
@@ -1,0 +1,109 @@
+// OPTIONAL k6 scenario: real order placement under load.
+//
+// Unlike the main load-test.js (read-dominant), this script actually places orders via
+// POST /api/orders. It is kept separate and deliberately uses fewer virtual users because
+// order placement mutates state. To avoid out-of-stock errors polluting the results it targets
+// a dedicated high-stock product seeded by loadtest-seed.sql ("Load Test Bestell Artikel").
+//
+// Prerequisites (see docs/loadtest.md):
+//   - stack running, loadtest-seed.sql applied (provides the high-stock product + loaduser accounts)
+//   - ideally a mail catcher (Mailpit/MailHog) so order-confirmation emails are intercepted
+//
+// Example:
+//   docker run --rm -e BASE_URL=http://host.docker.internal:8080 \
+//     -e LOGIN_USER_PREFIX=loaduser -e LOGIN_USER_COUNT=1000 \
+//     -v "${PWD}/loadtest:/scripts" grafana/k6 run /scripts/order-load-test.js
+
+import http from 'k6/http';
+import { check, group, sleep } from 'k6';
+import { Rate } from 'k6/metrics';
+
+const BASE_URL = __ENV.BASE_URL || 'http://host.docker.internal:8080';
+const LOGIN_PASSWORD = __ENV.LOGIN_PASSWORD || 'Password1!';
+const LOGIN_USER_PREFIX = __ENV.LOGIN_USER_PREFIX || 'loaduser';
+const LOGIN_USER_COUNT = Number(__ENV.LOGIN_USER_COUNT || 1000);
+const ORDER_PRODUCT_SEARCH = __ENV.ORDER_PRODUCT_SEARCH || 'Bestell Artikel';
+
+const orderErrors = new Rate('order_errors');
+
+export const options = {
+  // Fewer VUs than the read load — order placement is heavier and stateful.
+  stages: [
+    { duration: '30s', target: 10 },
+    { duration: '1m', target: 25 },
+    { duration: '1m', target: 50 },
+    { duration: '30s', target: 0 },
+  ],
+  thresholds: {
+    http_req_failed: ['rate<0.02'],
+    http_req_duration: ['p(95)<1500'],
+    order_errors: ['rate<0.02'],
+  },
+};
+
+function pickLoginUsername() {
+  if (LOGIN_USER_COUNT > 0) {
+    return `${LOGIN_USER_PREFIX}${1 + Math.floor(Math.random() * LOGIN_USER_COUNT)}`;
+  }
+  return LOGIN_USER_PREFIX;
+}
+
+function authHeaders(token) {
+  return {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+  };
+}
+
+export function setup() {
+  // Resolve the dedicated high-stock product id once, shared by all VUs.
+  const response = http.get(`${BASE_URL}/api/products?search=${encodeURIComponent(ORDER_PRODUCT_SEARCH)}`);
+  const products = response.status === 200 ? response.json() : [];
+  if (!Array.isArray(products) || products.length === 0) {
+    throw new Error(
+      `No product matched "${ORDER_PRODUCT_SEARCH}". Did you apply loadtest-seed.sql? (status ${response.status})`,
+    );
+  }
+  return { productId: products[0].id };
+}
+
+export default function (data) {
+  group('place order', () => {
+    const login = http.post(
+      `${BASE_URL}/api/auth/login`,
+      JSON.stringify({ username: pickLoginUsername(), password: LOGIN_PASSWORD }),
+      { headers: { 'Content-Type': 'application/json' }, tags: { name: 'POST /api/auth/login' } },
+    );
+    if (!check(login, { 'login 200': (r) => r.status === 200 && !!r.json('token') })) {
+      orderErrors.add(true);
+      return;
+    }
+    const headers = authHeaders(login.json('token'));
+
+    const addToCart = http.post(
+      `${BASE_URL}/api/cart/items`,
+      JSON.stringify({ productId: data.productId, quantity: 1 }),
+      { ...headers, tags: { name: 'POST /api/cart/items' } },
+    );
+    orderErrors.add(!check(addToCart, { 'add to cart 2xx': (r) => r.status >= 200 && r.status < 300 }));
+
+    // POST /api/orders builds the order from the cart when items is null.
+    const orderBody = JSON.stringify({
+      email: 'loadtest@example.test',
+      customerName: 'Load Test',
+      deliveryAddress: { street: 'Hauptstrasse 1', city: 'Bielefeld', postalCode: '33602', country: 'Germany' },
+      shippingMethod: 'STANDARD',
+      paymentMethod: { methodType: 'BANK_TRANSFER', maskedDetails: 'Rechnung' },
+      allowUnverifiedAddress: true,   // skip the external address-validation call under load
+      acceptedTermsAndConditions: true,
+      acceptedPrivacyPolicy: true,
+      items: null,
+    });
+    const order = http.post(`${BASE_URL}/api/orders`, orderBody, { ...headers, tags: { name: 'POST /api/orders' } });
+    orderErrors.add(!check(order, { 'order placed 2xx': (r) => r.status >= 200 && r.status < 300 }));
+  });
+
+  sleep(Math.random() * 2 + 1);
+}

--- a/src/main/resources/db/loadtest-seed.sql
+++ b/src/main/resources/db/loadtest-seed.sql
@@ -1,0 +1,71 @@
+-- ============================================================
+-- Load-test seed data — generates a realistic, large data volume
+-- for performance/load testing (see docs/loadtest.md).
+--
+-- Run AFTER Flyway migrations, on a FRESH database (e.g. after
+-- `./dev.bat rebuild`). Re-running on a non-fresh DB fails on the
+-- UNIQUE constraints (username/email/sku), which is intentional.
+--
+-- Usage (PowerShell):
+--   Get-Content src\main\resources\db\loadtest-seed.sql | docker exec -i webshop-postgres psql -U webshop -d webshop
+-- Usage (bash):
+--   docker exec -i webshop-postgres psql -U webshop -d webshop < src/main/resources/db/loadtest-seed.sql
+--
+-- Counts can be tuned via the two psql variables below.
+-- ============================================================
+
+\set product_count 5000
+\set customer_count 1000
+
+BEGIN;
+
+-- ── Bulk products ───────────────────────────────────────────────────────────
+-- All purchasable so they show up in the customer catalog endpoint under load.
+INSERT INTO products (
+    name, description, recommended_retail_price, co2_emission_kg,
+    eco_score, category, stock, sku, purchasable, promoted
+)
+SELECT
+    'Load Test Produkt ' || series,
+    'Automatisch generiertes Produkt fuer den Lasttest, Nummer ' || series,
+    ROUND((5 + random() * 995)::numeric, 2),
+    ROUND((random() * 200)::numeric, 3),
+    (ARRAY['A', 'B', 'C', 'D', 'E'])[1 + floor(random() * 5)::int],
+    (ARRAY['Electronics', 'Furniture', 'Stationery', 'Kitchen', 'Sports'])[1 + floor(random() * 5)::int],
+    (10 + floor(random() * 490))::int,
+    'LOAD-SKU-' || series,
+    TRUE,
+    (random() < 0.1)
+FROM generate_series(1, :product_count) AS series;
+
+-- ── Bulk customers (all share the password "Password1!") ─────────────────────
+INSERT INTO users (username, email, password_hash, user_type, customer_number)
+SELECT
+    'loaduser' || series,
+    'loaduser' || series || '@example.test',
+    '$2a$10$yT.Ge6bLC.BWERriPv/wguUMUtBF4iA3W0Q5VNDklGalWYlGy3Zze',
+    'PRIVATE',
+    'K-' || to_char(nextval('customer_number_sequence'), 'FM000000')
+FROM generate_series(1, :customer_count) AS series;
+
+INSERT INTO user_roles (user_id, role)
+SELECT id, 'CUSTOMER' FROM users WHERE username LIKE 'loaduser%';
+
+-- ── Dedicated high-stock product for the OPTIONAL real-order scenario ─────────
+-- A practically unlimited stock so concurrent order placement never depletes it
+-- (otherwise out-of-stock validation errors would pollute the error rate).
+INSERT INTO products (
+    name, description, recommended_retail_price, eco_score, category, stock, sku, purchasable
+)
+VALUES (
+    'Load Test Bestell Artikel',
+    'Hochlager-Artikel fuer den optionalen Bestell-Lasttest (siehe docs/loadtest.md)',
+    9.99, 'C', 'Loadtest', 100000000, 'LOAD-ORDER-PRODUCT', TRUE
+);
+
+COMMIT;
+
+-- Quick verification
+SELECT
+    (SELECT count(*) FROM products WHERE sku LIKE 'LOAD-SKU-%')      AS load_products,
+    (SELECT count(*) FROM users    WHERE username LIKE 'loaduser%')  AS load_customers;


### PR DESCRIPTION
# Pull Request

## 📝 Beschreibung

Last-/Ressourcentest mit k6 + Grafana/Prometheus, plus realistische Lastdaten und ein `loadtest`-Befehl im Dev-Script.

- **k6-Skripte** (`loadtest/`): `load-test.js` (read-dominant, optionaler `PLACE_ORDERS`-Modus für max. Auslastung) und `order-load-test.js` (fokussiertes echtes Bestell-Szenario gegen einen Hochlager-Artikel)
- **Lastdaten** (`loadtest-seed.sql`): 5.000 Produkte, 1.000 Kunden, dedizierter Hochlager-Bestell-Artikel (via `generate_series`)
- **`dev loadtest`** (`dev.ps1` + `dev.sh`): interaktiver Ablauf — rebuild (frische DB) + seed, dann Abfrage `ja / nein / ja inkl. Bestellungen`, k6-Logs live in der Konsole, danach optional reines Bestell-Szenario; Stack bleibt für Grafana/Mailpit laufen
- **`docker-compose.mailpit.yml`**: opt-in Override, fängt allen Mailverkehr lokal in Mailpit ab (überschreibt SMTP literal, unabhängig von `.env`); von `dev loadtest` automatisch eingebunden → kein echter Versand
- **`docs/loadtest.md`**: Anleitung, optionales Bestell-Szenario, E-Mail-Abfangen und **echte Messergebnisse**
- READMEs (Win/Linux/Mac) um den `loadtest`-Befehl ergänzt

### Messergebnisse (Auszug, indikativ — Stack + k6 auf einer Maschine)

- **Read-Last (bis 200 VUs):** Schwellen klar gerissen (p95 ~37 s, Fehlerquote 17 %). Hauptengpass: **ungepagter Katalog** (`GET /api/products` liefert alle 5.000 Produkte → ~1,1 GB Transfer).
- **Bestell-Last (bis 50 VUs):** funktional robust (<1 % Fehler, Bestellungen gehen durch), aber Latenz kippt (p95 ~10,7 s) durch die synchrone Checkout-Verarbeitung. Bestätigungsmails von Mailpit abgefangen.
- Empfehlungen dokumentiert (Pagination, schlanke Listen-DTOs, asynchroner Mailversand).

## 🎯 Ticket

Resolves #103 lasttest-k6-grafana-prometheus

## 📋 Änderungen
*Hake an, welche Änderungen erfolgt sind:*

- [x] Neue Features hinzugefügt
- [ ] Bugs behoben
- [ ] Code refaktoriert
- [x] Code ist selbsterklärend mit Kommentaren
- [x] Tests geschrieben/aktualisiert
- [x] Dokumentation aktualisiert

## 🔗 Related Issues

- Part of SEPBFWS124A/Webshop#299 (Frontend-User-Story, Strang B)
- Relates to SEPBFWS124A/Webshop-Backend#102 (Strang A: DB-Integrationstests)

---

**Wichtig:** Dieser PR wird automatisch den Ticket schließen, wenn er gemergt wird (via "Resolves #...").
Dieser PR geht gegen `main` (das Backend-Repo nutzt kein `develop`).
