### PR TITLE
Resolves #119 skip-ollama-flag

### DIFF
--- a/README-Linux.md
+++ b/README-Linux.md
@@ -227,6 +227,8 @@ Das Backend ist dann erreichbar unter: `http://localhost:8080`
 > **Tests:** `./dev.sh test` führt die Tests in einem Maven-Container aus. Die Integrationstests (`*IntegrationTest`) starten via **Testcontainers** ein echtes PostgreSQL (`postgres:16-alpine`), gegen das Flyway die echten Migrationen ausführt — Docker muss laufen. Die Unit-Tests (Mockito) brauchen keine Datenbank. Beim ersten Lauf werden Abhängigkeiten in ein Cache-Volume geladen und das `postgres:16-alpine`-Image gezogen.
 >
 > **Last-/Ressourcentest:** `./dev.sh loadtest` baut eine frische DB, spielt Lastdaten ein und startet einen **k6**-Lasttest (beobachtbar in Grafana). Destruktiv (löscht die DB), fragt vorher nach. Details: [`docs/loadtest.md`](docs/loadtest.md).
+>
+> **Ohne Shoppi entwickeln (`--skip-ollama`):** Mit dem Flag an `start`, `restart`, `rebuild` oder `loadtest` wird der Ollama-Container **nicht gestartet** und das `ollama/ollama`-Image **nicht** heruntergeladen — spart Setup-Zeit und RAM. Shoppi liefert dann nur eine „nicht verfügbar"-Meldung; alle anderen Funktionen sind unbeeinflusst. Beispiel: `./dev.sh start --skip-ollama`.
 
 ### Schritt 3 — Ollama-Modell ziehen (einmalig, nur für Shoppi KI-Assistent)
 ```bash

--- a/README-Mac.md
+++ b/README-Mac.md
@@ -228,6 +228,8 @@ Das Backend ist dann erreichbar unter: `http://localhost:8080`
 > **Tests:** `./dev.sh test` führt die Tests in einem Maven-Container aus. Die Integrationstests (`*IntegrationTest`) starten via **Testcontainers** ein echtes PostgreSQL (`postgres:16-alpine`), gegen das Flyway die echten Migrationen ausführt — Docker muss laufen. Die Unit-Tests (Mockito) brauchen keine Datenbank. Beim ersten Lauf werden Abhängigkeiten in ein Cache-Volume geladen und das `postgres:16-alpine`-Image gezogen.
 >
 > **Last-/Ressourcentest:** `./dev.sh loadtest` baut eine frische DB, spielt Lastdaten ein und startet einen **k6**-Lasttest (beobachtbar in Grafana). Destruktiv (löscht die DB), fragt vorher nach. Details: [`docs/loadtest.md`](docs/loadtest.md).
+>
+> **Ohne Shoppi entwickeln (`--skip-ollama`):** Mit dem Flag an `start`, `restart`, `rebuild` oder `loadtest` wird der Ollama-Container **nicht gestartet** und das `ollama/ollama`-Image **nicht** heruntergeladen — spart Setup-Zeit und RAM. Shoppi liefert dann nur eine „nicht verfügbar"-Meldung; alle anderen Funktionen sind unbeeinflusst. Beispiel: `./dev.sh start --skip-ollama`.
 
 ### Schritt 4 — Ollama-Modell ziehen (einmalig, nur für Shoppi KI-Assistent)
 ```bash

--- a/README.md
+++ b/README.md
@@ -236,6 +236,12 @@ Das Backend ist dann erreichbar unter: `http://localhost:8080`
 
 **Last-/Ressourcentest:** `./dev.bat loadtest` baut eine frische DB, spielt eine realistische Lastdatenmenge ein und startet einen **k6**-Lasttest (beobachtbar in Grafana). Der Befehl ist **destruktiv** (löscht die DB) und fragt vorher nach. Details, Auswertung und ein optionales Bestell-Lastszenario: [`docs/loadtest.md`](docs/loadtest.md).
 
