### PR TITLE
Resolves #146 restriktive-produkte

### DIFF
--- a/src/main/java/de/fhdw/webshop/cart/CartService.java
+++ b/src/main/java/de/fhdw/webshop/cart/CartService.java
@@ -140,6 +140,16 @@ public class CartService {
                 .mapToInt(CartItemResponse::quantity)
                 .sum();
 
+        // #148 — Mixed carts: the strictest rule applies. The whole cart is restricted
+        // as soon as a single item is restricted.
+        List<String> restrictionTypes = itemResponses.stream()
+                .filter(CartItemResponse::restricted)
+                .map(CartItemResponse::restrictionType)
+                .filter(java.util.Objects::nonNull)
+                .distinct()
+                .toList();
+        boolean cartRestricted = itemResponses.stream().anyMatch(CartItemResponse::restricted);
+
         return new CartResponse(
                 itemResponses,
                 subtotal,
@@ -155,7 +165,9 @@ public class CartService {
                 discountType,
                 discountLabel,
                 discountPercent,
-                discountMessages
+                discountMessages,
+                cartRestricted,
+                restrictionTypes
         );
     }
 
@@ -250,6 +262,12 @@ public class CartService {
     @Transactional
     public CartResponse addItemForCustomerByEmployee(User customer, AddToCartRequest addToCartRequest, User employee) {
         Product product = productService.loadProduct(addToCartRequest.productId());
+        // #149 — Customer-service block: an agent may not add a restricted product to a
+        // customer's cart unless the customer already holds a valid verification.
+        if (product.isRestricted() && !customer.isVerified()) {
+            throw new IllegalArgumentException(
+                    "Dieses Produkt ist restriktiv und kann nicht hinzugefügt werden, solange für das Kundenkonto keine gültige Verifizierung hinterlegt ist.");
+        }
         int previousQuantity = cartRepository.findByUserIdAndProductId(customer.getId(), product.getId())
                 .map(CartItem::getQuantity)
                 .orElse(0);
@@ -579,7 +597,11 @@ public class CartService {
                 cartItem.getQuantity(),
                 lineTotal,
                 lineCo2EmissionKg,
-                cartItem.getAddedAt()
+                cartItem.getAddedAt(),
+                cartItem.getProduct().isRestricted(),
+                cartItem.getProduct().getRestrictionType() == null
+                        ? null
+                        : cartItem.getProduct().getRestrictionType().name()
         );
     }
 

--- a/src/main/java/de/fhdw/webshop/cart/dto/CartItemResponse.java
+++ b/src/main/java/de/fhdw/webshop/cart/dto/CartItemResponse.java
@@ -31,5 +31,7 @@ public record CartItemResponse(
         int quantity,
         BigDecimal lineTotal,
         BigDecimal lineCo2EmissionKg,
-        Instant addedAt
+        Instant addedAt,
+        boolean restricted,
+        String restrictionType
 ) {}

--- a/src/main/java/de/fhdw/webshop/cart/dto/CartResponse.java
+++ b/src/main/java/de/fhdw/webshop/cart/dto/CartResponse.java
@@ -18,5 +18,7 @@ public record CartResponse(
         String discountType,
         String discountLabel,
         BigDecimal discountPercent,
-        List<String> discountMessages
+        List<String> discountMessages,
+        boolean restricted,
+        List<String> restrictionTypes
 ) {}

--- a/src/main/java/de/fhdw/webshop/order/Order.java
+++ b/src/main/java/de/fhdw/webshop/order/Order.java
@@ -86,6 +86,16 @@ public class Order {
     @Column(nullable = false, columnDefinition = "order_status")
     private OrderStatus status = OrderStatus.PENDING;
 
+    /** #149 — Fulfillment tag: the order contains a restricted product and needs special shipping. */
+    @Column(name = "restricted_shipping", nullable = false)
+    private boolean restrictedShipping = false;
+
+    @Column(name = "restriction_verified_at")
+    private Instant restrictionVerifiedAt;
+
+    @Column(name = "restriction_verification_reference", length = 120)
+    private String restrictionVerificationReference;
+
     @Column(name = "coupon_code", length = 50)
     private String couponCode;
 

--- a/src/main/java/de/fhdw/webshop/order/OrderService.java
+++ b/src/main/java/de/fhdw/webshop/order/OrderService.java
@@ -266,6 +266,9 @@ public class OrderService {
             throw new IllegalArgumentException("Bitte akzeptiere AGB, Widerrufsbelehrung und Datenschutzhinweise vor der Bestellung");
         }
         cartService.getCart(customer.getId());
+        // #148/#149 — Restricted products require a completed verification before checkout.
+        RestrictionVerification restriction = resolveRestrictionVerification(
+                customer, placeOrderRequest, cartRepository.findByUserId(customer.getId()));
         PreparedOrder preparedOrder = prepareCustomerOrder(customer, placeOrderRequest);
         DeliveryAddressRequest deliveryAddressRequest = placeOrderRequest != null ? placeOrderRequest.deliveryAddress() : null;
         PaymentMethodRequest paymentMethodRequest = placeOrderRequest != null ? placeOrderRequest.paymentMethod() : null;
@@ -277,6 +280,7 @@ public class OrderService {
         }
         if (preparedOrder.approvalRequired()) {
             Order savedOrder = persistApprovalRequest(preparedOrder, placeOrderRequest != null ? placeOrderRequest.approvalReason() : null);
+            applyRestrictionToOrder(savedOrder, restriction, customer);
             cartService.clearCartSilently(customer.getId());
             return toResponse(savedOrder);
         }
@@ -287,6 +291,7 @@ public class OrderService {
                 .findFirst()
                 .orElse(placeOrderRequest != null ? placeOrderRequest.affiliateCode() : null);
         Order savedOrder = persistPreparedOrder(preparedOrder);
+        applyRestrictionToOrder(savedOrder, restriction, customer);
         cartService.clearCartSilently(customer.getId());
         markCheckoutCodeAsUsed(preparedOrder, savedOrder, customer);
         affiliateService.processAffiliateConversions(savedOrder, affiliateCode);
@@ -307,6 +312,13 @@ public class OrderService {
     @Transactional
     public OrderResponse placeGuestOrder(@Valid PlaceOrderRequest placeOrderRequest) {
         validateLegalAcceptance(placeOrderRequest);
+        // #148 — Restricted products require a registered, verified customer account.
+        if (placeOrderRequest != null && placeOrderRequest.items() != null
+                && placeOrderRequest.items().stream()
+                        .anyMatch(item -> productService.loadProduct(item.productId()).isRestricted())) {
+            throw new IllegalArgumentException(
+                    "Dein Warenkorb enthält ein restriktives Produkt. Bitte melde dich mit einem Kundenkonto an – eine Gastbestellung ist hier nicht möglich.");
+        }
         PreparedOrder preparedOrder = prepareGuestOrder(placeOrderRequest);
         Order savedOrder = persistPreparedOrder(preparedOrder);
         markCheckoutCodeAsUsed(preparedOrder, savedOrder, null);
@@ -1186,7 +1198,8 @@ public class OrderService {
                 resolvePersistedDiscountType(order),
                 resolvePersistedDiscountLabel(order),
                 null,
-                List.of());
+                List.of(),
+                order.isRestrictedShipping());
     }
 
     private OrderApprovalResponse toApprovalResponse(Order order, Boolean confirmationEmailSent) {
@@ -1247,7 +1260,8 @@ public class OrderService {
                 resolvePersistedDiscountType(order),
                 resolvePersistedDiscountLabel(order),
                 null,
-                List.of());
+                List.of(),
+                order.isRestrictedShipping());
     }
 
     private Instant estimateDeliveryAt(Order order) {
@@ -1306,6 +1320,15 @@ public class OrderService {
                 ))
                 .toList();
 
+        // #148 — Restriction info for the checkout (strictest rule for mixed carts).
+        List<String> restrictionTypes = preparedOrder.items().stream()
+                .map(PreparedOrderItem::product)
+                .filter(product -> product != null && product.isRestricted() && product.getRestrictionType() != null)
+                .map(product -> product.getRestrictionType().name())
+                .distinct()
+                .toList();
+        boolean previewRestricted = !restrictionTypes.isEmpty();
+
         return new OrderPreviewResponse(
                 preparedOrder.order().getOrderNumber(),
                 preparedOrder.order().getCustomerEmail(),
@@ -1324,7 +1347,9 @@ public class OrderService {
                 preparedOrder.discountType(),
                 preparedOrder.discountLabel(),
                 preparedOrder.discountPercent(),
-                preparedOrder.discountMessages()
+                preparedOrder.discountMessages(),
+                previewRestricted,
+                restrictionTypes
         );
     }
 
@@ -1623,6 +1648,64 @@ public class OrderService {
             BigDecimal unitPrice,
             BigDecimal lineTotal
     ) {}
+
+    /**
+     * #148/#149 — Enforce that a restricted cart is only checked out by a verified customer.
+     * Persists the verification on the account (bonus: skip on future purchases).
+     */
+    private RestrictionVerification resolveRestrictionVerification(
+            User customer, PlaceOrderRequest request, List<CartItem> cartItems) {
+        boolean restricted = cartItems.stream()
+                .anyMatch(item -> item.getProduct() != null && item.getProduct().isRestricted());
+        if (!restricted) {
+            return new RestrictionVerification(false, null);
+        }
+        boolean alreadyVerified = customer.isVerified();
+        boolean confirmedNow = request != null && Boolean.TRUE.equals(request.restrictionVerified());
+        if (!alreadyVerified && !confirmedNow) {
+            throw new IllegalArgumentException(
+                    "Dieser Warenkorb enthält restriktive Produkte. Bitte schließe die erforderliche Verifizierung ab, bevor du die Bestellung abschließt.");
+        }
+        String reference;
+        if (alreadyVerified && customer.getVerificationReference() != null) {
+            reference = customer.getVerificationReference();
+        } else if (request != null && request.restrictionVerificationReference() != null
+                && !request.restrictionVerificationReference().isBlank()) {
+            reference = request.restrictionVerificationReference().trim();
+        } else {
+            reference = "VERIFY-" + UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+        }
+        if (!alreadyVerified) {
+            customer.setVerified(true);
+            customer.setVerifiedAt(Instant.now());
+            customer.setVerificationReference(reference);
+            userRepository.save(customer);
+        }
+        return new RestrictionVerification(true, reference);
+    }
+
+    /** #149 — Tag the order for special (restricted) shipping and write a tamper-evident audit entry. */
+    private void applyRestrictionToOrder(Order order, RestrictionVerification restriction, User customer) {
+        if (restriction == null || !restriction.restricted()) {
+            return;
+        }
+        Instant verifiedAt = Instant.now();
+        order.setRestrictedShipping(true);
+        order.setRestrictionVerifiedAt(verifiedAt);
+        order.setRestrictionVerificationReference(restriction.reference());
+        orderRepository.save(order);
+        auditLogService.record(
+                customer,
+                "RESTRICTED_PURCHASE_VERIFIED",
+                "Order",
+                order.getId(),
+                AuditInitiator.USER,
+                "Restriktive Bestellung " + order.getOrderNumber()
+                        + " verifiziert. Referenz: " + restriction.reference()
+                        + ", Zeitstempel: " + verifiedAt);
+    }
+
+    private record RestrictionVerification(boolean restricted, String reference) {}
 
     private record PreparedOrder(
             Order order,

--- a/src/main/java/de/fhdw/webshop/order/dto/OrderPreviewResponse.java
+++ b/src/main/java/de/fhdw/webshop/order/dto/OrderPreviewResponse.java
@@ -21,5 +21,7 @@ public record OrderPreviewResponse(
         String discountType,
         String discountLabel,
         BigDecimal discountPercent,
-        List<String> discountMessages
+        List<String> discountMessages,
+        boolean restricted,
+        List<String> restrictionTypes
 ) {}

--- a/src/main/java/de/fhdw/webshop/order/dto/OrderResponse.java
+++ b/src/main/java/de/fhdw/webshop/order/dto/OrderResponse.java
@@ -33,5 +33,6 @@ public record OrderResponse(
         String discountType,
         String discountLabel,
         BigDecimal discountPercent,
-        List<String> discountMessages
+        List<String> discountMessages,
+        boolean restrictedShipping
 ) {}

--- a/src/main/java/de/fhdw/webshop/order/dto/PlaceOrderRequest.java
+++ b/src/main/java/de/fhdw/webshop/order/dto/PlaceOrderRequest.java
@@ -25,5 +25,7 @@ public record PlaceOrderRequest(
         Long pickupStoreId,
         String approvalReason,
         List<@Valid PlaceOrderItemRequest> items,
-        String affiliateCode
+        String affiliateCode,
+        Boolean restrictionVerified,
+        String restrictionVerificationReference
 ) {}

--- a/src/main/java/de/fhdw/webshop/product/Product.java
+++ b/src/main/java/de/fhdw/webshop/product/Product.java
@@ -97,6 +97,14 @@ public class Product {
     @Column(name = "trade_in_enabled", nullable = false)
     private boolean tradeInEnabled = true;
 
+    /** #147 — When true, the product can only be bought by verified customers under specific conditions. */
+    @Column(nullable = false)
+    private boolean restricted = false;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "restriction_type", length = 40)
+    private RestrictionType restrictionType;
+
     /** Promoted products are highlighted on the storefront (US #26). */
     @Column(nullable = false)
     private boolean promoted = false;

--- a/src/main/java/de/fhdw/webshop/product/ProductService.java
+++ b/src/main/java/de/fhdw/webshop/product/ProductService.java
@@ -228,7 +228,9 @@ public class ProductService {
                         : List.of(),
                 product.getCreatedAt(),
                 product.getSupplierName(),
-                product.getSupplierLeadTimeDays()
+                product.getSupplierLeadTimeDays(),
+                product.isRestricted(),
+                product.getRestrictionType()
         );
     }
 
@@ -256,6 +258,9 @@ public class ProductService {
         if (productRequest.supplierLeadTimeDays() != null) {
             product.setSupplierLeadTimeDays(productRequest.supplierLeadTimeDays());
         }
+        boolean restricted = Boolean.TRUE.equals(productRequest.restricted());
+        product.setRestricted(restricted);
+        product.setRestrictionType(restricted ? productRequest.restrictionType() : null);
     }
 
     private void syncVariants(Product parent, ProductRequest productRequest) {
@@ -338,6 +343,8 @@ public class ProductService {
         variant.setSku(firstNonBlank(variantRequest.sku(), buildGeneratedSku(parent, index)));
         variant.setPurchasable(parent.isPurchasable());
         variant.setTradeInEnabled(parent.isTradeInEnabled());
+        variant.setRestricted(parent.isRestricted());
+        variant.setRestrictionType(parent.getRestrictionType());
         variant.setPromoted(false);
         variant.setPersonalizable(parent.isPersonalizable());
         variant.setPersonalizationMaxLength(parent.getPersonalizationMaxLength());

--- a/src/main/java/de/fhdw/webshop/product/RestrictionType.java
+++ b/src/main/java/de/fhdw/webshop/product/RestrictionType.java
@@ -1,0 +1,10 @@
+package de.fhdw.webshop.product;
+
+/**
+ * #147 — Type of purchase restriction applied to a product.
+ * AGE_18 requires an age confirmation (18+), B2B_PROOF requires a business proof.
+ */
+public enum RestrictionType {
+    AGE_18,
+    B2B_PROOF
+}

--- a/src/main/java/de/fhdw/webshop/product/dto/ProductRequest.java
+++ b/src/main/java/de/fhdw/webshop/product/dto/ProductRequest.java
@@ -1,6 +1,7 @@
 package de.fhdw.webshop.product.dto;
 
 import de.fhdw.webshop.product.ProductEcoScore;
+import de.fhdw.webshop.product.RestrictionType;
 
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
@@ -28,5 +29,7 @@ public record ProductRequest(
         List<ProductVariantAttributeRequest> variantAttributes,
         List<ProductVariantRequest> variants,
         String supplierName,
-        Integer supplierLeadTimeDays
+        Integer supplierLeadTimeDays,
+        Boolean restricted,
+        RestrictionType restrictionType
 ) {}

--- a/src/main/java/de/fhdw/webshop/product/dto/ProductResponse.java
+++ b/src/main/java/de/fhdw/webshop/product/dto/ProductResponse.java
@@ -2,6 +2,7 @@ package de.fhdw.webshop.product.dto;
 
 import de.fhdw.webshop.product.ProductEcoScore;
 import de.fhdw.webshop.product.ProductType;
+import de.fhdw.webshop.product.RestrictionType;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -35,5 +36,7 @@ public record ProductResponse(
         List<ProductResponse> variants,
         Instant createdAt,
         String supplierName,
-        Integer supplierLeadTimeDays
+        Integer supplierLeadTimeDays,
+        boolean restricted,
+        RestrictionType restrictionType
 ) {}

--- a/src/main/java/de/fhdw/webshop/user/User.java
+++ b/src/main/java/de/fhdw/webshop/user/User.java
@@ -61,6 +61,16 @@ public class User implements UserDetails {
     @Column(nullable = false)
     private boolean active = true;
 
+    /** #148 — True once the customer has passed restricted-product verification (skips future checks). */
+    @Column(nullable = false)
+    private boolean verified = false;
+
+    @Column(name = "verified_at")
+    private Instant verifiedAt;
+
+    @Column(name = "verification_reference", length = 120)
+    private String verificationReference;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt = Instant.now();
 

--- a/src/main/java/de/fhdw/webshop/warehouse/WarehouseService.java
+++ b/src/main/java/de/fhdw/webshop/warehouse/WarehouseService.java
@@ -1728,6 +1728,7 @@ public class WarehouseService {
                 order.getCustomerEmail(),
                 order.getStatus(),
                 plusMember,
+                order.isRestrictedShipping(),
                 regionKey,
                 regionLabels.getOrDefault(regionKey, "Unbekannte Route"),
                 order.getTruckIdentifier(),

--- a/src/main/java/de/fhdw/webshop/warehouse/dto/WarehouseOrderResponse.java
+++ b/src/main/java/de/fhdw/webshop/warehouse/dto/WarehouseOrderResponse.java
@@ -13,6 +13,7 @@ public record WarehouseOrderResponse(
         String customerEmail,
         OrderStatus status,
         boolean plusMember,
+        boolean restrictedShipping,
         String regionKey,
         String regionLabel,
         String truckIdentifier,

--- a/src/main/resources/db/migration/V102__add_restricted_products.sql
+++ b/src/main/resources/db/migration/V102__add_restricted_products.sql
@@ -1,0 +1,21 @@
+-- #147/#148/#149 Restricted products: age/B2B purchase restrictions and verification audit
+
+-- 1. Product restriction flags
+ALTER TABLE products
+    ADD COLUMN restricted        BOOLEAN     NOT NULL DEFAULT FALSE,
+    ADD COLUMN restriction_type  VARCHAR(40);
+
+-- 2. Customer verification status (bonus: skip verification on future purchases)
+ALTER TABLE users
+    ADD COLUMN verified               BOOLEAN     NOT NULL DEFAULT FALSE,
+    ADD COLUMN verified_at            TIMESTAMPTZ,
+    ADD COLUMN verification_reference VARCHAR(120);
+
+-- 3. Order fulfillment tag + verification audit reference
+ALTER TABLE orders
+    ADD COLUMN restricted_shipping              BOOLEAN     NOT NULL DEFAULT FALSE,
+    ADD COLUMN restriction_verified_at          TIMESTAMPTZ,
+    ADD COLUMN restriction_verification_reference VARCHAR(120);
+
+CREATE INDEX idx_products_restricted ON products(restricted) WHERE restricted = TRUE;
+CREATE INDEX idx_orders_restricted_shipping ON orders(restricted_shipping) WHERE restricted_shipping = TRUE;

--- a/src/main/resources/db/migration/V103__seed_restricted_demo_products.sql
+++ b/src/main/resources/db/migration/V103__seed_restricted_demo_products.sql
@@ -1,0 +1,32 @@
+-- #147 Seed two demo products that are restricted from the start (for testing).
+-- One age-restricted (18+) and one B2B-proof product. Idempotent via SKU guard.
+
+INSERT INTO products (
+    name, description, image_url, recommended_retail_price, co2_emission_kg,
+    eco_score, category, seller_name, product_type, stock, sku,
+    purchasable, trade_in_enabled, promoted, personalizable, has_variants,
+    supplier_name, supplier_lead_time_days, restricted, restriction_type
+)
+SELECT
+    'Hochprozentiger Premium-Whisky 0,7l',
+    'Edler Single Malt Whisky (42% vol.). Abgabe nur an Personen ab 18 Jahren – Altersnachweis erforderlich.',
+    NULL, 49.90, 1.200,
+    'C', 'Spirituosen', 'Webshop', 'STANDARD', 40, 'RESTRICTED-WHISKY-18',
+    TRUE, FALSE, TRUE, FALSE, FALSE,
+    'Highland Distillery Ltd.', 5, TRUE, 'AGE_18'
+WHERE NOT EXISTS (SELECT 1 FROM products WHERE sku = 'RESTRICTED-WHISKY-18');
+
+INSERT INTO products (
+    name, description, image_url, recommended_retail_price, co2_emission_kg,
+    eco_score, category, seller_name, product_type, stock, sku,
+    purchasable, trade_in_enabled, promoted, personalizable, has_variants,
+    supplier_name, supplier_lead_time_days, restricted, restriction_type
+)
+SELECT
+    'Profi-Laserentfernungsmesser (Gewerbe)',
+    'Industrielles Vermessungsgerät. Verkauf ausschließlich an Gewerbekunden – B2B-Nachweis erforderlich.',
+    NULL, 329.00, 3.500,
+    'B', 'Werkzeug', 'Webshop', 'STANDARD', 25, 'RESTRICTED-B2B-LASER',
+    TRUE, TRUE, FALSE, FALSE, FALSE,
+    'Industrial Tools GmbH', 7, TRUE, 'B2B_PROOF'
+WHERE NOT EXISTS (SELECT 1 FROM products WHERE sku = 'RESTRICTED-B2B-LASER');

--- a/src/test/java/de/fhdw/webshop/order/OrderServiceTest.java
+++ b/src/test/java/de/fhdw/webshop/order/OrderServiceTest.java
@@ -327,6 +327,8 @@ class OrderServiceTest {
                 null,
                 approvalReason,
                 null,
+                null,
+                null,
                 null);
     }
 
@@ -347,6 +349,8 @@ class OrderServiceTest {
                 false,
                 false,
                 pickupStoreId,
+                null,
+                null,
                 null,
                 null,
                 null);

--- a/src/test/java/de/fhdw/webshop/product/ProductServiceVariantTest.java
+++ b/src/test/java/de/fhdw/webshop/product/ProductServiceVariantTest.java
@@ -115,8 +115,10 @@ class ProductServiceVariantTest {
                         new ProductVariantAttributeRequest("Groesse", List.of("S", "M"))
                 ),
                 variants,
-                "EcoLogistics GmbH", 
-                3
+                "EcoLogistics GmbH",
+                3,
+                false,
+                null
         );
     }
 

--- a/src/test/java/de/fhdw/webshop/warehouse/WarehouseControllerTest.java
+++ b/src/test/java/de/fhdw/webshop/warehouse/WarehouseControllerTest.java
@@ -271,6 +271,7 @@ class WarehouseControllerTest {
                 "max@example.test",
                 status,
                 false,
+                false,
                 "DE-33602",
                 "Germany · Bielefeld",
                 null,


### PR DESCRIPTION
## Summary

Implementiert restriktive Produkte (Altersnachweis 18+, B2B-Nachweis) im Backend (Epic #146).

- **#147** Datenmodell & API: `Product.restricted` + `restrictionType` (`AGE_18` / `B2B_PROOF`), Migration V102, in DTOs + `ProductService` (Varianten erben die Restriktion)
- **#148** Verifizierung: Warenkorb-Restriktionsstatus (gemischter Warenkorb = strengste Regel) in `CartResponse`/`CartItemResponse`; `placeOrder` erzwingt Verifizierung (Checkbox **oder** bereits `user.verified`); `placeGuestOrder` blockiert restriktive Produkte (Kundenkonto erforderlich); Bonus: `user.verified` wird persistiert; `OrderPreviewResponse` liefert `restricted` + `restrictionTypes`
- **#149** Fulfillment & Compliance: `order.restrictedShipping` (Tag `RESTRICTED_SHIPPING`) in `OrderResponse` und `WarehouseOrderResponse`; revisionssicherer Audit-Eintrag `RESTRICTED_PURCHASE_VERIFIED` (Zeitstempel + Referenz); Kundenservice-Sperre (Mitarbeiter kann restriktives Produkt nicht in den Warenkorb eines unverifizierten Kunden legen)
- **#146** Seed: zwei restriktive Demo-Produkte (Whisky 18+, Laser B2B) via V103 für direktes Testen

## Neue/erweiterte Endpunkte
- `GET /api/products` / `POST` / `PUT /{id}` — `restricted` + `restrictionType`
- `GET /api/cart` — `restricted` + `restrictionTypes`
- `POST /api/orders/checkout` — `restrictionVerified` erforderlich bei restriktivem Warenkorb
- `GET /api/warehouse/orders` — `restrictedShipping`

## Test plan
- [ ] `./dev.bat restart` — Flyway führt V102 + V103 aus
- [ ] Storefront: Demo-Produkte tragen Badge; Detailseite zeigt Hinweis
- [ ] Gast-Checkout mit restriktivem Produkt → blockiert
- [ ] Kunden-Checkout → Verifizierung erforderlich → Bestellung trägt `RESTRICTED_SHIPPING`
- [ ] Mitarbeiter: restriktives Produkt in Warenkorb eines unverifizierten Kunden → abgelehnt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
