### PR TITLE
Resolves #138 wareneingang-lagerbestand-lagerauswahl

### DIFF
--- a/src/main/java/de/fhdw/webshop/purchaseorder/PurchaseOrder.java
+++ b/src/main/java/de/fhdw/webshop/purchaseorder/PurchaseOrder.java
@@ -2,6 +2,7 @@ package de.fhdw.webshop.purchaseorder;
 
 import de.fhdw.webshop.product.Product;
 import de.fhdw.webshop.user.User;
+import de.fhdw.webshop.warehouse.WarehouseLocation;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -46,4 +47,9 @@ public class PurchaseOrder {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ordered_by_user_id")
     private User orderedByUser;
+
+    /** #138/#139 — Target warehouse where goods will be received. */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "warehouse_location_id")
+    private WarehouseLocation warehouseLocation;
 }

--- a/src/main/java/de/fhdw/webshop/purchaseorder/PurchaseOrderService.java
+++ b/src/main/java/de/fhdw/webshop/purchaseorder/PurchaseOrderService.java
@@ -8,6 +8,10 @@ import de.fhdw.webshop.purchaseorder.dto.CreatePurchaseOrderRequest;
 import de.fhdw.webshop.purchaseorder.dto.PurchaseOrderResponse;
 import de.fhdw.webshop.stockforecast.SoldQuantityRepository;
 import de.fhdw.webshop.user.User;
