### PR TITLE
Resolves #133 webshop-plus-premium-abonnement

### DIFF
--- a/src/main/java/de/fhdw/webshop/messaging/SubscriptionRenewedEvent.java
+++ b/src/main/java/de/fhdw/webshop/messaging/SubscriptionRenewedEvent.java
@@ -1,0 +1,12 @@
+package de.fhdw.webshop.messaging;
+
+import java.time.Instant;
+
+/**
+ * #136 — Published to RabbitMQ when a Webshop Plus subscription is successfully renewed.
+ */
+public record SubscriptionRenewedEvent(
+        Long subscriptionId,
+        Long userId,
+        Instant nextPeriodEnd
+) {}

--- a/src/main/java/de/fhdw/webshop/order/OrderService.java
+++ b/src/main/java/de/fhdw/webshop/order/OrderService.java
@@ -32,6 +32,7 @@ import de.fhdw.webshop.product.ProductType;
 import de.fhdw.webshop.messaging.OrderCreatedEvent;
 import de.fhdw.webshop.messaging.OrderEventPublisher;
 import de.fhdw.webshop.productbundle.ProductBundleService;
+import de.fhdw.webshop.subscription.SubscriptionService;
 import de.fhdw.webshop.reservation.StockReservationService;
 import de.fhdw.webshop.user.DeliveryAddress;
 import de.fhdw.webshop.user.DeliveryAddressRepository;