+**Ohne Shoppi entwickeln (`--skip-ollama`):** Mit dem Flag `--skip-ollama` an `start`, `restart`, `rebuild` oder `loadtest` wird der Ollama-Container **nicht gestartet** und das große `ollama/ollama`-Image **nicht** heruntergeladen — spart Setup-Zeit und RAM, wenn du gerade nicht an Shoppi/KI arbeitest. Shoppi liefert dann im Frontend nur eine „nicht verfügbar"-Meldung; alle anderen Funktionen sind unbeeinflusst.
+```bat
+./dev.bat start --skip-ollama
+./dev.bat loadtest --skip-ollama --yes
+```
+
 ### Schritt 3 — Ollama-Modell ziehen (einmalig, nur für Shoppi KI-Assistent)
 ```bash
 docker exec webshop-ollama ollama pull gemma4:e4b

--- a/deepdive.md
+++ b/deepdive.md
@@ -170,6 +170,7 @@ Das eigentliche Steuerungsskript. Alles läuft über Docker — kein Java lokal 
 | `dev restart` | Backend-Container stoppen + neu starten |
 | `dev rebuild` | `docker compose up --build --force-recreate` (kein Layer-Cache) |
 | `dev test` | Test-Suite in einem Maven-Container ausführen (optional mit `-Dtest`-Filter) |
+| `<command> --skip-ollama` | `start`/`restart`/`rebuild`/`loadtest` ohne Ollama-Container (Image wird nicht gezogen, Shoppi liefert „nicht verfügbar") |
 
 ---
 
@@ -1058,6 +1059,25 @@ Maven-Container den auf dem Host gemappten DB-Port erreicht, zeigt `TESTCONTAINE
 dev test                          # komplette Suite (Unit + Integration)
 dev test CartFlowIntegrationTest  # nur eine Klasse
 dev test '*IntegrationTest'       # nur die Integrationstests
+```
+
+### dev --skip-ollama
+
+Optionaler Flag für `start`, `restart`, `rebuild` und `loadtest`. Bewirkt zwei Dinge:
+
+1. **GPU-Erkennung und das GPU-Compose-Override werden übersprungen** (sind ohne Ollama irrelevant).
+2. **`docker compose up` bekommt die Services explizit aufgezählt** — ohne `ollama` in der Liste:
+   ```
+   docker compose up -d --build postgres backend prometheus blackbox-exporter grafana [mailpit]
+   ```
+   Da Compose nur die gelisteten Services anfasst, wird das `ollama/ollama`-Image **weder gezogen noch gebaut** und der Container nicht gestartet. Erspart auf dem ersten Lauf den ~2 GB Image-Pull (und den ~10 GB Modell-Download, der ohnehin manuell ist).
+
+Im Frontend antwortet Shoppi dann mit einer „nicht verfügbar"-Meldung — alle anderen Funktionen bleiben unberührt. Wer das große Image schon mal lokal gezogen hatte: `docker image rm ollama/ollama` räumt es händisch auf (kein Teil des Flags).
+
+```bash
+dev start --skip-ollama
+dev rebuild --skip-ollama
+dev loadtest --skip-ollama --yes
 ```
 
 ---

--- a/dev.ps1
+++ b/dev.ps1
@@ -19,15 +19,35 @@
 
 param(
     [string]$Command = "",
-    [switch]$KeepDb,
-    [string]$TestFilter = "",
-    [switch]$Yes
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$RemainingArguments
 )
 
 $Root = $PSScriptRoot
 $Port = 8080
 $HealthUrl = "http://localhost:$Port/api/health"
+
+# Flags are parsed manually here (mirrors dev.sh). PowerShell's parameter binder does
+# not reliably match kebab-case names like --skip-ollama against switch parameters,
+# so we capture everything via $RemainingArguments and dispatch explicitly. This also
+# guarantees that an unknown flag does not crash the script with "parameter not found".
+$KeepDb = $false
+$Yes = $false
+$SkipOllama = $false
+$TestFilter = ""
 $IncludeMailpit = $false   # set by 'loadtest' so outgoing mail is captured by Mailpit
+
+if ($RemainingArguments) {
+    foreach ($rawArgument in $RemainingArguments) {
+        switch ($rawArgument.ToString().ToLower()) {
+            "--keep-db"     { $KeepDb = $true }
+            "--yes"         { $Yes = $true }
+            "-y"            { $Yes = $true }
+            "--skip-ollama" { $SkipOllama = $true }
+            default         { $TestFilter = $rawArgument }
+        }
+    }
+}
 
 # --- helpers -----------------------------------------------------------------
 
@@ -53,22 +73,26 @@ function Get-GpuVendor {
 function Get-OllamaComposeFiles {
     param([string]$RootPath)
 
-    $gpuVendor = Get-GpuVendor
     $composeFiles = @("`"$RootPath\docker-compose.yml`"")
 
