### PR TITLE
fix(backend): fix 500 errors in admin marketplace review endpoints

### DIFF
--- a/src/main/java/de/fhdw/webshop/admin/marketplace/AdminMarketplaceReviewController.java
+++ b/src/main/java/de/fhdw/webshop/admin/marketplace/AdminMarketplaceReviewController.java
@@ -42,8 +42,17 @@ public class AdminMarketplaceReviewController {
 
         Pageable pageable = PageRequest.of(page, size);
         String searchParam = (search != null && !search.isBlank()) ? search.trim() : null;
-        return productFeedbackRepository.findAllForAdmin(approved, searchParam, pageable)
-                .map(this::toProductReviewDto);
+        Page<ProductFeedback> resultPage;
+        if (approved == null && searchParam == null) {
+            resultPage = productFeedbackRepository.findAllByOrderByCreatedAtDesc(pageable);
+        } else if (approved != null && searchParam == null) {
+            resultPage = productFeedbackRepository.findByApprovedOrderByCreatedAtDesc(approved, pageable);
+        } else if (approved == null) {
+            resultPage = productFeedbackRepository.findBySearchTermOrderByCreatedAtDesc(searchParam, pageable);
+        } else {
+            resultPage = productFeedbackRepository.findByApprovedAndSearchTerm(approved, searchParam, pageable);
+        }
+        return resultPage.map(this::toProductReviewDto);
     }
 
     @PutMapping("/product-reviews/{id}/approve")
@@ -74,8 +83,17 @@ public class AdminMarketplaceReviewController {
 
         Pageable pageable = PageRequest.of(page, size);
         String searchParam = (search != null && !search.isBlank()) ? search.trim() : null;
-        return sellerReviewRepository.findAllForAdmin(approved, searchParam, pageable)
-                .map(this::toSellerReviewDto);
+        Page<SellerReview> resultPage;
+        if (approved == null && searchParam == null) {
+            resultPage = sellerReviewRepository.findAllByOrderByCreatedAtDesc(pageable);
+        } else if (approved != null && searchParam == null) {
+            resultPage = sellerReviewRepository.findByApprovedOrderByCreatedAtDesc(approved, pageable);
+        } else if (approved == null) {
+            resultPage = sellerReviewRepository.findBySearchTermOrderByCreatedAtDesc(searchParam, pageable);
+        } else {
+            resultPage = sellerReviewRepository.findByApprovedAndSearchTerm(approved, searchParam, pageable);
+        }
+        return resultPage.map(this::toSellerReviewDto);
     }
 
     @PutMapping("/seller-reviews/{id}/approve")