@@ -118,6 +119,7 @@ public class OrderService {
     private final ProductBundleService productBundleService;
     private final AffiliateService affiliateService;
     private final OrderEventPublisher orderEventPublisher;
+    private final SubscriptionService subscriptionService;
 
     @Value("${app.frontend.base-url:http://localhost:5173}")
     private String frontendBaseUrl;
@@ -555,7 +557,10 @@ public class OrderService {
                 ? calculateCheckoutDiscount(itemSubtotal, checkoutDiscount)
                 : volumeDiscount.amount();
         BigDecimal subtotal = itemSubtotal.subtract(discountAmount).max(BigDecimal.ZERO).setScale(2, RoundingMode.HALF_UP);
-        BigDecimal shippingCost = pickupStore != null
+        // #135 — Webshop Plus subscribers get free shipping on every order
+        boolean plusMember = customer != null
+                && subscriptionService.hasActivePlusSubscription(customer.getId());
+        BigDecimal shippingCost = (pickupStore != null || plusMember)
                 ? BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
                 : calculateShippingCost(subtotal, shippingMethod);
         BigDecimal taxAmount = subtotal.multiply(TAX_RATE).setScale(2, RoundingMode.HALF_UP);
@@ -586,7 +591,8 @@ public class OrderService {
                 carbonCompensationSelected,
                 totalPrice,
                 approvalRequired,
-                approvalRequired ? approvalBudgetLimit : null
+                approvalRequired ? approvalBudgetLimit : null,
+                plusMember
         );
     }
 
@@ -1310,6 +1316,7 @@ public class OrderService {
                 preparedOrder.climateContributionAmount(),
                 preparedOrder.totalCo2EmissionKg(),
                 preparedOrder.totalPrice(),
+                preparedOrder.plusMember(),
                 preparedOrder.order().getCouponCode(),
                 preparedOrder.approvalRequired(),
                 preparedOrder.approvalBudgetLimit(),
@@ -1634,7 +1641,8 @@ public class OrderService {
             boolean carbonCompensationSelected,
             BigDecimal totalPrice,
             boolean approvalRequired,
-            BigDecimal approvalBudgetLimit
+            BigDecimal approvalBudgetLimit,
+            boolean plusMember
     ) {}
 
     private record CheckoutDiscount(

--- a/src/main/java/de/fhdw/webshop/order/dto/OrderPreviewResponse.java
+++ b/src/main/java/de/fhdw/webshop/order/dto/OrderPreviewResponse.java
@@ -13,6 +13,7 @@ public record OrderPreviewResponse(
         BigDecimal climateContributionAmount,
         BigDecimal totalCo2EmissionKg,
         BigDecimal totalPrice,
+        boolean plusMember,
         String couponCode,
         Boolean approvalRequired,
         BigDecimal approvalBudgetLimit,

--- a/src/main/java/de/fhdw/webshop/subscription/Subscription.java
+++ b/src/main/java/de/fhdw/webshop/subscription/Subscription.java
@@ -1,0 +1,49 @@
+package de.fhdw.webshop.subscription;
+
+import de.fhdw.webshop.user.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@Entity
+@Table(name = "subscriptions")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Subscription {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private SubscriptionStatus status = SubscriptionStatus.ACTIVE;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private SubscriptionPlan plan = SubscriptionPlan.PLUS;
+
+    @Column(name = "monthly_price", nullable = false, precision = 10, scale = 2)
+    private BigDecimal monthlyPrice = new BigDecimal("9.99");
+
+    @Column(name = "started_at", nullable = false, updatable = false)
+    private Instant startedAt = Instant.now();
+
+    @Column(name = "current_period_start", nullable = false)
+    private Instant currentPeriodStart = Instant.now();
+
+    @Column(name = "current_period_end", nullable = false)
+    private Instant currentPeriodEnd;
+
+    @Column(name = "cancelled_at")
+    private Instant cancelledAt;
+}

--- a/src/main/java/de/fhdw/webshop/subscription/SubscriptionController.java
+++ b/src/main/java/de/fhdw/webshop/subscription/SubscriptionController.java
@@ -1,0 +1,39 @@
+package de.fhdw.webshop.subscription;
+
+import de.fhdw.webshop.subscription.dto.SubscriptionResponse;
+import de.fhdw.webshop.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/subscriptions")
+@RequiredArgsConstructor
+public class SubscriptionController {
+
+    private final SubscriptionService subscriptionService;
+
+    /** #134 — Get the current user's subscription status. */
+    @GetMapping("/me")
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public ResponseEntity<SubscriptionResponse> getMySubscription(@AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(subscriptionService.getMySubscription(user));
+    }
+
+    /** #134 — Subscribe to Webshop Plus. */
+    @PostMapping
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public ResponseEntity<SubscriptionResponse> subscribe(@AuthenticationPrincipal User user) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(subscriptionService.subscribe(user));
+    }
+
+    /** #134 — Cancel automatic renewal (subscription stays active until period end). */
+    @PutMapping("/me/cancel")
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public ResponseEntity<SubscriptionResponse> cancel(@AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(subscriptionService.cancel(user));
+    }
+}

--- a/src/main/java/de/fhdw/webshop/subscription/SubscriptionPlan.java
+++ b/src/main/java/de/fhdw/webshop/subscription/SubscriptionPlan.java
@@ -1,0 +1,5 @@
+package de.fhdw.webshop.subscription;
+
+public enum SubscriptionPlan {
+    PLUS
+}

--- a/src/main/java/de/fhdw/webshop/subscription/SubscriptionRepository.java
+++ b/src/main/java/de/fhdw/webshop/subscription/SubscriptionRepository.java
@@ -1,0 +1,19 @@
+package de.fhdw.webshop.subscription;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
+
+    Optional<Subscription> findByUserIdAndStatus(Long userId, SubscriptionStatus status);
+
+    boolean existsByUserIdAndStatus(Long userId, SubscriptionStatus status);
+
+    @Query("SELECT s FROM Subscription s WHERE s.status = 'ACTIVE' AND s.currentPeriodEnd <= :now")
+    List<Subscription> findDueForRenewal(@Param("now") Instant now);
+}

--- a/src/main/java/de/fhdw/webshop/subscription/SubscriptionScheduler.java
+++ b/src/main/java/de/fhdw/webshop/subscription/SubscriptionScheduler.java
@@ -1,0 +1,27 @@
+package de.fhdw.webshop.subscription;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * #136 — Daily job that renews or expires due Webshop Plus subscriptions.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SubscriptionScheduler {
+
+    private final SubscriptionService subscriptionService;
+
+    @Scheduled(cron = "0 0 6 * * *")
+    public void processSubscriptions() {
+        log.info("SubscriptionScheduler: starting daily renewal run");
+        try {
+            subscriptionService.processDueSubscriptions();
+        } catch (Exception e) {
+            log.error("SubscriptionScheduler: renewal run failed: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/de/fhdw/webshop/subscription/SubscriptionService.java
+++ b/src/main/java/de/fhdw/webshop/subscription/SubscriptionService.java
@@ -1,0 +1,110 @@
+package de.fhdw.webshop.subscription;
+
+import de.fhdw.webshop.messaging.SubscriptionRenewedEvent;
+import de.fhdw.webshop.subscription.dto.SubscriptionResponse;
+import de.fhdw.webshop.user.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SubscriptionService {
+
+    private static final String EXCHANGE = "webshop.events";
+    private static final String RENEWED_KEY = "subscription.renewed";
+
+    private final SubscriptionRepository subscriptionRepository;
+    private final RabbitTemplate rabbitTemplate;
+
+    /** #134 — Get the current user's active (or cancelled) subscription. */
+    @Transactional(readOnly = true)
+    public SubscriptionResponse getMySubscription(User user) {
+        return subscriptionRepository
+                .findByUserIdAndStatus(user.getId(), SubscriptionStatus.ACTIVE)
+                .or(() -> subscriptionRepository.findByUserIdAndStatus(user.getId(), SubscriptionStatus.CANCELLED))
+                .map(this::toResponse)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Kein Abonnement gefunden."));
+    }
+
+    /** #134 — Subscribe the user to Webshop Plus. */
+    @Transactional
+    public SubscriptionResponse subscribe(User user) {
+        if (subscriptionRepository.existsByUserIdAndStatus(user.getId(), SubscriptionStatus.ACTIVE)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Du hast bereits ein aktives Webshop Plus-Abonnement.");
+        }
+        Instant now = Instant.now();
+        Subscription subscription = new Subscription();
+        subscription.setUser(user);
+        subscription.setStartedAt(now);
+        subscription.setCurrentPeriodStart(now);
+        subscription.setCurrentPeriodEnd(now.plus(30, ChronoUnit.DAYS));
+        return toResponse(subscriptionRepository.save(subscription));
+    }
+
+    /** #134 — Cancel automatic renewal; subscription stays active until period end. */
+    @Transactional
+    public SubscriptionResponse cancel(User user) {
+        Subscription subscription = subscriptionRepository
+                .findByUserIdAndStatus(user.getId(), SubscriptionStatus.ACTIVE)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Kein aktives Abonnement gefunden."));
+        subscription.setCancelledAt(Instant.now());
+        subscription.setStatus(SubscriptionStatus.CANCELLED);
+        return toResponse(subscriptionRepository.save(subscription));
+    }
+
+    /** #135 — True when the user has a currently active Plus subscription. */
+    @Transactional(readOnly = true)
+    public boolean hasActivePlusSubscription(Long userId) {
+        return subscriptionRepository.existsByUserIdAndStatus(userId, SubscriptionStatus.ACTIVE);
+    }
+
+    /** #136 — Called by scheduler: renew or expire due subscriptions. */
+    @Transactional
+    public void processDueSubscriptions() {
+        List<Subscription> due = subscriptionRepository.findDueForRenewal(Instant.now());
+        log.info("SubscriptionService: processing {} due subscription(s)", due.size());
+        for (Subscription s : due) {
+            if (s.getCancelledAt() != null) {
+                s.setStatus(SubscriptionStatus.EXPIRED);
+                subscriptionRepository.save(s);
+                log.info("Subscription {} expired (was cancelled by user)", s.getId());
+            } else {
+                Instant newStart = s.getCurrentPeriodEnd();
+                Instant newEnd = newStart.plus(30, ChronoUnit.DAYS);
+                s.setCurrentPeriodStart(newStart);
+                s.setCurrentPeriodEnd(newEnd);
+                subscriptionRepository.save(s);
+                publishRenewedEvent(s);
+                log.info("Subscription {} renewed until {}", s.getId(), newEnd);
+            }
+        }
+    }
+
+    private void publishRenewedEvent(Subscription s) {
+        try {
+            rabbitTemplate.convertAndSend(EXCHANGE, RENEWED_KEY,
+                    new SubscriptionRenewedEvent(s.getId(), s.getUser().getId(), s.getCurrentPeriodEnd()));
+        } catch (Exception e) {
+            log.error("Failed to publish subscription.renewed event for {}: {}", s.getId(), e.getMessage());
+        }
+    }
+
+    private SubscriptionResponse toResponse(Subscription s) {
+        return new SubscriptionResponse(
+                s.getId(), s.getPlan(), s.getStatus(), s.getMonthlyPrice(),
+                s.getStartedAt(), s.getCurrentPeriodStart(), s.getCurrentPeriodEnd(), s.getCancelledAt()
+        );
+    }
+}

--- a/src/main/java/de/fhdw/webshop/subscription/SubscriptionStatus.java
+++ b/src/main/java/de/fhdw/webshop/subscription/SubscriptionStatus.java
@@ -1,0 +1,7 @@
+package de.fhdw.webshop.subscription;
+
+public enum SubscriptionStatus {
+    ACTIVE,
+    CANCELLED,
+    EXPIRED
+}

--- a/src/main/java/de/fhdw/webshop/subscription/dto/SubscriptionResponse.java
+++ b/src/main/java/de/fhdw/webshop/subscription/dto/SubscriptionResponse.java
@@ -1,0 +1,18 @@
+package de.fhdw.webshop.subscription.dto;
+
+import de.fhdw.webshop.subscription.SubscriptionPlan;
+import de.fhdw.webshop.subscription.SubscriptionStatus;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+public record SubscriptionResponse(
+        Long id,
+        SubscriptionPlan plan,
+        SubscriptionStatus status,
+        BigDecimal monthlyPrice,
+        Instant startedAt,
+        Instant currentPeriodStart,
+        Instant currentPeriodEnd,
+        Instant cancelledAt
+) {}

--- a/src/main/java/de/fhdw/webshop/warehouse/WarehouseService.java
+++ b/src/main/java/de/fhdw/webshop/warehouse/WarehouseService.java
@@ -111,6 +111,7 @@ public class WarehouseService {
     private final AuditLogService auditLogService;
     private final ApplicationEventPublisher eventPublisher;
     private final WarehouseStockBalanceService warehouseStockBalanceService;
+    private final de.fhdw.webshop.subscription.SubscriptionService subscriptionService;
 
     @Transactional
     public List<WarehouseOrderResponse> listOrders(OrderStatus status) {
@@ -1716,6 +1717,9 @@ public class WarehouseService {
                 .filter(value -> !value.isBlank())
                 .collect(Collectors.joining(", "));
 
+        boolean plusMember = order.getCustomer() != null
+                && subscriptionService.hasActivePlusSubscription(order.getCustomer().getId());
+
         return new WarehouseOrderResponse(
                 order.getId(),
                 order.getId(),
@@ -1723,6 +1727,7 @@ public class WarehouseService {
                 order.getCustomerName(),
                 order.getCustomerEmail(),
                 order.getStatus(),
+                plusMember,
                 regionKey,
                 regionLabels.getOrDefault(regionKey, "Unbekannte Route"),
                 order.getTruckIdentifier(),

--- a/src/main/java/de/fhdw/webshop/warehouse/dto/WarehouseOrderResponse.java
+++ b/src/main/java/de/fhdw/webshop/warehouse/dto/WarehouseOrderResponse.java
@@ -12,6 +12,7 @@ public record WarehouseOrderResponse(
         String customerName,
         String customerEmail,
         OrderStatus status,
+        boolean plusMember,
         String regionKey,
         String regionLabel,
         String truckIdentifier,

--- a/src/main/resources/db/migration/V101__create_subscriptions.sql
+++ b/src/main/resources/db/migration/V101__create_subscriptions.sql
@@ -1,0 +1,18 @@
+-- #134 Create subscriptions table for Webshop Plus membership
+-- Using VARCHAR instead of native PostgreSQL ENUM to avoid Hibernate type cast issues
+CREATE TABLE subscriptions (
+    id                   BIGSERIAL PRIMARY KEY,
+    user_id              BIGINT         NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    status               VARCHAR(20)    NOT NULL DEFAULT 'ACTIVE',
+    plan                 VARCHAR(30)    NOT NULL DEFAULT 'PLUS',
+    monthly_price        DECIMAL(10, 2) NOT NULL DEFAULT 9.99,
+    started_at           TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+    current_period_start TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+    current_period_end   TIMESTAMPTZ    NOT NULL DEFAULT (NOW() + INTERVAL '1 month'),
+    cancelled_at         TIMESTAMPTZ
+);
+
+CREATE INDEX idx_subscriptions_user_id    ON subscriptions(user_id);
+CREATE INDEX idx_subscriptions_status     ON subscriptions(status);
+CREATE INDEX idx_subscriptions_period_end ON subscriptions(current_period_end)
+    WHERE status = 'ACTIVE';

--- a/src/test/java/de/fhdw/webshop/order/OrderServiceTest.java
+++ b/src/test/java/de/fhdw/webshop/order/OrderServiceTest.java
@@ -244,6 +244,7 @@ class OrderServiceTest {
         ProductBundleService productBundleService = mock(ProductBundleService.class);
         AffiliateService affiliateService = mock(AffiliateService.class);
         OrderEventPublisher orderEventPublisher = mock(OrderEventPublisher.class);
+        de.fhdw.webshop.subscription.SubscriptionService subscriptionService = mock(de.fhdw.webshop.subscription.SubscriptionService.class);
 
         OrderService service = new OrderService(
                 orderRepository,
@@ -270,7 +271,8 @@ class OrderServiceTest {
                 stockReservationService,
                 productBundleService,
                 affiliateService,
-                orderEventPublisher);
+                orderEventPublisher,
+                subscriptionService);
 
         User customer = businessCustomer(10L, "employee");
         User manager = businessCustomer(11L, "manager");

--- a/src/test/java/de/fhdw/webshop/warehouse/WarehouseControllerTest.java
+++ b/src/test/java/de/fhdw/webshop/warehouse/WarehouseControllerTest.java
@@ -270,6 +270,7 @@ class WarehouseControllerTest {
                 "Max Mustermann",
                 "max@example.test",
                 status,
+                false,
                 "DE-33602",
                 "Germany · Bielefeld",
                 null,

--- a/src/test/java/de/fhdw/webshop/warehouse/WarehouseServiceTest.java
+++ b/src/test/java/de/fhdw/webshop/warehouse/WarehouseServiceTest.java
@@ -7,6 +7,7 @@ import de.fhdw.webshop.order.OrderItem;
 import de.fhdw.webshop.order.OrderRepository;
 import de.fhdw.webshop.order.OrderStatus;
 import de.fhdw.webshop.product.Product;
+import de.fhdw.webshop.subscription.SubscriptionService;
 import de.fhdw.webshop.user.DeliveryAddressRepository;
 import de.fhdw.webshop.user.User;
 import de.fhdw.webshop.warehouse.dto.AdvanceOrderResponse;
@@ -322,6 +323,8 @@ class WarehouseServiceTest {
         AuditLogService auditLogService = mock(AuditLogService.class);
         ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
         WarehouseStockBalanceService warehouseStockBalanceService = mock(WarehouseStockBalanceService.class);
+        SubscriptionService subscriptionService = mock(SubscriptionService.class);
+
 
         WarehouseService service = new WarehouseService(
                 orderRepository,
@@ -333,7 +336,8 @@ class WarehouseServiceTest {
                 warehouseTruckRepository,
                 auditLogService,
                 eventPublisher,
-                warehouseStockBalanceService
+                warehouseStockBalanceService,
+                subscriptionService
         );
 
         when(orderRepository.findByTruckIdentifierOrderByCreatedAtAsc(anyString())).thenReturn(List.of());

--- a/src/test/java/de/fhdw/webshop/warehouse/WarehouseTruckDepartureTest.java
+++ b/src/test/java/de/fhdw/webshop/warehouse/WarehouseTruckDepartureTest.java
@@ -7,6 +7,7 @@ import de.fhdw.webshop.order.OrderItem;
 import de.fhdw.webshop.order.OrderRepository;
 import de.fhdw.webshop.order.OrderStatus;
 import de.fhdw.webshop.product.Product;
+import de.fhdw.webshop.subscription.SubscriptionService;
 import de.fhdw.webshop.user.DeliveryAddressRepository;
 import de.fhdw.webshop.user.User;
 import de.fhdw.webshop.warehouse.dto.AdvanceOrderResponse;
@@ -391,6 +392,7 @@ class WarehouseTruckDepartureTest {
         AuditLogService auditLogService = mock(AuditLogService.class);
         ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
         WarehouseStockBalanceService warehouseStockBalanceService = mock(WarehouseStockBalanceService.class);
+        SubscriptionService subscriptionService = mock(SubscriptionService.class);
 
         WarehouseService service = new WarehouseService(
                 orderRepository,
@@ -402,7 +404,8 @@ class WarehouseTruckDepartureTest {
                 warehouseTruckRepository,
                 auditLogService,
                 eventPublisher,
-                warehouseStockBalanceService
+                warehouseStockBalanceService,
+                subscriptionService
         );
 
         when(orderRepository.findByTruckIdentifierOrderByCreatedAtAsc(anyString())).thenReturn(List.of());

--- a/src/test/java/de/fhdw/webshop/warehouse/WarehouseTruckDepartureWorkflowTest.java
+++ b/src/test/java/de/fhdw/webshop/warehouse/WarehouseTruckDepartureWorkflowTest.java
@@ -5,6 +5,7 @@ import de.fhdw.webshop.admin.AuditLogService;
 import de.fhdw.webshop.order.Order;
 import de.fhdw.webshop.order.OrderRepository;
 import de.fhdw.webshop.order.OrderStatus;
+import de.fhdw.webshop.subscription.SubscriptionService;
 import de.fhdw.webshop.user.DeliveryAddressRepository;
 import de.fhdw.webshop.user.User;
 import de.fhdw.webshop.warehouse.dto.AdvanceOrderResponse;
@@ -332,6 +333,7 @@ class WarehouseTruckDepartureWorkflowTest {
         AuditLogService auditLogService = mock(AuditLogService.class);
         ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
         WarehouseStockBalanceService warehouseStockBalanceService = mock(WarehouseStockBalanceService.class);
+        SubscriptionService subscriptionService = mock(SubscriptionService.class);
 
         WarehouseService service = new WarehouseService(
                 orderRepository,
@@ -343,7 +345,8 @@ class WarehouseTruckDepartureWorkflowTest {
                 warehouseTruckRepository,
                 auditLogService,
                 eventPublisher,
-                warehouseStockBalanceService
+                warehouseStockBalanceService,
+                subscriptionService
         );
 
         when(orderRepository.findByTruckIdentifierOrderByCreatedAtAsc(anyString())).thenReturn(List.of());

--- a/src/test/java/de/fhdw/webshop/warehouse/WarehouseTruckStartDepartureTest.java
+++ b/src/test/java/de/fhdw/webshop/warehouse/WarehouseTruckStartDepartureTest.java
@@ -5,6 +5,7 @@ import de.fhdw.webshop.admin.AuditLogService;
 import de.fhdw.webshop.order.Order;
 import de.fhdw.webshop.order.OrderRepository;
 import de.fhdw.webshop.order.OrderStatus;
+import de.fhdw.webshop.subscription.SubscriptionService;
 import de.fhdw.webshop.user.DeliveryAddressRepository;
 import de.fhdw.webshop.user.User;
 import de.fhdw.webshop.warehouse.dto.DepartureReadinessResponse;
@@ -527,11 +528,12 @@ class WarehouseTruckStartDepartureTest {
         AuditLogService auditLogService = mock(AuditLogService.class);
         ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
         WarehouseStockBalanceService balanceService = mock(WarehouseStockBalanceService.class);
+        SubscriptionService subscriptionService = mock(SubscriptionService.class);
 
         WarehouseService service = new WarehouseService(
                 orderRepo, deliveryAddressRepo, addressLookupService, productRepo,
                 warehouseLocationRepo, stockRepo, truckRepo, auditLogService,
-                eventPublisher, balanceService
+                eventPublisher, balanceService, subscriptionService
         );
 
         when(orderRepo.findByTruckIdentifierOrderByCreatedAtAsc(anyString())).thenReturn(List.of());


### PR DESCRIPTION
## Summary

Implementiert das **Webshop Plus** Premium-Abonnement im Backend (Epic #133).

- **#134** Subscription-Paket: `Subscription`-Entity + Enums, Repository, `SubscriptionService` (subscribe / cancel / getMy / hasActivePlusSubscription), `SubscriptionController` (`GET /me`, `POST`, `PUT /me/cancel`), `SubscriptionScheduler` (täglich 06:00), Migration `V101__create_subscriptions.sql`
- **#136** Automatische Verlängerung: `processDueSubscriptions` verlängert aktive bzw. lässt gekündigte Abos ablaufen und publiziert `subscription.renewed` als RabbitMQ-Event (`SubscriptionRenewedEvent`)
- **#135** Kostenloser Versand: aktive Plus-Abonnenten erhalten `shippingCost = 0` (Standard + Express); `plusMember`-Flag in `OrderPreviewResponse` für die Bestellprüfung
- **#133** Lager-Sichtbarkeit: `plusMember`-Flag in `WarehouseOrderResponse`, ermittelt über `SubscriptionService` — so sehen Lagermitarbeiter, welche Bestellungen von Plus-Abonnenten stammen

## Neue Endpunkte

| Methode | URL | Zweck |
|---|---|---|
| GET | `/api/subscriptions/me` | Abo-Status des Kunden |
| POST | `/api/subscriptions` | Webshop Plus abonnieren |
| PUT | `/api/subscriptions/me/cancel` | Zum Periodenende kündigen |

## Test plan
- [ ] `./dev.bat restart` (Flyway spielt V101 ein)
- [ ] Als Kunde: `POST /api/subscriptions` → `GET /me` zeigt ACTIVE
- [ ] Bestellung aufgeben → `shippingCost = 0`, `plusMember = true` in Preview
- [ ] Lager-Endpunkt (`/api/warehouse/orders`) zeigt `plusMember` pro Bestellung
- [ ] `PUT /me/cancel` → Status CANCELLED, bleibt bis Periodenende aktiv

🤖 Generated with [Claude Code](https://claude.com/claude-code)