-    switch ($gpuVendor) {
-        "nvidia" {
-            Write-Host "GPU detected: NVIDIA - enabling GPU acceleration for Ollama."
-            $composeFiles += "`"$RootPath\docker-compose.gpu-nvidia.yml`""
-        }
-        "amd" {
-            Write-Host "GPU detected: AMD - GPU acceleration requires ROCm (Linux only). Running Ollama on CPU."
-        }
-        "intel" {
-            Write-Host "GPU detected: Intel - GPU acceleration for Ollama in Docker is not supported on Windows. Running on CPU."
-        }
-        default {
-            Write-Host "No dedicated GPU detected - Ollama will run on CPU."
+    if ($script:SkipOllama) {
+        Write-Host "Ollama is skipped (--skip-ollama) - GPU detection and override disabled."
+    } else {
+        $gpuVendor = Get-GpuVendor
+        switch ($gpuVendor) {
+            "nvidia" {
+                Write-Host "GPU detected: NVIDIA - enabling GPU acceleration for Ollama."
+                $composeFiles += "`"$RootPath\docker-compose.gpu-nvidia.yml`""
+            }
+            "amd" {
+                Write-Host "GPU detected: AMD - GPU acceleration requires ROCm (Linux only). Running Ollama on CPU."
+            }
+            "intel" {
+                Write-Host "GPU detected: Intel - GPU acceleration for Ollama in Docker is not supported on Windows. Running on CPU."
+            }
+            default {
+                Write-Host "No dedicated GPU detected - Ollama will run on CPU."
+            }
         }
     }
 
@@ -78,6 +102,17 @@ function Get-OllamaComposeFiles {
     }
 
     return ($composeFiles -join " -f ")
