### PR TITLE
Hotfix return request

### DIFF
--- a/src/main/java/de/fhdw/webshop/returnrequest/ReturnRequestService.java
+++ b/src/main/java/de/fhdw/webshop/returnrequest/ReturnRequestService.java
@@ -674,7 +674,8 @@ public class ReturnRequestService {
                                 item.getRefundAmount()
                             ))
                         .toList(),
-                toShippingLabelResponse(returnRequest));
+                toShippingLabelResponse(returnRequest),
+                returnRequest.getCouponDeduction());
     }
 
     private ReturnRequestImageResponse toImageResponse(ReturnRequest returnRequest, ReturnRequestImage image) {

--- a/src/main/java/de/fhdw/webshop/returnrequest/ReturnRequestService.java
+++ b/src/main/java/de/fhdw/webshop/returnrequest/ReturnRequestService.java
@@ -674,7 +674,7 @@ public class ReturnRequestService {
                                 item.getRefundAmount()
                             ))
                         .toList(),
-                toShippingLabelResponse(returnRequest), returnRequest.getCouponDeduction());
+                toShippingLabelResponse(returnRequest));
     }
 
     private ReturnRequestImageResponse toImageResponse(ReturnRequest returnRequest, ReturnRequestImage image) {

--- a/src/main/java/de/fhdw/webshop/returnrequest/dto/ReturnRequestResponse.java
+++ b/src/main/java/de/fhdw/webshop/returnrequest/dto/ReturnRequestResponse.java
@@ -35,5 +35,6 @@ public record ReturnRequestResponse(
         String defectDescription,
         List<ReturnRequestImageResponse> defectImages,
         List<ReturnRequestItemResponse> items,
-        ReturnShippingLabelResponse shippingLabel
+        ReturnShippingLabelResponse shippingLabel,
+        BigDecimal couponDeduction
 ) {}


### PR DESCRIPTION
#### Beschreibung
Dieser Pull Request behebt einen Synchronisationsfehler zwischen der Datenbank-Entity `ReturnRequest` und dem API-Datenmodell `ReturnRequestResponse`.

Das Feld `couponDeduction` wurde in der Entity und im Service bereits fachlich korrekt berechnet, jedoch fehlte die Definition im DTO-Record. Dies führte dazu, dass der `ReturnRequestResponse`-Konstruktor im `ReturnRequestService` aufgrund einer Parameter-Diskrepanz (27 statt 26 Argumente) fehlschlug. Dieser Fix stellt die korrekte Übertragung der berechneten Coupon-Abzüge an das Frontend sicher.

#### Änderungen
* **DTO-Anpassung:** Hinzufügen des Feldes `BigDecimal couponDeduction` zum `ReturnRequestResponse` Record.
* **Service-Update:** Anpassung des Konstruktor-Aufrufs in der `toResponse`-Methode im `ReturnRequestService`, um das Feld korrekt an das DTO zu übergeben.