### PR TITLE
US-329: Warenkorb-Erinnerungen versenden

### DIFF
--- a/src/main/java/de/fhdw/webshop/accountlink/AccountLinkService.java
+++ b/src/main/java/de/fhdw/webshop/accountlink/AccountLinkService.java
@@ -219,6 +219,7 @@ public class AccountLinkService {
                 user.getEmployeeNumber(),
                 user.getUserType(),
                 user.getCustomerNumber(),
-                user.getAgbAcceptedAt());
+                user.getAgbAcceptedAt(),
+                user.isCartReminderEnabled());
     }
 }

--- a/src/main/java/de/fhdw/webshop/admin/AdminController.java
+++ b/src/main/java/de/fhdw/webshop/admin/AdminController.java
@@ -204,7 +204,8 @@ public class AdminController {
                 user.getEmployeeNumber(),
                 user.getUserType(),
                 user.getCustomerNumber(),
-                user.getAgbAcceptedAt());
+                user.getAgbAcceptedAt(),
+                user.isCartReminderEnabled());
     }
 
     private void synchronizeUserBusinessIdentifiers(User user, UserRole effectiveRole) {

--- a/src/main/java/de/fhdw/webshop/cart/CartService.java
+++ b/src/main/java/de/fhdw/webshop/cart/CartService.java
@@ -10,6 +10,7 @@ import de.fhdw.webshop.cart.dto.QuickOrderPreviewResponse;
 import de.fhdw.webshop.cart.dto.QuickOrderPreviewRow;
 import de.fhdw.webshop.cart.audit.CartChangeAction;
 import de.fhdw.webshop.cart.audit.CartChangeLogService;
+import de.fhdw.webshop.cartreminder.CartReminderService;
 import de.fhdw.webshop.discount.Coupon;
 import de.fhdw.webshop.discount.CouponRepository;
 import de.fhdw.webshop.discount.VolumeDiscountService;
@@ -65,6 +66,7 @@ public class CartService {
     private final CartChangeLogService cartChangeLogService;
     private final StockReservationService stockReservationService;
     private final ProductBundleService productBundleService;
+    private final CartReminderService cartReminderService;
 
     private static final BigDecimal TAX_RATE      = BigDecimal.valueOf(0.19);
     private static final BigDecimal SHIPPING_COST = new BigDecimal("4.99");
@@ -214,6 +216,7 @@ public class CartService {
         cartItem.setQuantity(requestedQuantity);
         CartItem savedItem = cartRepository.save(cartItem);
         stockReservationService.refreshReservation(savedItem);
+        cartReminderService.markCartChanged(user.getId());
         return getCart(user.getId());
     }
 
@@ -238,6 +241,7 @@ public class CartService {
             stockReservationService.refreshReservation(savedItem);
         }
 
+        cartReminderService.markCartChanged(user.getId());
         return getCart(user.getId());
     }
 
@@ -273,7 +277,7 @@ public class CartService {
                 .orElseThrow(() -> new EntityNotFoundException("Item not in cart: productId=" + productId));
         stockReservationService.releaseCartItemReservation(cartItem.getId());
         cartRepository.deleteByUserIdAndProductId(user.getId(), productId);
-        return getCart(user.getId());
+        return getCartAndRefreshReminderState(user.getId());
     }
 
     /** US #253 - Removing an item from a customer cart by an employee is recorded as well. */
@@ -303,7 +307,7 @@ public class CartService {
                 .orElseThrow(() -> new EntityNotFoundException("Item not in cart: cartItemId=" + cartItemId));
         stockReservationService.releaseCartItemReservation(cartItem.getId());
         cartRepository.delete(cartItem);
-        return getCart(user.getId());
+        return getCartAndRefreshReminderState(user.getId());
     }
 
     @Transactional
@@ -322,7 +326,7 @@ public class CartService {
             stockReservationService.releaseCartItemReservation(bundleItem.getId());
         }
         cartRepository.deleteAll(bundleItems);
-        return getCart(user.getId());
+        return getCartAndRefreshReminderState(user.getId());
     }
 
     /** US #73 — Set a new quantity; quantity 0 removes the item entirely. */
@@ -338,6 +342,7 @@ public class CartService {
         cartItem.setQuantity(quantity);
         CartItem savedItem = cartRepository.save(cartItem);
         stockReservationService.refreshReservation(savedItem);
+        cartReminderService.markCartChanged(user.getId());
         return getCart(user.getId());
     }
 