+}
+
+# Returns the space-separated list of services that should be passed to
+# `docker compose up` when --skip-ollama is set, so that Compose neither pulls
+# nor starts the ollama service (and therefore does not download its image).
+function Get-NonOllamaServiceList {
+    $services = @("postgres", "backend", "prometheus", "blackbox-exporter", "grafana")
+    if ($script:IncludeMailpit) {
+        $services += "mailpit"
+    }
+    return ($services -join " ")
 }
 
 function Test-DockerRunning {
@@ -106,8 +141,10 @@ function Show-Usage {
     Write-Host "           DESTRUCTIVE: deletes the database. Asks for confirmation (skip with --yes)"
     Write-Host ""
     Write-Host "Options:"
-    Write-Host "  --keep-db   Keep PostgreSQL data (combine with stop/restart/rebuild)"
-    Write-Host "  --yes       Skip the loadtest confirmation prompt"
+    Write-Host "  --keep-db      Keep PostgreSQL data (combine with stop/restart/rebuild)"
+    Write-Host "  --yes          Skip the loadtest confirmation prompt"
+    Write-Host "  --skip-ollama  Do not start (or pull) the Ollama container - Shoppi will be unavailable"
+    Write-Host "                 Works with start/restart/rebuild/loadtest"
     Write-Host ""
 }
 
@@ -206,10 +243,16 @@ function Show-SeedHint {
     Write-Host "  Linux / macOS (bash):"
     Write-Host "    docker exec -i webshop-postgres psql -U webshop -d webshop < src/main/resources/db/dev-seed.sql"
     Write-Host ""
-    Write-Host "--- Shoppi KI-Assistent (Ollama model, run once) ---"
-    Write-Host "  docker exec webshop-ollama ollama pull gemma4:e4b"
-    Write-Host "  (This downloads ~10 GB on first run. The model is cached in the ollama_data volume.)"
-    Write-Host ""
+    if (-not $script:SkipOllama) {
+        Write-Host "--- Shoppi KI-Assistent (Ollama model, run once) ---"
+        Write-Host "  docker exec webshop-ollama ollama pull gemma4:e4b"
+        Write-Host "  (This downloads ~10 GB on first run. The model is cached in the ollama_data volume.)"
+        Write-Host ""
+    } else {
+        Write-Host "--- Shoppi KI-Assistent ---"
+        Write-Host "  Skipped (--skip-ollama). Shoppi answers with an 'unavailable' message."
+        Write-Host ""
+    }
     Write-Host "--- Monitoring & Alerting ---"
     Write-Host "  Grafana:    http://localhost:3001  (admin / admin)"
     Write-Host "  Dashboards: JVM Overview, HTTP Requests, Spring Boot Overview"
@@ -252,6 +295,10 @@ function Start-Backend {
 
     if ($KeepDb) {
         Invoke-Expression "docker compose -f $composeFiles up -d --build backend"
+    } elseif ($SkipOllama) {
+        $services = Get-NonOllamaServiceList
+        Write-Host "Starting services without ollama (--skip-ollama): $services"
+        Invoke-Expression "docker compose -f $composeFiles up -d --build $services"
     } else {
         Invoke-Expression "docker compose -f $composeFiles up -d --build"
     }
@@ -298,7 +345,13 @@ function Rebuild-Backend {
             Write-Host "ERROR: docker compose build failed."
             return
         }
-        Invoke-Expression "docker compose -f $composeFiles up -d --force-recreate"
+        if ($SkipOllama) {
+            $services = Get-NonOllamaServiceList
+            Write-Host "Starting services without ollama (--skip-ollama): $services"
+            Invoke-Expression "docker compose -f $composeFiles up -d --force-recreate $services"
+        } else {
+            Invoke-Expression "docker compose -f $composeFiles up -d --force-recreate"
+        }
     }
 
     if ($LASTEXITCODE -ne 0) {

--- a/dev.sh
+++ b/dev.sh
@@ -27,6 +27,7 @@ HEALTH_URL="http://localhost:$PORT/api/health"
 COMMAND="${1:-}"
 KEEP_DB=false
 ASSUME_YES=false
+SKIP_OLLAMA=false
 TEST_FILTER=""
 INCLUDE_MAILPIT=false   # set by 'loadtest' so outgoing mail is captured by Mailpit
 COMPOSE_FILES=()
@@ -36,9 +37,10 @@ COMPOSE_FILES=()
 [[ $# -gt 0 ]] && shift
 for arg in "$@"; do
     case "$arg" in
-        --keep-db) KEEP_DB=true ;;
-        --yes|-y)  ASSUME_YES=true ;;
-        *)         TEST_FILTER="$arg" ;;
+        --keep-db)     KEEP_DB=true ;;
+        --yes|-y)      ASSUME_YES=true ;;
+        --skip-ollama) SKIP_OLLAMA=true ;;
+        *)             TEST_FILTER="$arg" ;;
     esac
 done
 