+import de.fhdw.webshop.warehouse.WarehouseLocation;
+import de.fhdw.webshop.warehouse.WarehouseLocationRepository;
+import de.fhdw.webshop.warehouse.WarehouseProductStock;
+import de.fhdw.webshop.warehouse.WarehouseProductStockRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,6 +34,8 @@ public class PurchaseOrderService {
     private final ProductRepository productRepository;
     private final SoldQuantityRepository soldQuantityRepository;
     private final OllamaClient ollamaClient;
+    private final WarehouseLocationRepository warehouseLocationRepository;
+    private final WarehouseProductStockRepository warehouseProductStockRepository;
 
     @Transactional(readOnly = true)
     public List<PurchaseOrderResponse> listAll() {
@@ -45,6 +51,12 @@ public class PurchaseOrderService {
 
         int aiSuggestedQuantity = suggestQuantity(product);
 
+        WarehouseLocation warehouse = null;
+        if (request.warehouseLocationId() != null) {
+            warehouse = warehouseLocationRepository.findById(request.warehouseLocationId())
+                    .orElse(null);
+        }
+
         PurchaseOrder purchaseOrder = new PurchaseOrder();
         purchaseOrder.setProduct(product);
         purchaseOrder.setQuantity(request.quantity());
@@ -55,10 +67,16 @@ public class PurchaseOrderService {
         );
         purchaseOrder.setAiSuggestedQuantity(aiSuggestedQuantity);
         purchaseOrder.setOrderedByUser(actingUser);
+        purchaseOrder.setWarehouseLocation(warehouse);
 
         return toResponse(purchaseOrderRepository.save(purchaseOrder));
     }
 
+    /**
+     * #138 — Confirm goods receipt.
+     * Updates both the global product.stock and the warehouse-specific
+     * warehouse_product_stocks entry so the AdminInventoryPage reflects the change.
+     */
     @Transactional
     public PurchaseOrderResponse confirmReceipt(Long purchaseOrderId, User actingUser) {
         PurchaseOrder purchaseOrder = purchaseOrderRepository.findById(purchaseOrderId)
@@ -68,9 +86,37 @@ public class PurchaseOrderService {
             throw new IllegalStateException("Wareneingang wurde bereits bestätigt.");
         }
 
-        Product product = purchaseOrder.getProduct();
-        product.setStock(product.getStock() + purchaseOrder.getQuantity());
+        int qty = purchaseOrder.getQuantity();
+        Product product = productRepository.findById(purchaseOrder.getProduct().getId())
+                .orElseThrow(() -> new EntityNotFoundException("Product not found"));
+
+        // 1. Update global stock on the product
+        product.setStock(product.getStock() + qty);
         productRepository.save(product);
+
+        // 2. Update warehouse-specific stock so AdminInventoryPage reflects the change
+        WarehouseLocation warehouse = purchaseOrder.getWarehouseLocation();
+        if (warehouse == null) {
+            // Fallback: use the first available warehouse location
+            warehouse = warehouseLocationRepository.findAll().stream().findFirst().orElse(null);
+        }
+        if (warehouse != null) {
+            final WarehouseLocation wh = warehouse;
+            WarehouseProductStock stock = warehouseProductStockRepository
+                    .findByProductIdAndWarehouseLocationId(product.getId(), wh.getId())
+                    .orElseGet(() -> {
+                        WarehouseProductStock newStock = new WarehouseProductStock();
+                        newStock.setProduct(product);
+                        newStock.setWarehouseLocation(wh);
+                        newStock.setQuantity(0);
+                        return newStock;
+                    });
+            stock.setQuantity(stock.getQuantity() + qty);
+            warehouseProductStockRepository.save(stock);
+            log.info("Received {} units of product {} into warehouse {}", qty, product.getId(), wh.getId());
+        } else {
+            log.warn("No warehouse location available for purchase order {}; only global stock updated", purchaseOrderId);
+        }
 
         purchaseOrder.setStatus(PurchaseOrderStatus.RECEIVED);
         purchaseOrder.setReceivedAt(Instant.now());
@@ -121,6 +167,7 @@ public class PurchaseOrderService {
     }
 
     private PurchaseOrderResponse toResponse(PurchaseOrder po) {
+        WarehouseLocation wh = po.getWarehouseLocation();
         return new PurchaseOrderResponse(
                 po.getId(),
                 po.getProduct().getId(),
@@ -131,7 +178,9 @@ public class PurchaseOrderService {
                 po.getStatus(),
                 po.getAiSuggestedQuantity(),
                 po.getOrderedAt(),
-                po.getReceivedAt()
+                po.getReceivedAt(),
+                wh != null ? wh.getId() : null,
+                wh != null ? wh.getName() : null
         );
     }
 }

--- a/src/main/java/de/fhdw/webshop/purchaseorder/dto/CreatePurchaseOrderRequest.java
+++ b/src/main/java/de/fhdw/webshop/purchaseorder/dto/CreatePurchaseOrderRequest.java
@@ -6,5 +6,6 @@ import jakarta.validation.constraints.NotNull;
 public record CreatePurchaseOrderRequest(
         @NotNull Long productId,
         @NotNull @Min(1) Integer quantity,
-        String supplierName
+        String supplierName,
+        Long warehouseLocationId
 ) {}

--- a/src/main/java/de/fhdw/webshop/purchaseorder/dto/PurchaseOrderResponse.java
+++ b/src/main/java/de/fhdw/webshop/purchaseorder/dto/PurchaseOrderResponse.java
@@ -14,5 +14,7 @@ public record PurchaseOrderResponse(
         PurchaseOrderStatus status,
         Integer aiSuggestedQuantity,
         Instant orderedAt,
-        Instant receivedAt
+        Instant receivedAt,
+        Long warehouseLocationId,
+        String warehouseLocationName
 ) {}

--- a/src/main/resources/db/migration/V99__add_warehouse_to_purchase_orders.sql
+++ b/src/main/resources/db/migration/V99__add_warehouse_to_purchase_orders.sql
@@ -1,0 +1,6 @@
+-- #138 Add target warehouse location to purchase orders
+ALTER TABLE purchase_orders
+    ADD COLUMN IF NOT EXISTS warehouse_location_id BIGINT
+        REFERENCES warehouse_locations(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_purchase_orders_warehouse ON purchase_orders(warehouse_location_id);


### PR DESCRIPTION
## Summary

- **#138 Bugfix**: `confirmReceipt` hat bisher nur `product.stock` aktualisiert, aber nicht die `warehouse_product_stocks`-Tabelle — die Quelle der `AdminInventoryPage`. Der Wareneingang ist deshalb im Lagerbestand nie erschienen. Fix: nach Bestätigung wird der Eintrag in `warehouse_product_stocks` für das gewählte Lager erhöht (Fallback auf erstes verfügbares Lager wenn keins angegeben).
- **#139 Feature**: Neues Feld `warehouseLocationId` an `PurchaseOrder`. Beim Anlegen einer Nachbestellung kann das Ziel-Lager mitgegeben werden. `PurchaseOrderResponse` gibt jetzt `warehouseLocationId` und `warehouseLocationName` zurück.
- **DB-Migration V99**: `warehouse_location_id` (nullable FK) an `purchase_orders`

## Neue Endpunkte / Änderungen

| Endpunkt | Änderung |
|---|---|
| `POST /api/purchase-orders` | Akzeptiert optional `warehouseLocationId` |
| `PUT /api/purchase-orders/{id}/receive` | Aktualisiert jetzt korrekt `warehouse_product_stocks` |

## Test plan
- [ ] Backend starten (`./dev.bat restart`) — Flyway führt V99 aus
- [ ] Nachbestellung mit Lager anlegen: `POST /api/purchase-orders` mit `warehouseLocationId`
- [ ] Wareneingang bestätigen: `PUT /{id}/receive`
- [ ] In `AdminInventoryPage` prüfen ob Bestand für das gewählte Lager korrekt erhöht ist

🤖 Generated with [Claude Code](https://claude.com/claude-code)
