### PR TITLE
Add affiliate tier system (Tier 1/2/3) with auto-promotion

### DIFF
--- a/src/main/java/de/fhdw/webshop/affiliate/AffiliateProfile.java
+++ b/src/main/java/de/fhdw/webshop/affiliate/AffiliateProfile.java
@@ -27,6 +27,10 @@ public class AffiliateProfile {
     @Column(name = "commission_rate", nullable = false, precision = 5, scale = 4)
     private BigDecimal commissionRate = new BigDecimal("0.0100");
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tier", nullable = false, length = 20)
+    private AffiliateTier tier = AffiliateTier.TIER_3;
+
     @Column(name = "total_earnings_confirmed", nullable = false, precision = 12, scale = 2)
     private BigDecimal totalEarningsConfirmed = BigDecimal.ZERO;
 

--- a/src/main/java/de/fhdw/webshop/affiliate/AffiliateService.java
+++ b/src/main/java/de/fhdw/webshop/affiliate/AffiliateService.java
@@ -100,7 +100,8 @@ public class AffiliateService {
         if (profileRepository.findByUser(application.getUser()).isEmpty()) {
             AffiliateProfile profile = new AffiliateProfile();
             profile.setUser(application.getUser());
-            profile.setCommissionRate(new BigDecimal("0.0100"));
+            profile.setCommissionRate(AffiliateTier.TIER_3.getDefaultRate());
+            profile.setTier(AffiliateTier.TIER_3);
             profile.setActive(true);
             profileRepository.save(profile);
         }
@@ -251,6 +252,7 @@ public class AffiliateService {
             if (totalCommission.compareTo(BigDecimal.ZERO) > 0) {
                 profile.setPendingEarnings(profile.getPendingEarnings().add(totalCommission));
                 profileRepository.save(profile);
+                recalculateTierAndRate(profile);
                 auditLogService.recordSystemAction(
                         "AFFILIATE_CONVERSION_CREATED", "AffiliateConversion",
                         order.getId(),
@@ -306,6 +308,7 @@ public class AffiliateService {
                     p.getId(), p.getUser().getId(),
                     p.getUser().getUsername(), p.getUser().getEmail(),
                     p.getCommissionRate(),
+                    p.getTier().name(),
                     links.size(),
                     links.stream().mapToLong(AffiliateLink::getClickCount).sum(),
                     convs.size(),
@@ -328,12 +331,34 @@ public class AffiliateService {
         AffiliateProfile profile = profileRepository.findById(affiliateId)
                 .orElseThrow(() -> new EntityNotFoundException(
                         "Affiliate-Profil nicht gefunden: " + affiliateId));
+        AffiliateTier tier = AffiliateTier.fromRate(rate);
         profile.setCommissionRate(rate);
+        profile.setTier(tier);
         profileRepository.save(profile);
         auditLogService.recordSystemAction(
                 "AFFILIATE_COMMISSION_RATE_UPDATED", "AffiliateProfile",
-                affiliateId, "Provisionsrate auf " + rate + " gesetzt für: "
+                affiliateId, "Provisionsrate auf " + rate + " (" + tier + ") gesetzt für: "
                         + profile.getUser().getUsername());
+    }
+
+    /** Recalculates tier and auto-sets commission rate based on total generated revenue. */
+    private void recalculateTierAndRate(AffiliateProfile profile) {
+        BigDecimal totalRevenue = conversionRepository
+                .findByAffiliateLink_AffiliateProfileOrderByCreatedAtDesc(profile)
+                .stream()
+                .map(AffiliateConversion::getPurchaseAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        AffiliateTier newTier = AffiliateTier.fromRevenue(totalRevenue);
+        if (newTier != profile.getTier()) {
+            profile.setTier(newTier);
+            profile.setCommissionRate(newTier.getDefaultRate());
+            profileRepository.save(profile);
+            auditLogService.recordSystemAction(
+                    "AFFILIATE_TIER_AUTO_UPGRADED", "AffiliateProfile",
+                    profile.getId(),
+                    "Tier automatisch auf " + newTier + " angepasst (Umsatz: " + totalRevenue + " €)"
+                            + " für: " + profile.getUser().getUsername());
+        }
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
@@ -343,14 +368,24 @@ public class AffiliateService {
                 linkRepository.findByAffiliateProfileOrderByCreatedAtDesc(profile);
         List<AffiliateConversion> conversions =
                 conversionRepository.findByAffiliateLink_AffiliateProfileOrderByCreatedAtDesc(profile);
+        BigDecimal totalRevenue = conversions.stream()
+                .map(AffiliateConversion::getPurchaseAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        AffiliateTier currentTier = profile.getTier();
+        BigDecimal nextTierRevenue = switch (currentTier) {
+            case TIER_3 -> AffiliateTier.TIER_2.getMinRevenue().subtract(totalRevenue).max(BigDecimal.ZERO);
+            case TIER_2 -> AffiliateTier.TIER_1.getMinRevenue().subtract(totalRevenue).max(BigDecimal.ZERO);
+            case TIER_1 -> BigDecimal.ZERO;
+        };
         return new AffiliateDashboardStats(
                 links.stream().mapToLong(AffiliateLink::getClickCount).sum(),
                 conversions.size(),
-                conversions.stream().map(AffiliateConversion::getPurchaseAmount)
-                        .reduce(BigDecimal.ZERO, BigDecimal::add),
+                totalRevenue,
                 profile.getTotalEarningsConfirmed(),
                 profile.getPendingEarnings(),
-                links.stream().filter(AffiliateLink::isActive).count()
+                links.stream().filter(AffiliateLink::isActive).count(),
+                currentTier.name(),
+                nextTierRevenue
         );
     }
 

--- a/src/main/java/de/fhdw/webshop/affiliate/AffiliateTier.java
+++ b/src/main/java/de/fhdw/webshop/affiliate/AffiliateTier.java
@@ -1,0 +1,42 @@
+package de.fhdw.webshop.affiliate;
+
+import java.math.BigDecimal;
+
+public enum AffiliateTier {
+
+    TIER_1(new BigDecimal("0.0500"), new BigDecimal("50000")),
+    TIER_2(new BigDecimal("0.0250"), new BigDecimal("10000")),
+    TIER_3(new BigDecimal("0.0100"), BigDecimal.ZERO);
+
+    private final BigDecimal defaultRate;
+    private final BigDecimal minRevenue;
+
+    AffiliateTier(BigDecimal defaultRate, BigDecimal minRevenue) {
+        this.defaultRate = defaultRate;
+        this.minRevenue = minRevenue;
+    }
+
+    public BigDecimal getDefaultRate() {
+        return defaultRate;
+    }
+
+    public BigDecimal getMinRevenue() {
+        return minRevenue;
+    }
+
+    /** Derive tier from total generated revenue (sum of purchaseAmounts). */
+    public static AffiliateTier fromRevenue(BigDecimal totalRevenue) {
+        if (totalRevenue == null) return TIER_3;
+        if (totalRevenue.compareTo(TIER_1.minRevenue) >= 0) return TIER_1;
+        if (totalRevenue.compareTo(TIER_2.minRevenue) >= 0) return TIER_2;
+        return TIER_3;
+    }
+
+    /** Derive display tier from a commission rate (used for manual overrides). */
+    public static AffiliateTier fromRate(BigDecimal rate) {
+        if (rate == null) return TIER_3;
+        if (rate.compareTo(TIER_1.defaultRate) >= 0) return TIER_1;
+        if (rate.compareTo(TIER_2.defaultRate) >= 0) return TIER_2;
+        return TIER_3;
+    }
+}

--- a/src/main/java/de/fhdw/webshop/affiliate/dto/AdminAffiliateListItem.java
+++ b/src/main/java/de/fhdw/webshop/affiliate/dto/AdminAffiliateListItem.java
@@ -8,6 +8,7 @@ public record AdminAffiliateListItem(
         String username,
         String email,
         BigDecimal commissionRate,
+        String tier,
         long totalLinks,
         long totalClicks,
         long totalConversions,

--- a/src/main/java/de/fhdw/webshop/affiliate/dto/AffiliateDashboardStats.java
+++ b/src/main/java/de/fhdw/webshop/affiliate/dto/AffiliateDashboardStats.java
@@ -8,5 +8,7 @@ public record AffiliateDashboardStats(
         BigDecimal totalRevenue,
         BigDecimal confirmedEarnings,
         BigDecimal pendingEarnings,
-        long activeLinksCount
+        long activeLinksCount,
+        String tier,
+        BigDecimal nextTierRevenue
 ) {}

--- a/src/main/resources/db/migration/V104__add_tier_to_affiliate_profiles.sql
+++ b/src/main/resources/db/migration/V104__add_tier_to_affiliate_profiles.sql
@@ -1,0 +1,19 @@
+ALTER TABLE affiliate_profiles
+    ADD COLUMN tier VARCHAR(20) NOT NULL DEFAULT 'TIER_3';
+
+UPDATE affiliate_profiles ap
+SET tier = CASE
+    WHEN (
+        SELECT COALESCE(SUM(ac.purchase_amount), 0)
+        FROM affiliate_conversions ac
+        JOIN affiliate_links al ON ac.affiliate_link_id = al.id
+        WHERE al.affiliate_profile_id = ap.id
+    ) >= 50000 THEN 'TIER_1'
+    WHEN (
+        SELECT COALESCE(SUM(ac.purchase_amount), 0)
+        FROM affiliate_conversions ac
+        JOIN affiliate_links al ON ac.affiliate_link_id = al.id
+        WHERE al.affiliate_profile_id = ap.id
+    ) >= 10000 THEN 'TIER_2'
+    ELSE 'TIER_3'
+END;


### PR DESCRIPTION
Tier rules:
- Tier 1: total sales >= 50,000 EUR -> 5% commission
- Tier 2: total sales >= 10,000 EUR -> 2.5% commission
- Tier 3: total sales < 10,000 EUR  -> 1% commission

Changes:
- AffiliateTier enum with defaultRate and minRevenue per tier
- AffiliateProfile.tier field (persisted as VARCHAR)
- V104 migration adds tier column and backfills existing profiles
- AffiliateService: recalculateTierAndRate() called on each new conversion; updateCommissionRate() derives tier from manual input via AffiliateTier.fromRate() without changing the entered rate
- AdminAffiliateListItem and AffiliateDashboardStats carry tier name and nextTierRevenue for UI display