@@ -77,30 +79,45 @@ get_gpu_vendor() {
 
 setup_compose_files() {
     COMPOSE_FILES=("-f" "$ROOT/docker-compose.yml")
-    local gpu_vendor
-    gpu_vendor="$(get_gpu_vendor)"
 
-    case "$gpu_vendor" in
-        nvidia)
-            echo "GPU detected: NVIDIA - enabling GPU acceleration for Ollama."
-            COMPOSE_FILES+=("-f" "$ROOT/docker-compose.gpu-nvidia.yml")
-            ;;
-        amd)
-            echo "GPU detected: AMD - enabling GPU acceleration for Ollama (ROCm)."
-            COMPOSE_FILES+=("-f" "$ROOT/docker-compose.gpu-amd.yml")
-            ;;
-        macos)
-            echo "macOS: GPU passthrough is not supported in Docker. Ollama will run on CPU."
-            ;;
-        *)
-            echo "No dedicated GPU detected - Ollama will run on CPU."
-            ;;
-    esac
+    if [[ "$SKIP_OLLAMA" == "true" ]]; then
+        echo "Ollama is skipped (--skip-ollama) - GPU detection and override disabled."
+    else
+        local gpu_vendor
+        gpu_vendor="$(get_gpu_vendor)"
+        case "$gpu_vendor" in
+            nvidia)
+                echo "GPU detected: NVIDIA - enabling GPU acceleration for Ollama."
+                COMPOSE_FILES+=("-f" "$ROOT/docker-compose.gpu-nvidia.yml")
+                ;;
+            amd)
+                echo "GPU detected: AMD - enabling GPU acceleration for Ollama (ROCm)."
+                COMPOSE_FILES+=("-f" "$ROOT/docker-compose.gpu-amd.yml")
+                ;;
+            macos)
+                echo "macOS: GPU passthrough is not supported in Docker. Ollama will run on CPU."
+                ;;
+            *)
+                echo "No dedicated GPU detected - Ollama will run on CPU."
+                ;;
+        esac
+    fi
 
     if [[ "$INCLUDE_MAILPIT" == "true" ]]; then
         echo "Mailpit override enabled - outgoing mail is captured locally (no real SMTP)."
         COMPOSE_FILES+=("-f" "$ROOT/docker-compose.mailpit.yml")
     fi