--- a/src/main/java/de/fhdw/webshop/marketplace/MarketplaceService.java
+++ b/src/main/java/de/fhdw/webshop/marketplace/MarketplaceService.java
@@ -42,7 +42,7 @@ public class MarketplaceService {
         return sellerProfileRepository.findAllByActiveTrueOrderByDisplayNameAsc()
                 .stream()
                 .map(profile -> {
-                    List<SellerReview> reviews = sellerReviewRepository.findBySellerNameIgnoreCaseOrderByCreatedAtDesc(profile.getDisplayName());
+                    List<SellerReview> reviews = sellerReviewRepository.findBySellerNameIgnoreCaseAndApprovedTrueOrderByCreatedAtDesc(profile.getDisplayName());
                     double avg = reviews.stream().mapToInt(SellerReview::getRating).average().orElse(0.0);
                     double avgProduct = productFeedbackValidationService.getAverageRatingBySeller(profile.getDisplayName());
                     return new MarketplaceSellerDto(profile.getDisplayName(), profile.getDisplayName(), avg, reviews.size(), avgProduct);
@@ -60,7 +60,7 @@ public class MarketplaceService {
                 .map(this::toProductDto)
                 .toList();
 
-        List<SellerReview> reviews = sellerReviewRepository.findBySellerNameIgnoreCaseOrderByCreatedAtDesc(sellerName);
+        List<SellerReview> reviews = sellerReviewRepository.findBySellerNameIgnoreCaseAndApprovedTrueOrderByCreatedAtDesc(sellerName);
         OptionalDouble avg = reviews.stream().mapToInt(SellerReview::getRating).average();
 
         List<MarketplaceReviewDto> recentReviews = reviews.stream()

--- a/src/main/java/de/fhdw/webshop/product/ProductFeedbackRepository.java
+++ b/src/main/java/de/fhdw/webshop/product/ProductFeedbackRepository.java
@@ -16,17 +16,15 @@ public interface ProductFeedbackRepository extends JpaRepository<ProductFeedback
 
     List<ProductFeedback> findByProductIdAndApprovedTrueOrderByCreatedAtDesc(Long productId);
 
-    @Query("""
-            SELECT f FROM ProductFeedback f
-            WHERE (:approvedFilter IS NULL OR f.approved = :approvedFilter)
-            AND (:search IS NULL OR LOWER(f.comment) LIKE LOWER(CONCAT('%', :search, '%')))
-            ORDER BY f.createdAt DESC
-            """)
-    Page<ProductFeedback> findAllForAdmin(
-            @Param("approvedFilter") Boolean approvedFilter,
-            @Param("search") String search,
-            Pageable pageable
-    );
+    Page<ProductFeedback> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+    Page<ProductFeedback> findByApprovedOrderByCreatedAtDesc(Boolean approved, Pageable pageable);
+
+    @Query("SELECT f FROM ProductFeedback f WHERE LOWER(f.comment) LIKE LOWER(CONCAT('%', :search, '%')) ORDER BY f.createdAt DESC")
+    Page<ProductFeedback> findBySearchTermOrderByCreatedAtDesc(@Param("search") String search, Pageable pageable);
+
+    @Query("SELECT f FROM ProductFeedback f WHERE f.approved = :approved AND LOWER(f.comment) LIKE LOWER(CONCAT('%', :search, '%')) ORDER BY f.createdAt DESC")
+    Page<ProductFeedback> findByApprovedAndSearchTerm(@Param("approved") Boolean approved, @Param("search") String search, Pageable pageable);
 
     boolean existsByProductIdAndUserId(Long productId, Long userId);
 

--- a/src/main/java/de/fhdw/webshop/sellerreview/SellerReviewRepository.java
+++ b/src/main/java/de/fhdw/webshop/sellerreview/SellerReviewRepository.java
@@ -20,18 +20,26 @@ public interface SellerReviewRepository extends JpaRepository<SellerReview, Long
 
     List<SellerReview> findBySellerNameIgnoreCaseAndApprovedTrueOrderByCreatedAtDesc(String sellerName);
 
+    Page<SellerReview> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+    Page<SellerReview> findByApprovedOrderByCreatedAtDesc(Boolean approved, Pageable pageable);
+
     @Query("""
-            SELECT r FROM SellerReview r
-            WHERE (:approvedFilter IS NULL OR r.approved = :approvedFilter)
-            AND (:search IS NULL OR
-                LOWER(r.comment) LIKE LOWER(CONCAT('%', :search, '%'))
-                OR LOWER(r.sellerName) LIKE LOWER(CONCAT('%', :search, '%'))
-                OR LOWER(r.customer.username) LIKE LOWER(CONCAT('%', :search, '%')))
+            SELECT r FROM SellerReview r JOIN r.customer c
+            WHERE LOWER(r.comment) LIKE LOWER(CONCAT('%', :search, '%'))
+               OR LOWER(r.sellerName) LIKE LOWER(CONCAT('%', :search, '%'))
+               OR LOWER(c.username) LIKE LOWER(CONCAT('%', :search, '%'))
             ORDER BY r.createdAt DESC
             """)
-    Page<SellerReview> findAllForAdmin(
-            @Param("approvedFilter") Boolean approvedFilter,
-            @Param("search") String search,
-            Pageable pageable
-    );
+    Page<SellerReview> findBySearchTermOrderByCreatedAtDesc(@Param("search") String search, Pageable pageable);
+
+    @Query("""
+            SELECT r FROM SellerReview r JOIN r.customer c
+            WHERE r.approved = :approved
+            AND (LOWER(r.comment) LIKE LOWER(CONCAT('%', :search, '%'))
+               OR LOWER(r.sellerName) LIKE LOWER(CONCAT('%', :search, '%'))
+               OR LOWER(c.username) LIKE LOWER(CONCAT('%', :search, '%')))
+            ORDER BY r.createdAt DESC
+            """)
+    Page<SellerReview> findByApprovedAndSearchTerm(@Param("approved") Boolean approved, @Param("search") String search, Pageable pageable);
 }


### PR DESCRIPTION
Replace nullable JPQL parameter pattern (:param IS NULL OR ...) with Java-level dispatch to specific repository methods, as Hibernate 6 cannot reliably type-bind null Boolean parameters in JPQL. Also fix MarketplaceService to use the approved-only query so that unapproved reviews are no longer exposed on the public seller profile page.