@@ -379,6 +384,7 @@ public class CartService {
         cartItem.setQuantity(quantity);
         CartItem savedItem = cartRepository.save(cartItem);
         stockReservationService.refreshReservation(savedItem);
+        cartReminderService.markCartChanged(user.getId());
         return getCart(user.getId());
     }
 
@@ -428,6 +434,7 @@ public class CartService {
             CartItem savedItem = cartRepository.save(cartItem);
             stockReservationService.refreshReservation(savedItem);
         }
+        cartReminderService.markCartChanged(user.getId());
         return getCart(user.getId());
     }
 
@@ -492,6 +499,9 @@ public class CartService {
             addedQuantity += row.requestedQuantity();
         }
 
+        if (addedLines > 0) {
+            cartReminderService.markCartChanged(user.getId());
+        }
         return new QuickOrderConfirmResponse(getCart(user.getId()), addedLines, addedQuantity, skippedRows);
     }
 
@@ -500,12 +510,23 @@ public class CartService {
     public void clearCartSilently(Long userId) {
         stockReservationService.releaseUserReservations(userId);
         cartRepository.deleteByUserId(userId);
+        cartReminderService.markCartCleared(userId);
     }
 
     @Transactional
     public CartResponse clearCart(Long userId) {
         clearCartSilently(userId);
         return getCart(userId);
+    }
+
+    private CartResponse getCartAndRefreshReminderState(Long userId) {
+        CartResponse cart = getCart(userId);
+        if (cart.items().isEmpty()) {
+            cartReminderService.markCartCleared(userId);
+        } else {
+            cartReminderService.markCartChanged(userId);
+        }
+        return cart;
     }
 
     private CartItemResponse toItemResponse(CartItem cartItem, Long userId) {

--- a/src/main/java/de/fhdw/webshop/cartreminder/CartReminder.java
+++ b/src/main/java/de/fhdw/webshop/cartreminder/CartReminder.java
@@ -1,0 +1,37 @@
+package de.fhdw.webshop.cartreminder;
+
+import de.fhdw.webshop.user.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "cart_reminders")
+@Getter
+@Setter
+@NoArgsConstructor
+public class CartReminder {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Column(name = "last_modified_at")
+    private Instant lastModifiedAt;
+
+    @Column(name = "reminder_sent_at")
+    private Instant reminderSentAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt = Instant.now();
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt = Instant.now();
+}

--- a/src/main/java/de/fhdw/webshop/cartreminder/CartReminderRepository.java
+++ b/src/main/java/de/fhdw/webshop/cartreminder/CartReminderRepository.java
@@ -1,0 +1,26 @@
+package de.fhdw.webshop.cartreminder;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+public interface CartReminderRepository extends JpaRepository<CartReminder, Long> {
+
+    Optional<CartReminder> findByUserId(Long userId);
+
+    @Query("""
+            SELECT reminder
+            FROM CartReminder reminder
+            JOIN FETCH reminder.user user
+            WHERE reminder.lastModifiedAt IS NOT NULL
+              AND reminder.lastModifiedAt <= :cutoff
+              AND reminder.reminderSentAt IS NULL
+              AND user.active = true
+              AND user.cartReminderEnabled = true
+            """)
+    List<CartReminder> findDueReminders(@Param("cutoff") Instant cutoff);
+}

--- a/src/main/java/de/fhdw/webshop/cartreminder/CartReminderScheduler.java
+++ b/src/main/java/de/fhdw/webshop/cartreminder/CartReminderScheduler.java
@@ -1,0 +1,23 @@
+package de.fhdw.webshop.cartreminder;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CartReminderScheduler {
+
+    private final CartReminderService cartReminderService;
+
+    /** US #325 — Sends one reminder for abandoned carts after the configured waiting period. */
+    @Scheduled(cron = "${cart-reminders.cron:0 15 * * * *}")
+    public void sendCartReminders() {
+        int sent = cartReminderService.sendDueReminders();
+        if (sent > 0) {
+            log.info("Sent {} cart reminder email(s)", sent);
+        }
+    }
+}

--- a/src/main/java/de/fhdw/webshop/cartreminder/CartReminderService.java
+++ b/src/main/java/de/fhdw/webshop/cartreminder/CartReminderService.java
@@ -1,0 +1,165 @@
+package de.fhdw.webshop.cartreminder;
+
+import de.fhdw.webshop.cart.CartItem;
+import de.fhdw.webshop.cart.CartRepository;
+import de.fhdw.webshop.notification.EmailService;
+import de.fhdw.webshop.product.Product;
+import de.fhdw.webshop.user.User;
+import de.fhdw.webshop.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CartReminderService {
+
+    private final CartReminderRepository cartReminderRepository;
+    private final CartRepository cartRepository;
+    private final UserRepository userRepository;
+    private final EmailService emailService;
+
+    @Value("${app.frontend-url:http://localhost:5173}")
+    private String frontendUrl;
+
+    @Value("${cart-reminders.delay-hours:24}")
+    private long reminderDelayHours;
+
+    @Transactional
+    public void markCartChanged(Long userId) {
+        User user = userRepository.findById(userId).orElse(null);
+        if (user == null) {
+            return;
+        }
+
+        CartReminder reminder = cartReminderRepository.findByUserId(userId)
+                .orElseGet(() -> {
+                    CartReminder newReminder = new CartReminder();
+                    newReminder.setUser(user);
+                    return newReminder;
+                });
+        Instant now = Instant.now();
+        reminder.setLastModifiedAt(now);
+        reminder.setReminderSentAt(null);
+        reminder.setUpdatedAt(now);
+        cartReminderRepository.save(reminder);
+    }
+
+    @Transactional
+    public void markCartCleared(Long userId) {
+        cartReminderRepository.findByUserId(userId).ifPresent(reminder -> {
+            Instant now = Instant.now();
+            reminder.setLastModifiedAt(null);
+            reminder.setReminderSentAt(null);
+            reminder.setUpdatedAt(now);
+            cartReminderRepository.save(reminder);
+        });
+    }
+
+    @Transactional
+    public int sendDueReminders() {
+        Instant cutoff = Instant.now().minus(Duration.ofHours(reminderDelayHours));
+        int sentCount = 0;
+
+        for (CartReminder reminder : cartReminderRepository.findDueReminders(cutoff)) {
+            if (sendReminderIfStillRelevant(reminder)) {
+                sentCount++;
+            }
+        }
+
+        return sentCount;
+    }
+
+    private boolean sendReminderIfStillRelevant(CartReminder reminder) {
+        User customer = reminder.getUser();
+        List<CartItem> purchasableItems = cartRepository.findByUserId(customer.getId()).stream()
+                .filter(item -> item.getQuantity() > 0)
+                .filter(item -> item.getProduct() != null && item.getProduct().isPurchasable())
+                .toList();
+
+        if (purchasableItems.isEmpty()) {
+            markCartCleared(customer.getId());
+            return false;
+        }
+
+        boolean sent = emailService.sendEmailToCustomer(
+                customer,
+                "Dein Warenkorb wartet auf dich",
+                buildReminderBody(customer, purchasableItems)
+        );
+
+        if (!sent) {
+            log.warn("Cart reminder email could not be sent for user {}", customer.getId());
+            return false;
+        }
+
+        Instant now = Instant.now();
+        reminder.setReminderSentAt(now);
+        reminder.setUpdatedAt(now);
+        cartReminderRepository.save(reminder);
+        return true;
+    }
+
+    private String buildReminderBody(User customer, List<CartItem> items) {
+        int totalQuantity = items.stream().mapToInt(CartItem::getQuantity).sum();
+        BigDecimal total = items.stream()
+                .map(this::lineTotal)
+                .reduce(BigDecimal.ZERO, BigDecimal::add)
+                .setScale(2, RoundingMode.HALF_UP);
+
+        StringBuilder body = new StringBuilder();
+        body.append("Hallo ").append(customer.getUsername()).append(",\n\n");
+        body.append("dein Warenkorb wartet noch auf dich. Du hast ")
+                .append(totalQuantity)
+                .append(totalQuantity == 1 ? " Artikel" : " Artikel")
+                .append(" im Warenkorb.\n\n");
+        body.append("Warenkorb-Übersicht:\n");
+        for (CartItem item : items) {
+            body.append("- ")
+                    .append(item.getQuantity())
+                    .append("x ")
+                    .append(item.getProduct().getName())
+                    .append(" (")
+                    .append(formatMoney(lineTotal(item)))
+                    .append(")\n");
+        }
+        body.append("\nGesamtbetrag: ").append(formatMoney(total)).append("\n");
+        body.append("Direkt zurück zum Warenkorb: ").append(cartUrl()).append("\n\n");
+        body.append("Wenn du keine Warenkorb-Erinnerungen mehr erhalten möchtest, kannst du sie in deinem Profil deaktivieren.");
+        return body.toString();
+    }
+
+    private BigDecimal lineTotal(CartItem item) {
+        return unitPrice(item)
+                .multiply(BigDecimal.valueOf(item.getQuantity()))
+                .setScale(2, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal unitPrice(CartItem item) {
+        if (item.getPriceOverride() != null) {
+            return item.getPriceOverride();
+        }
+        if (item.getGiftCardAmount() != null) {
+            return item.getGiftCardAmount();
+        }
+        Product product = item.getProduct();
+        return product.getRecommendedRetailPrice() != null ? product.getRecommendedRetailPrice() : BigDecimal.ZERO;
+    }
+
+    private String cartUrl() {
+        return frontendUrl.replaceAll("/+$", "") + "/cart";
+    }
+
+    private String formatMoney(BigDecimal value) {
+        return value.setScale(2, RoundingMode.HALF_UP).toPlainString() + " EUR";
+    }
+}

--- a/src/main/java/de/fhdw/webshop/customer/CustomerController.java
+++ b/src/main/java/de/fhdw/webshop/customer/CustomerController.java
@@ -295,7 +295,8 @@ public class CustomerController {
                 customer.getEmployeeNumber(),
                 customer.getUserType(),
                 customer.getCustomerNumber(),
-                customer.getAgbAcceptedAt());
+                customer.getAgbAcceptedAt(),
+                customer.isCartReminderEnabled());
 
         CartResponse cart = cartService.getCart(id);
         BigDecimal cartTotal = cart != null && cart.total() != null ? cart.total() : BigDecimal.ZERO;
@@ -383,7 +384,8 @@ public class CustomerController {
                 user.getEmployeeNumber(),
                 user.getUserType(),
                 user.getCustomerNumber(),
-                user.getAgbAcceptedAt());
+                user.getAgbAcceptedAt(),
+                user.isCartReminderEnabled());
     }
 
     private List<String> buildAlerts(

--- a/src/main/java/de/fhdw/webshop/user/User.java
+++ b/src/main/java/de/fhdw/webshop/user/User.java
@@ -78,6 +78,9 @@ public class User implements UserDetails {
     @Column(name = "agb_accepted_at")
     private Instant agbAcceptedAt;
 
+    @Column(name = "cart_reminder_enabled", nullable = false)
+    private boolean cartReminderEnabled = true;
+
     // ── Convenience helpers ────────────────────────────────────────────────────
 
     public boolean hasRole(UserRole role) {

--- a/src/main/java/de/fhdw/webshop/user/UserController.java
+++ b/src/main/java/de/fhdw/webshop/user/UserController.java
@@ -56,6 +56,15 @@ public class UserController {
         return ResponseEntity.noContent().build();
     }
 
+    /** US #325 — Customer enables or disables abandoned-cart reminder emails. */
+    @PutMapping("/me/cart-reminders")
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public ResponseEntity<UserProfileResponse> updateCartReminderSettings(
+            @AuthenticationPrincipal User currentUser,
+            @Valid @RequestBody CartReminderSettingsRequest request) {
+        return ResponseEntity.ok(userService.updateCartReminderSettings(currentUser, request));
+    }
+
     /** US #7 — Deregister (soft-delete) own account. */
     @DeleteMapping("/me")
     public ResponseEntity<Void> deactivateAccount(@AuthenticationPrincipal User currentUser) {

--- a/src/main/java/de/fhdw/webshop/user/UserService.java
+++ b/src/main/java/de/fhdw/webshop/user/UserService.java
@@ -23,6 +23,12 @@ public class UserService {
         return toProfileResponse(currentUser);
     }
 
+    @Transactional
+    public UserProfileResponse updateCartReminderSettings(User currentUser, CartReminderSettingsRequest request) {
+        currentUser.setCartReminderEnabled(Boolean.TRUE.equals(request.enabled()));
+        return toProfileResponse(userRepository.save(currentUser));
+    }
+
     public CheckoutProfileResponse getCheckoutProfile(User currentUser) {
         DeliveryAddressResponse deliveryAddress = deliveryAddressRepository.findFirstByUserId(currentUser.getId())
                 .map(this::toDeliveryAddressResponse)
@@ -111,7 +117,8 @@ public class UserService {
                 user.getEmployeeNumber(),
                 user.getUserType(),
                 user.getCustomerNumber(),
-                user.getAgbAcceptedAt()
+                user.getAgbAcceptedAt(),
+                user.isCartReminderEnabled()
         );
     }
 

--- a/src/main/java/de/fhdw/webshop/user/dto/CartReminderSettingsRequest.java
+++ b/src/main/java/de/fhdw/webshop/user/dto/CartReminderSettingsRequest.java
@@ -1,0 +1,7 @@
+package de.fhdw.webshop.user.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CartReminderSettingsRequest(
+        @NotNull Boolean enabled
+) {}

--- a/src/main/java/de/fhdw/webshop/user/dto/UserProfileResponse.java
+++ b/src/main/java/de/fhdw/webshop/user/dto/UserProfileResponse.java
@@ -15,5 +15,6 @@ public record UserProfileResponse(
         String employeeNumber,
         UserType userType,
         String customerNumber,
-        Instant agbAcceptedAt
+        Instant agbAcceptedAt,
+        boolean cartReminderEnabled
 ) {}

--- a/src/main/resources/db/migration/V308__create_cart_reminders.sql
+++ b/src/main/resources/db/migration/V308__create_cart_reminders.sql
@@ -1,0 +1,14 @@
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS cart_reminder_enabled BOOLEAN NOT NULL DEFAULT TRUE;
+
+CREATE TABLE IF NOT EXISTS cart_reminders (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL UNIQUE REFERENCES users(id) ON DELETE CASCADE,
+    last_modified_at TIMESTAMP,
+    reminder_sent_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_cart_reminders_due
+    ON cart_reminders(last_modified_at, reminder_sent_at);

--- a/src/test/java/de/fhdw/webshop/cartreminder/CartReminderServiceTest.java
+++ b/src/test/java/de/fhdw/webshop/cartreminder/CartReminderServiceTest.java
@@ -1,0 +1,149 @@
+package de.fhdw.webshop.cartreminder;
+
+import de.fhdw.webshop.cart.CartItem;
+import de.fhdw.webshop.cart.CartRepository;
+import de.fhdw.webshop.notification.EmailService;
+import de.fhdw.webshop.product.Product;
+import de.fhdw.webshop.user.User;
+import de.fhdw.webshop.user.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CartReminderServiceTest {
+
+    @Test
+    void sendsReminderForDuePurchasableCartAndStoresSentTimestamp() {
+        TestContext context = newContext();
+        User customer = customer(1L);
+        CartReminder reminder = reminder(customer);
+        CartItem item = cartItem(customer, "Laptop Pro", "1299.00", 1, true);
+
+        when(context.cartReminderRepository.findDueReminders(any(Instant.class))).thenReturn(List.of(reminder));
+        when(context.cartRepository.findByUserId(customer.getId())).thenReturn(List.of(item));
+        when(context.emailService.sendEmailToCustomer(any(User.class), contains("Warenkorb"), contains("Laptop Pro")))
+                .thenReturn(true);
+
+        int sent = context.service.sendDueReminders();
+
+        assertThat(sent).isEqualTo(1);
+        verify(context.emailService).sendEmailToCustomer(customer, "Dein Warenkorb wartet auf dich", 
+                "Hallo kunde,\n\n"
+                        + "dein Warenkorb wartet noch auf dich. Du hast 1 Artikel im Warenkorb.\n\n"
+                        + "Warenkorb-Übersicht:\n"
+                        + "- 1x Laptop Pro (1299.00 EUR)\n\n"
+                        + "Gesamtbetrag: 1299.00 EUR\n"
+                        + "Direkt zurück zum Warenkorb: http://localhost:5173/cart\n\n"
+                        + "Wenn du keine Warenkorb-Erinnerungen mehr erhalten möchtest, kannst du sie in deinem Profil deaktivieren.");
+        ArgumentCaptor<CartReminder> reminderCaptor = ArgumentCaptor.forClass(CartReminder.class);
+        verify(context.cartReminderRepository).save(reminderCaptor.capture());
+        assertThat(reminderCaptor.getValue().getReminderSentAt()).isNotNull();
+    }
+
+    @Test
+    void doesNotSendReminderForEmptyOrUnavailableCartAndClearsCycle() {
+        TestContext context = newContext();
+        User customer = customer(2L);
+        CartReminder reminder = reminder(customer);
+        CartItem unavailableItem = cartItem(customer, "Archivprodukt", "19.99", 1, false);
+
+        when(context.cartReminderRepository.findDueReminders(any(Instant.class))).thenReturn(List.of(reminder));
+        when(context.cartReminderRepository.findByUserId(customer.getId())).thenReturn(Optional.of(reminder));
+        when(context.cartRepository.findByUserId(customer.getId())).thenReturn(List.of(unavailableItem));
+
+        int sent = context.service.sendDueReminders();
+
+        assertThat(sent).isZero();
+        verify(context.emailService, never()).sendEmailToCustomer(any(), any(), any());
+        ArgumentCaptor<CartReminder> reminderCaptor = ArgumentCaptor.forClass(CartReminder.class);
+        verify(context.cartReminderRepository).save(reminderCaptor.capture());
+        assertThat(reminderCaptor.getValue().getLastModifiedAt()).isNull();
+        assertThat(reminderCaptor.getValue().getReminderSentAt()).isNull();
+    }
+
+    @Test
+    void cartChangeStartsNewCycleAndAllowsAnotherReminder() {
+        TestContext context = newContext();
+        User customer = customer(3L);
+        CartReminder existingReminder = reminder(customer);
+        existingReminder.setReminderSentAt(Instant.now());
+
+        when(context.userRepository.findById(customer.getId())).thenReturn(Optional.of(customer));
+        when(context.cartReminderRepository.findByUserId(customer.getId())).thenReturn(Optional.of(existingReminder));
+
+        context.service.markCartChanged(customer.getId());
+
+        ArgumentCaptor<CartReminder> reminderCaptor = ArgumentCaptor.forClass(CartReminder.class);
+        verify(context.cartReminderRepository).save(reminderCaptor.capture());
+        assertThat(reminderCaptor.getValue().getLastModifiedAt()).isNotNull();
+        assertThat(reminderCaptor.getValue().getReminderSentAt()).isNull();
+    }
+
+    private static TestContext newContext() {
+        CartReminderRepository cartReminderRepository = mock(CartReminderRepository.class);
+        CartRepository cartRepository = mock(CartRepository.class);
+        UserRepository userRepository = mock(UserRepository.class);
+        EmailService emailService = mock(EmailService.class);
+        CartReminderService service = new CartReminderService(
+                cartReminderRepository,
+                cartRepository,
+                userRepository,
+                emailService
+        );
+        ReflectionTestUtils.setField(service, "frontendUrl", "http://localhost:5173");
+        ReflectionTestUtils.setField(service, "reminderDelayHours", 24L);
+        return new TestContext(service, cartReminderRepository, cartRepository, userRepository, emailService);
+    }
+
+    private static User customer(Long id) {
+        User user = new User();
+        user.setId(id);
+        user.setUsername("kunde");
+        user.setEmail("kunde@example.test");
+        user.setCartReminderEnabled(true);
+        user.setActive(true);
+        return user;
+    }
+
+    private static CartReminder reminder(User user) {
+        CartReminder reminder = new CartReminder();
+        reminder.setUser(user);
+        reminder.setLastModifiedAt(Instant.now().minusSeconds(90_000));
+        return reminder;
+    }
+
+    private static CartItem cartItem(User user, String productName, String price, int quantity, boolean purchasable) {
+        Product product = new Product();
+        product.setId(10L);
+        product.setName(productName);
+        product.setRecommendedRetailPrice(new BigDecimal(price));
+        product.setPurchasable(purchasable);
+
+        CartItem item = new CartItem();
+        item.setUser(user);
+        item.setProduct(product);
+        item.setQuantity(quantity);
+        return item;
+    }
+
+    private record TestContext(
+            CartReminderService service,
+            CartReminderRepository cartReminderRepository,
+            CartRepository cartRepository,
+            UserRepository userRepository,
+            EmailService emailService
+    ) {}
+}


### PR DESCRIPTION
# Pull Request

## 📝 Beschreibung

Kurze Zusammenfassung der Änderungen:

Diese PR implementiert US-329 „Automatische Warenkorb-Erinnerung“ im Backend. Das System speichert Warenkorb-Erinnerungszyklen, erkennt fällige nicht abgeschlossene Warenkörbe, versendet einmalige Erinnerungs-E-Mails und bietet eine Profil-Einstellung zum Aktivieren oder Deaktivieren der Erinnerungen.

## 🎯 Ticket

Resolves #325

## 📋 Änderungen
*Hake an, welche Änderungen erfolgt sind:*

- [x] Neue Features hinzugefügt
- [ ] Bugs behoben
- [ ] Code refaktoriert
- [ ] Code ist selbsterklärend mit Kommentaren
- [x] Tests geschrieben/aktualisiert
- [ ] Dokumentation aktualisiert

## 🔗 Related Issues

- Relates to #329