+}
+
+# Echoes the space-separated list of services to pass to `docker compose up`
+# when --skip-ollama is set, so that Compose neither pulls nor starts the
+# ollama service (and therefore does not download its image).
+non_ollama_service_list() {
+    local services="postgres backend prometheus blackbox-exporter grafana"
+    if [[ "$INCLUDE_MAILPIT" == "true" ]]; then
+        services="$services mailpit"
+    fi
+    echo "$services"
 }
 
 test_docker_running() {
@@ -203,9 +220,14 @@ show_seed_hint() {
     echo "  docker exec -i webshop-postgres psql -U webshop -d webshop \\"
     echo "    < src/main/resources/db/dev-seed.sql"
     echo ""
-    echo "--- Shoppi KI-Assistent (Ollama model, run once) ---"
-    echo "  docker exec webshop-ollama ollama pull gemma4:e4b"
-    echo "  (This downloads ~10 GB on first run. Model is cached in the ollama_data volume.)"
+    if [[ "$SKIP_OLLAMA" == "true" ]]; then
+        echo "--- Shoppi KI-Assistent ---"
+        echo "  Skipped (--skip-ollama). Shoppi answers with an 'unavailable' message."
+    else
+        echo "--- Shoppi KI-Assistent (Ollama model, run once) ---"
+        echo "  docker exec webshop-ollama ollama pull gemma4:e4b"
+        echo "  (This downloads ~10 GB on first run. Model is cached in the ollama_data volume.)"
+    fi
     echo ""
     echo "--- Monitoring & Alerting ---"
     echo "  Grafana:    http://localhost:3001  (admin / admin)"
@@ -231,8 +253,10 @@ show_usage() {
     echo "           DESTRUCTIVE: deletes the database. Asks for confirmation (skip with --yes)"
     echo ""
     echo "Options:"
-    echo "  --keep-db   Keep PostgreSQL running (combine with stop/restart/rebuild)"
-    echo "  --yes       Skip the loadtest confirmation prompt"
+    echo "  --keep-db      Keep PostgreSQL running (combine with stop/restart/rebuild)"
+    echo "  --yes          Skip the loadtest confirmation prompt"
+    echo "  --skip-ollama  Do not start (or pull) the Ollama container - Shoppi will be unavailable"
+    echo "                 Works with start/restart/rebuild/loadtest"
     echo ""
 }
 
@@ -297,6 +321,12 @@ start_backend() {
 
     if [[ "$KEEP_DB" == "true" ]]; then
         docker compose "${COMPOSE_FILES[@]}" up -d --build backend
+    elif [[ "$SKIP_OLLAMA" == "true" ]]; then
+        local services
+        services="$(non_ollama_service_list)"
+        echo "Starting services without ollama (--skip-ollama): $services"
+        # shellcheck disable=SC2086
+        docker compose "${COMPOSE_FILES[@]}" up -d --build $services
     else
         docker compose "${COMPOSE_FILES[@]}" up -d --build
     fi
@@ -334,7 +364,15 @@ rebuild_backend() {
             echo "Removing PostgreSQL volume ($postgres_volume) for a clean database..."
             docker volume rm "$postgres_volume"
         fi
-        docker compose "${COMPOSE_FILES[@]}" up -d --build --force-recreate
+        if [[ "$SKIP_OLLAMA" == "true" ]]; then
+            local services
+            services="$(non_ollama_service_list)"
+            echo "Starting services without ollama (--skip-ollama): $services"
+            # shellcheck disable=SC2086
+            docker compose "${COMPOSE_FILES[@]}" up -d --build --force-recreate $services
+        else
+            docker compose "${COMPOSE_FILES[@]}" up -d --build --force-recreate
+        fi
     fi
 
     if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
# Pull Request

## 📝 Beschreibung

Ergänzt einen `--skip-ollama`-Flag im Dev-Script (Win + Linux/Mac), mit dem der Ollama-Container beim `start`/`restart`/`rebuild`/`loadtest` **nicht gestartet wird** und das `ollama/ollama`-Image **nicht gezogen** wird. Spart auf dem ersten Lauf den ~2-GB-Image-Pull (+ ~10 GB Modell-Download, der ohnehin manuell ist). Das Frontend ist unempfindlich: Shoppi liefert dann eine "nicht verfügbar"-Meldung, alle anderen Funktionen sind unbeeinflusst.

**Mechanik:**
- `dev.ps1` / `dev.sh` lesen den Flag aus den Argumenten.
- `Get-OllamaComposeFiles` / `setup_compose_files` überspringen die GPU-Erkennung und das GPU-Compose-Override.
- `docker compose up` bekommt die Services **explizit** aufgezählt (ohne `ollama`) → Compose pullt das ollama-Image nicht und startet keinen Container.
- `Show-SeedHint` blendet den Ollama-Pull-Hinweis aus.

**Bonus / Bugfix unterwegs:** `dev.ps1` parst die Flags jetzt manuell aus `$RemainingArguments` (statt sich auf PowerShells Param-Binding für kebab-case zu verlassen). Damit funktionieren `--keep-db`, `--yes` und `--skip-ollama` deterministisch — die alte Binding-Logik war für kebab-case unzuverlässig.

Manuell getestet:
- `dev.bat start --skip-ollama` → kein ollama, kein Image-Pull, GPU-Detection übersprungen, Seed-Hint zeigt "Skipped" ✓
- `dev.bat start` (default) → Ollama startet wie bisher ✓
- `dev.bat rebuild --skip-ollama` → DB-Volume gelöscht + ollama übersprungen ✓
- `dev.bat stop` → räumt sauber ab (orphan-Removal greift) ✓

## 🎯 Ticket

Resolves #119 skip-ollama-flag

## 📋 Änderungen
*Hake an, welche Änderungen erfolgt sind:*

- [x] Neue Features hinzugefügt
- [x] Bugs behoben
- [x] Code refaktoriert
- [x] Code ist selbsterklärend mit Kommentaren
- [ ] Tests geschrieben/aktualisiert
- [x] Dokumentation aktualisiert

## 🔗 Related Issues

- Part of SEPBFWS124A/Webshop#339 (Frontend-Tracking-Issue für diese reine Backend-Änderung)

---

**Wichtig:** Dieser PR wird automatisch den Ticket schließen, wenn er gemergt wird (via "Resolves #...").
Dieser PR geht gegen `main` (das Backend-Repo nutzt kein `develop`).
