### PR TITLE
feat(#374): add marketplace dispute backend

### DIFF
--- a/src/main/java/de/fhdw/webshop/admin/AdminController.java
+++ b/src/main/java/de/fhdw/webshop/admin/AdminController.java
@@ -246,7 +246,7 @@ public class AdminController {
         User targetUser = userRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("User not found: " + id));
         if (adminUser.getId().equals(targetUser.getId())) {
-            throw new IllegalArgumentException("Administratoren koennen ihr eigenes Konto nicht deaktivieren.");
+            throw new IllegalArgumentException("Administratoren können ihr eigenes Konto nicht deaktivieren.");
         }
 
         if (targetUser.isActive()) {
@@ -266,7 +266,7 @@ public class AdminController {
                 .orElseThrow(() -> new EntityNotFoundException("User not found: " + id));
         if (targetUser.getUsername().startsWith("deleted_")
                 && targetUser.getEmail().endsWith("@deleted.invalid")) {
-            throw new IllegalArgumentException("Geloeschte Benutzerkonten koennen nicht reaktiviert werden.");
+            throw new IllegalArgumentException("Geloeschte Benutzerkonten können nicht reaktiviert werden.");
         }
 
         if (!targetUser.isActive()) {
@@ -286,7 +286,7 @@ public class AdminController {
         User targetUser = userRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("User not found: " + id));
         if (adminUser.getId().equals(targetUser.getId())) {
-            throw new IllegalArgumentException("Administratoren koennen ihr eigenes Konto nicht loeschen.");
+            throw new IllegalArgumentException("Administratoren können ihr eigenes Konto nicht loeschen.");
         }
         String deletedUsername = targetUser.getUsername();
         accountLinkService.removeLinksForUser(id);
@@ -335,10 +335,10 @@ public class AdminController {
                 .orElseThrow(() -> new EntityNotFoundException("User not found: " + userId));
 
         if (!targetUser.isActive()) {
-            throw new IllegalArgumentException("Deaktivierte Benutzerkonten koennen nicht impersoniert werden.");
+            throw new IllegalArgumentException("Deaktivierte Benutzerkonten können nicht impersoniert werden.");
         }
         if (targetUser.hasRole(UserRole.ADMIN)) {
-            throw new IllegalArgumentException("Administratoren koennen keine Administrator-Identitaet annehmen.");
+            throw new IllegalArgumentException("Administratoren können keine Administrator-Identitaet annehmen.");
         }
 
         String impersonationToken = jwtTokenProvider.generateImpersonationToken(targetUser, adminUser);

--- a/src/main/java/de/fhdw/webshop/admin/statistics/alerting/StatisticAlertService.java
+++ b/src/main/java/de/fhdw/webshop/admin/statistics/alerting/StatisticAlertService.java
@@ -194,8 +194,8 @@ public class StatisticAlertService {
     }
 
     private static String buildReason(StatisticAlertThreshold threshold, BigDecimal deviationPercent) {
-        String direction = deviationPercent.signum() >= 0 ? "ueber" : "unter";
-        return "%s liegt um %s%% %s dem Vergleichszeitraum und ueberschreitet den Schwellwert von %s%%."
+        String direction = deviationPercent.signum() >= 0 ? "über" : "unter";
+        return "%s liegt um %s%% %s dem Vergleichszeitraum und überschreitet den Schwellwert von %s%%."
                 .formatted(
                         threshold.getMetric().getLabel(),
                         deviationPercent.abs().setScale(2, RoundingMode.HALF_UP),
@@ -214,7 +214,7 @@ public class StatisticAlertService {
         if (request.deviationPercent() == null
                 || request.deviationPercent().compareTo(BigDecimal.ZERO) <= 0
                 || request.deviationPercent().compareTo(MAX_THRESHOLD_PERCENT) > 0) {
-            throw new IllegalArgumentException("Der Schwellwert muss groesser als 0 und maximal 1000 Prozent sein.");
+            throw new IllegalArgumentException("Der Schwellwert muss größer als 0 und maximal 1000 Prozent sein.");
         }
     }
 

--- a/src/main/java/de/fhdw/webshop/auth/AuthService.java
+++ b/src/main/java/de/fhdw/webshop/auth/AuthService.java
@@ -45,7 +45,7 @@ public class AuthService {
     @Transactional
     public AuthResponse register(RegisterRequest registerRequest) {
         if (registerRequest.userType() == UserType.INTERNAL) {
-            throw new IllegalArgumentException("Interne Benutzer koennen nur durch Administratoren angelegt werden.");
+            throw new IllegalArgumentException("Interne Benutzer können nur durch Administratoren angelegt werden.");
         }
         if (userRepository.existsByUsername(registerRequest.username())) {
             throw new IllegalArgumentException("Username already taken: " + registerRequest.username());

--- a/src/main/java/de/fhdw/webshop/customer/CustomerController.java
+++ b/src/main/java/de/fhdw/webshop/customer/CustomerController.java
@@ -366,7 +366,7 @@ public class CustomerController {
     private User loadCustomerById(Long id) {
         User customer = userService.loadById(id);
         if (!isCustomer(customer)) {
-            throw new IllegalArgumentException("Dieser Endpunkt gilt nur fuer Kundenkonten.");
+            throw new IllegalArgumentException("Dieser Endpunkt gilt nur für Kundenkonten.");
         }
         return customer;
     }
@@ -438,7 +438,7 @@ public class CustomerController {
         }
 
         if (latestOrderAt != null && latestOrderAt.isBefore(Instant.now().minus(90, ChronoUnit.DAYS))) {
-            return "Der Kunde war frueher aktiv, hat aber seit ueber 90 Tagen keine Bestellung mehr abgeschlossen.";
+            return "Der Kunde war früher aktiv, hat aber seit über 90 Tagen keine Bestellung mehr abgeschlossen.";
         }
 
         if (businessCustomer) {
@@ -446,7 +446,7 @@ public class CustomerController {
         }
 
         if (hasActivePromotion) {
-            return "Es laufen bereits Vertriebsmassnahmen. Jetzt ist ein guter Zeitpunkt fuer eine konkrete Nachfassaktion.";
+            return "Es laufen bereits Vertriebsmaßnahmen. Jetzt ist ein guter Zeitpunkt für eine konkrete Nachfassaktion.";
         }
 
         return "Der Kunde zeigt ein stabiles Kaufverhalten und kann gezielt mit passenden Artikeln oder Serviceangeboten angesprochen werden.";

--- a/src/main/java/de/fhdw/webshop/marketplacedispute/MarketplaceDispute.java
+++ b/src/main/java/de/fhdw/webshop/marketplacedispute/MarketplaceDispute.java
@@ -1,0 +1,94 @@
+package de.fhdw.webshop.marketplacedispute;
+
+import de.fhdw.webshop.order.Order;
+import de.fhdw.webshop.order.OrderItem;
+import de.fhdw.webshop.user.User;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "marketplace_disputes")
+@Getter
+@Setter
+@NoArgsConstructor
+public class MarketplaceDispute {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "order_item_id", nullable = false)
+    private OrderItem orderItem;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "customer_id", nullable = false)
+    private User customer;
+
+    @Column(name = "seller_name", nullable = false, length = 180)
+    private String sellerName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 40)
+    private MarketplaceDisputeReason reason;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 40)
+    private MarketplaceDisputeStatus status = MarketplaceDisputeStatus.OPEN;
+
+    @Column(length = 2000)
+    private String description;
+
+    @Column(name = "payout_blocked", nullable = false)
+    private boolean payoutBlocked = true;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @Column(name = "resolved_at")
+    private Instant resolvedAt;
+
+    @OneToMany(mappedBy = "dispute", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MarketplaceDisputeHistory> history = new ArrayList<>();
+
+    @OneToMany(mappedBy = "dispute", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MarketplaceDisputeImage> images = new ArrayList<>();
+
+    @PrePersist
+    void onCreate() {
+        Instant now = Instant.now();
+        createdAt = now;
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        updatedAt = Instant.now();
+    }
+}

--- a/src/main/java/de/fhdw/webshop/marketplacedispute/MarketplaceDisputeController.java
+++ b/src/main/java/de/fhdw/webshop/marketplacedispute/MarketplaceDisputeController.java
@@ -1,0 +1,88 @@
+package de.fhdw.webshop.marketplacedispute;
+
+import de.fhdw.webshop.marketplacedispute.dto.CreateMarketplaceDisputeRequest;
+import de.fhdw.webshop.marketplacedispute.dto.MarketplaceDisputeResponse;
+import de.fhdw.webshop.marketplacedispute.dto.MarketplaceDisputeStatusUpdateRequest;
+import de.fhdw.webshop.user.User;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MarketplaceDisputeController {
+
+    private final MarketplaceDisputeService disputeService;
+
+    @PostMapping("/api/orders/{orderId}/items/{orderItemId}/disputes")
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public ResponseEntity<MarketplaceDisputeResponse> createDispute(
+            @AuthenticationPrincipal User customer,
+            @PathVariable Long orderId,
+            @PathVariable Long orderItemId,
+            @Valid @RequestBody CreateMarketplaceDisputeRequest request
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(disputeService.createDispute(customer, orderId, orderItemId, request));
+    }
+
+    @GetMapping("/api/customers/me/disputes")
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public ResponseEntity<List<MarketplaceDisputeResponse>> listMyDisputes(@AuthenticationPrincipal User customer) {
+        return ResponseEntity.ok(disputeService.listCustomerDisputes(customer));
+    }
+
+    @GetMapping("/api/orders/{orderId}/disputes")
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public ResponseEntity<List<MarketplaceDisputeResponse>> listOrderDisputes(
+            @AuthenticationPrincipal User customer,
+            @PathVariable Long orderId
+    ) {
+        return ResponseEntity.ok(disputeService.listCustomerOrderDisputes(customer, orderId));
+    }
+
+    @GetMapping("/api/seller-portal/disputes")
+    @PreAuthorize("hasRole('SELLER')")
+    public ResponseEntity<List<MarketplaceDisputeResponse>> listSellerDisputes(@AuthenticationPrincipal User seller) {
+        return ResponseEntity.ok(disputeService.listSellerDisputes(seller));
+    }
+
+    @GetMapping("/api/seller-portal/disputes/{disputeId}")
+    @PreAuthorize("hasRole('SELLER')")
+    public ResponseEntity<MarketplaceDisputeResponse> getSellerDispute(
+            @AuthenticationPrincipal User seller,
+            @PathVariable Long disputeId
+    ) {
+        return ResponseEntity.ok(disputeService.getSellerDispute(seller, disputeId));
+    }
+
+    @GetMapping("/api/admin/disputes")
+    @PreAuthorize("hasAnyRole('EMPLOYEE','SALES_EMPLOYEE','ADMIN')")
+    public ResponseEntity<List<MarketplaceDisputeResponse>> listAdminDisputes(
+            @RequestParam(required = false) MarketplaceDisputeStatus status
+    ) {
+        return ResponseEntity.ok(disputeService.listAdminDisputes(status));
+    }
+
+    @PatchMapping("/api/admin/disputes/{disputeId}/status")
+    @PreAuthorize("hasAnyRole('EMPLOYEE','SALES_EMPLOYEE','ADMIN')")
+    public ResponseEntity<MarketplaceDisputeResponse> updateStatus(
+            @AuthenticationPrincipal User employee,
+            @PathVariable Long disputeId,
+            @Valid @RequestBody MarketplaceDisputeStatusUpdateRequest request
+    ) {
+        return ResponseEntity.ok(disputeService.updateStatus(employee, disputeId, request));
+    }
+}

--- a/src/main/java/de/fhdw/webshop/marketplacedispute/MarketplaceDisputeHistory.java
+++ b/src/main/java/de/fhdw/webshop/marketplacedispute/MarketplaceDisputeHistory.java
@@ -1,0 +1,51 @@
+package de.fhdw.webshop.marketplacedispute;
+
+import de.fhdw.webshop.user.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "marketplace_dispute_history")
+@Getter
+@Setter
+@NoArgsConstructor
+public class MarketplaceDisputeHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "dispute_id", nullable = false)
+    private MarketplaceDispute dispute;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 40)
+    private MarketplaceDisputeStatus status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "changed_by_id")
+    private User changedBy;
+
+    @Column(name = "changed_by_username", length = 120)
+    private String changedByUsername;
+
+    @Column(name = "changed_at", nullable = false)
+    private Instant changedAt = Instant.now();
+
+    @Column(length = 1000)
+    private String note;
+}

--- a/src/main/java/de/fhdw/webshop/marketplacedispute/MarketplaceDisputeImage.java
+++ b/src/main/java/de/fhdw/webshop/marketplacedispute/MarketplaceDisputeImage.java
@@ -1,0 +1,37 @@
+package de.fhdw.webshop.marketplacedispute;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "marketplace_dispute_images")
+@Getter
+@Setter
+@NoArgsConstructor
+public class MarketplaceDisputeImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "dispute_id", nullable = false)
+    private MarketplaceDispute dispute;
+
+    @Column(name = "image_url", nullable = false, length = 1000)
+    private String imageUrl;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt = Instant.now();
+}

--- a/src/main/java/de/fhdw/webshop/marketplacedispute/MarketplaceDisputeReason.java
+++ b/src/main/java/de/fhdw/webshop/marketplacedispute/MarketplaceDisputeReason.java
@@ -1,0 +1,9 @@
+package de.fhdw.webshop.marketplacedispute;
+
+public enum MarketplaceDisputeReason {
+    DAMAGED_ITEM,
+    WRONG_ITEM,
+    ITEM_NOT_RECEIVED,
+    SELLER_PROBLEM,
+    OTHER
+}

--- a/src/main/java/de/fhdw/webshop/marketplacedispute/MarketplaceDisputeRepository.java
+++ b/src/main/java/de/fhdw/webshop/marketplacedispute/MarketplaceDisputeRepository.java
@@ -1,0 +1,32 @@
+package de.fhdw.webshop.marketplacedispute;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MarketplaceDisputeRepository extends JpaRepository<MarketplaceDispute, Long> {
+
+    @EntityGraph(attributePaths = {"order", "orderItem", "orderItem.product", "customer"})
+    List<MarketplaceDispute> findByCustomerIdOrderByCreatedAtDesc(Long customerId);
+
+    @EntityGraph(attributePaths = {"order", "orderItem", "orderItem.product", "customer"})
+    List<MarketplaceDispute> findByOrderIdAndCustomerIdOrderByCreatedAtDesc(Long orderId, Long customerId);
+
+    @EntityGraph(attributePaths = {"order", "orderItem", "orderItem.product", "customer"})
+    List<MarketplaceDispute> findBySellerNameIgnoreCaseOrderByCreatedAtDesc(String sellerName);
+
+    @EntityGraph(attributePaths = {"order", "orderItem", "orderItem.product", "customer"})
+    List<MarketplaceDispute> findAllByOrderByCreatedAtDesc();
+
+    @EntityGraph(attributePaths = {"order", "orderItem", "orderItem.product", "customer"})
+    Optional<MarketplaceDispute> findByIdAndCustomerId(Long id, Long customerId);
+
+    @EntityGraph(attributePaths = {"order", "orderItem", "orderItem.product", "customer"})
+    Optional<MarketplaceDispute> findByIdAndSellerNameIgnoreCase(Long id, String sellerName);
+
+    boolean existsByOrderItemIdAndStatusIn(Long orderItemId, Collection<MarketplaceDisputeStatus> statuses);
+
+    List<MarketplaceDispute> findBySellerNameIgnoreCaseAndStatusIn(String sellerName, Collection<MarketplaceDisputeStatus> statuses);
+}

--- a/src/main/java/de/fhdw/webshop/marketplacedispute/MarketplaceDisputeService.java
+++ b/src/main/java/de/fhdw/webshop/marketplacedispute/MarketplaceDisputeService.java
@@ -1,0 +1,222 @@
+package de.fhdw.webshop.marketplacedispute;
+
+import de.fhdw.webshop.marketplacedispute.dto.CreateMarketplaceDisputeRequest;
+import de.fhdw.webshop.marketplacedispute.dto.MarketplaceDisputeHistoryResponse;
+import de.fhdw.webshop.marketplacedispute.dto.MarketplaceDisputeResponse;
+import de.fhdw.webshop.marketplacedispute.dto.MarketplaceDisputeStatusUpdateRequest;
+import de.fhdw.webshop.order.Order;
+import de.fhdw.webshop.order.OrderItem;
+import de.fhdw.webshop.order.OrderRepository;
+import de.fhdw.webshop.order.OrderStatus;
+import de.fhdw.webshop.sellerportal.SellerProfileRepository;
+import de.fhdw.webshop.user.User;
+import jakarta.persistence.EntityNotFoundException;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MarketplaceDisputeService {
+
+    private static final String WEBSHOP_SELLER_NAME = "Webshop";
+    private static final Set<MarketplaceDisputeStatus> ACTIVE_STATUSES =
+            Set.of(MarketplaceDisputeStatus.OPEN, MarketplaceDisputeStatus.UNDER_REVIEW);
+
+    private final MarketplaceDisputeRepository disputeRepository;
+    private final OrderRepository orderRepository;
+    private final SellerProfileRepository sellerProfileRepository;
+
+    @Transactional
+    public MarketplaceDisputeResponse createDispute(
+            User customer,
+            Long orderId,
+            Long orderItemId,
+            CreateMarketplaceDisputeRequest request
+    ) {
+        Order order = orderRepository.findByIdAndCustomerId(orderId, customer.getId())
+                .orElseThrow(() -> new EntityNotFoundException("Bestellung nicht gefunden: " + orderId));
+        if (order.getStatus() != OrderStatus.DELIVERED) {
+            throw new IllegalArgumentException("Konfliktfälle können erst für gelieferte Marketplace-Bestellungen eröffnet werden.");
+        }
+
+        OrderItem orderItem = order.getItems().stream()
+                .filter(item -> item.getId().equals(orderItemId))
+                .findFirst()
+                .orElseThrow(() -> new EntityNotFoundException("Bestellposition nicht gefunden: " + orderItemId));
+        String sellerName = resolveSellerName(orderItem);
+        if (!isMarketplaceSeller(sellerName)) {
+            throw new IllegalArgumentException("Konfliktfälle sind nur für Drittanbieter-Artikel möglich.");
+        }
+        if (disputeRepository.existsByOrderItemIdAndStatusIn(orderItemId, ACTIVE_STATUSES)) {
+            throw new IllegalStateException("Für diese Bestellposition existiert bereits ein offener Konfliktfall.");
+        }
+
+        MarketplaceDispute dispute = new MarketplaceDispute();
+        dispute.setOrder(order);
+        dispute.setOrderItem(orderItem);
+        dispute.setCustomer(customer);
+        dispute.setSellerName(sellerName);
+        dispute.setReason(request.reason());
+        dispute.setStatus(MarketplaceDisputeStatus.OPEN);
+        dispute.setDescription(blankToNull(request.description()));
+        dispute.setPayoutBlocked(true);
+
+        for (String imageUrl : normalizeImageUrls(request.imageUrls())) {
+            MarketplaceDisputeImage image = new MarketplaceDisputeImage();
+            image.setDispute(dispute);
+            image.setImageUrl(imageUrl);
+            dispute.getImages().add(image);
+        }
+
+        addHistory(dispute, MarketplaceDisputeStatus.OPEN, customer, "Konfliktfall durch Kunden eröffnet.");
+        return toResponse(disputeRepository.save(dispute));
+    }
+
+    @Transactional(readOnly = true)
+    public List<MarketplaceDisputeResponse> listCustomerDisputes(User customer) {
+        return disputeRepository.findByCustomerIdOrderByCreatedAtDesc(customer.getId()).stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<MarketplaceDisputeResponse> listCustomerOrderDisputes(User customer, Long orderId) {
+        return disputeRepository.findByOrderIdAndCustomerIdOrderByCreatedAtDesc(orderId, customer.getId()).stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<MarketplaceDisputeResponse> listSellerDisputes(User sellerUser) {
+        String sellerName = requireSellerDisplayName(sellerUser);
+        return disputeRepository.findBySellerNameIgnoreCaseOrderByCreatedAtDesc(sellerName).stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public MarketplaceDisputeResponse getSellerDispute(User sellerUser, Long disputeId) {
+        String sellerName = requireSellerDisplayName(sellerUser);
+        return disputeRepository.findByIdAndSellerNameIgnoreCase(disputeId, sellerName)
+                .map(this::toResponse)
+                .orElseThrow(() -> new EntityNotFoundException("Konfliktfall nicht gefunden: " + disputeId));
+    }
+
+    @Transactional(readOnly = true)
+    public List<MarketplaceDisputeResponse> listAdminDisputes(MarketplaceDisputeStatus status) {
+        return disputeRepository.findAllByOrderByCreatedAtDesc().stream()
+                .filter(dispute -> status == null || dispute.getStatus() == status)
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Transactional
+    public MarketplaceDisputeResponse updateStatus(
+            User employee,
+            Long disputeId,
+            MarketplaceDisputeStatusUpdateRequest request
+    ) {
+        MarketplaceDispute dispute = disputeRepository.findById(disputeId)
+                .orElseThrow(() -> new EntityNotFoundException("Konfliktfall nicht gefunden: " + disputeId));
+        MarketplaceDisputeStatus status = request.status();
+        dispute.setStatus(status);
+        dispute.setPayoutBlocked(ACTIVE_STATUSES.contains(status));
+        if (!ACTIVE_STATUSES.contains(status)) {
+            dispute.setResolvedAt(Instant.now());
+        } else {
+            dispute.setResolvedAt(null);
+        }
+        addHistory(dispute, status, employee, blankToNull(request.note()));
+        return toResponse(disputeRepository.save(dispute));
+    }
+
+    public boolean isMarketplaceSeller(String sellerName) {
+        return sellerName != null && !sellerName.isBlank() && !WEBSHOP_SELLER_NAME.equalsIgnoreCase(sellerName.trim());
+    }
+
+    private String resolveSellerName(OrderItem orderItem) {
+        String sellerName = blankToNull(orderItem.getSellerName());
+        if (sellerName != null) {
+            return sellerName;
+        }
+        if (orderItem.getProduct() != null) {
+            return blankToNull(orderItem.getProduct().getSellerName());
+        }
+        return WEBSHOP_SELLER_NAME;
+    }
+
+    private String requireSellerDisplayName(User sellerUser) {
+        return sellerProfileRepository.findByUserId(sellerUser.getId())
+                .orElseThrow(() -> new EntityNotFoundException("Kein aktives Verkaeuferprofil gefunden."))
+                .getDisplayName();
+    }
+
+    private void addHistory(MarketplaceDispute dispute, MarketplaceDisputeStatus status, User user, String note) {
+        MarketplaceDisputeHistory history = new MarketplaceDisputeHistory();
+        history.setDispute(dispute);
+        history.setStatus(status);
+        history.setChangedBy(user);
+        history.setChangedByUsername(user == null ? "System" : user.getUsername());
+        history.setNote(note);
+        dispute.getHistory().add(history);
+    }
+
+    private List<String> normalizeImageUrls(List<String> imageUrls) {
+        if (imageUrls == null) {
+            return List.of();
+        }
+        return imageUrls.stream()
+                .map(this::blankToNull)
+                .filter(value -> value != null)
+                .distinct()
+                .limit(3)
+                .toList();
+    }
+
+    private MarketplaceDisputeResponse toResponse(MarketplaceDispute dispute) {
+        OrderItem item = dispute.getOrderItem();
+        return new MarketplaceDisputeResponse(
+                dispute.getId(),
+                dispute.getOrder().getId(),
+                dispute.getOrder().getOrderNumber(),
+                item.getId(),
+                item.getProduct().getId(),
+                item.getProduct().getName(),
+                dispute.getOrder().getCustomerName() == null ? dispute.getCustomer().getUsername() : dispute.getOrder().getCustomerName(),
+                dispute.getSellerName(),
+                dispute.getReason(),
+                dispute.getStatus(),
+                dispute.getDescription(),
+                dispute.isPayoutBlocked(),
+                dispute.getCreatedAt(),
+                dispute.getUpdatedAt(),
+                dispute.getResolvedAt(),
+                dispute.getImages().stream()
+                        .sorted(Comparator.comparing(MarketplaceDisputeImage::getId))
+                        .map(MarketplaceDisputeImage::getImageUrl)
+                        .toList(),
+                dispute.getHistory().stream()
+                        .sorted(Comparator.comparing(MarketplaceDisputeHistory::getChangedAt))
+                        .map(history -> new MarketplaceDisputeHistoryResponse(
+                                history.getId(),
+                                history.getStatus(),
+                                history.getChangedByUsername(),
+                                history.getChangedAt(),
+                                history.getNote()))
+                        .toList()
+        );
+    }
+
+    private String blankToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/src/main/java/de/fhdw/webshop/marketplacedispute/MarketplaceDisputeStatus.java
+++ b/src/main/java/de/fhdw/webshop/marketplacedispute/MarketplaceDisputeStatus.java
@@ -1,0 +1,8 @@
+package de.fhdw.webshop.marketplacedispute;
+
+public enum MarketplaceDisputeStatus {
+    OPEN,
+    UNDER_REVIEW,
+    RESOLVED,
+    REJECTED
+}

--- a/src/main/java/de/fhdw/webshop/marketplacedispute/dto/CreateMarketplaceDisputeRequest.java
+++ b/src/main/java/de/fhdw/webshop/marketplacedispute/dto/CreateMarketplaceDisputeRequest.java
@@ -1,0 +1,18 @@
+package de.fhdw.webshop.marketplacedispute.dto;
+
+import de.fhdw.webshop.marketplacedispute.MarketplaceDisputeReason;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record CreateMarketplaceDisputeRequest(
+        @NotNull(message = "Bitte einen Konfliktgrund auswaehlen.")
+        MarketplaceDisputeReason reason,
+
+        @Size(max = 2000, message = "Die Beschreibung darf maximal 2000 Zeichen lang sein.")
+        String description,
+
+        @Size(max = 3, message = "Es duerfen maximal 3 Nachweisbilder hinterlegt werden.")
+        List<@Size(max = 1000, message = "Eine Bildreferenz darf maximal 1000 Zeichen lang sein.") String> imageUrls
+) {
+}

--- a/src/main/java/de/fhdw/webshop/marketplacedispute/dto/MarketplaceDisputeHistoryResponse.java
+++ b/src/main/java/de/fhdw/webshop/marketplacedispute/dto/MarketplaceDisputeHistoryResponse.java
@@ -1,0 +1,13 @@
+package de.fhdw.webshop.marketplacedispute.dto;
+
+import de.fhdw.webshop.marketplacedispute.MarketplaceDisputeStatus;
+import java.time.Instant;
+
+public record MarketplaceDisputeHistoryResponse(
+        Long id,
+        MarketplaceDisputeStatus status,
+        String changedBy,
+        Instant changedAt,
+        String note
+) {
+}

--- a/src/main/java/de/fhdw/webshop/marketplacedispute/dto/MarketplaceDisputeResponse.java
+++ b/src/main/java/de/fhdw/webshop/marketplacedispute/dto/MarketplaceDisputeResponse.java
@@ -1,0 +1,27 @@
+package de.fhdw.webshop.marketplacedispute.dto;
+
+import de.fhdw.webshop.marketplacedispute.MarketplaceDisputeReason;
+import de.fhdw.webshop.marketplacedispute.MarketplaceDisputeStatus;
+import java.time.Instant;
+import java.util.List;
+
+public record MarketplaceDisputeResponse(
+        Long id,
+        Long orderId,
+        String orderNumber,
+        Long orderItemId,
+        Long productId,
+        String productName,
+        String customerName,
+        String sellerName,
+        MarketplaceDisputeReason reason,
+        MarketplaceDisputeStatus status,
+        String description,
+        boolean payoutBlocked,
+        Instant createdAt,
+        Instant updatedAt,
+        Instant resolvedAt,
+        List<String> imageUrls,
+        List<MarketplaceDisputeHistoryResponse> history
+) {
+}

--- a/src/main/java/de/fhdw/webshop/marketplacedispute/dto/MarketplaceDisputeStatusUpdateRequest.java
+++ b/src/main/java/de/fhdw/webshop/marketplacedispute/dto/MarketplaceDisputeStatusUpdateRequest.java
@@ -1,0 +1,14 @@
+package de.fhdw.webshop.marketplacedispute.dto;
+
+import de.fhdw.webshop.marketplacedispute.MarketplaceDisputeStatus;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record MarketplaceDisputeStatusUpdateRequest(
+        @NotNull(message = "Bitte einen Status auswaehlen.")
+        MarketplaceDisputeStatus status,
+
+        @Size(max = 1000, message = "Die Notiz darf maximal 1000 Zeichen lang sein.")
+        String note
+) {
+}

--- a/src/main/java/de/fhdw/webshop/order/OrderService.java
+++ b/src/main/java/de/fhdw/webshop/order/OrderService.java
@@ -153,7 +153,7 @@ public class OrderService {
                 .orElseThrow(() -> new EntityNotFoundException("Order not found: " + orderId));
 
         if (!canCustomerCancel(order)) {
-            throw new IllegalArgumentException("Bestellungen koennen nur im Status Aufgegeben storniert werden.");
+            throw new IllegalArgumentException("Bestellungen können nur im Status Aufgegeben storniert werden.");
         }
 
         restoreReservedStock(order);
@@ -162,7 +162,7 @@ public class OrderService {
 
         auditLogService.record(customer, "CANCEL_ORDER", "Order", savedOrder.getId(),
                 AuditInitiator.USER,
-                "Status geaendert auf Storniert fuer Bestellung " + savedOrder.getOrderNumber());
+                "Status geaendert auf Storniert für Bestellung " + savedOrder.getOrderNumber());
         triggerRefundIfRequired(savedOrder, customer);
 
         return toResponse(savedOrder);
@@ -512,7 +512,7 @@ public class OrderService {
                     requestedItem.cartItemId(),
                     product.getId(),
                     requestedItem.quantity())) {
-                throw new IllegalArgumentException("Die Reservierung fuer " + product.getName()
+                throw new IllegalArgumentException("Die Reservierung für " + product.getName()
                         + " ist abgelaufen. Bitte aktualisiere deinen Warenkorb.");
             }
             String personalizationText = normalizePersonalizationText(product, requestedItem.personalizationText());
@@ -1091,7 +1091,7 @@ public class OrderService {
 
         auditLogService.record(customer, "ORDER_REFUND_TRIGGERED", "Order", order.getId(),
                 AuditInitiator.SYSTEM,
-                "Automatische Rueckerstattung fuer " + order.getPaymentMethodType()
+                "Automatische Rueckerstattung für " + order.getPaymentMethodType()
                         + " angestossen, Betrag=" + order.getTotalPrice());
     }
 
@@ -1355,7 +1355,7 @@ public class OrderService {
 
     private boolean sendOrderConfirmation(Order order) {
         StringBuilder body = new StringBuilder()
-                .append("Vielen Dank fuer deine Bestellung.\n\n")
+                .append("Vielen Dank für deine Bestellung.\n\n")
                 .append("Bestellnummer: ").append(order.getOrderNumber()).append('\n')
                 .append("Gesamtbetrag: ").append(order.getTotalPrice()).append(" EUR\n");
 

--- a/src/main/java/de/fhdw/webshop/product/ProductService.java
+++ b/src/main/java/de/fhdw/webshop/product/ProductService.java
@@ -514,10 +514,10 @@ public class ProductService {
             return null;
         }
         if (personalizationMaxLength == null || personalizationMaxLength <= 0) {
-            throw new IllegalArgumentException("Die maximale Zeichenlaenge fuer Personalisierung muss groesser als 0 sein.");
+            throw new IllegalArgumentException("Die maximale Zeichenlaenge für Personalisierung muss größer als 0 sein.");
         }
         if (personalizationMaxLength > 1000) {
-            throw new IllegalArgumentException("Die maximale Zeichenlaenge fuer Personalisierung darf hoechstens 1000 betragen.");
+            throw new IllegalArgumentException("Die maximale Zeichenlaenge für Personalisierung darf hoechstens 1000 betragen.");
         }
         return personalizationMaxLength;
     }

--- a/src/main/java/de/fhdw/webshop/quote/QuoteRequestService.java
+++ b/src/main/java/de/fhdw/webshop/quote/QuoteRequestService.java
@@ -166,13 +166,13 @@ public class QuoteRequestService {
             throw new IllegalArgumentException("Der Artikel " + product.getName() + " ist aktuell nicht bestellbar.");
         }
         if (product.getProductType() != ProductType.DIGITAL_GIFT_CARD && product.getStock() < quantity) {
-            throw new IllegalArgumentException("Der Bestand reicht fuer " + product.getName() + " nicht aus.");
+            throw new IllegalArgumentException("Der Bestand reicht für " + product.getName() + " nicht aus.");
         }
     }
 
     private void requireBusinessCustomer(User user) {
         if (user == null || user.getUserType() != UserType.BUSINESS) {
-            throw new IllegalArgumentException("Angebotsanforderungen sind nur fuer verifizierte B2B-Kunden verfuegbar.");
+            throw new IllegalArgumentException("Angebotsanforderungen sind nur für verifizierte B2B-Kunden verfuegbar.");
         }
     }
 
@@ -216,7 +216,7 @@ public class QuoteRequestService {
                 Gueltig bis: %s
                 Gesamtbetrag: %s
 
-                Das Angebot ist im Kundenkonto unter "Meine Angebote" abrufbar und kann innerhalb der Gueltigkeitsfrist wieder in den Warenkorb uebernommen werden.
+                Das Angebot ist im Kundenkonto unter "Meine Angebote" abrufbar und kann innerhalb der Gueltigkeitsfrist wieder in den Warenkorb übernommen werden.
                 """.formatted(
                 quoteRequest.getQuoteNumber(),
                 DATE_FORMATTER.format(quoteRequest.getValidUntil()),
@@ -298,7 +298,7 @@ public class QuoteRequestService {
         lines.add("Versand: " + formatMoney(quoteRequest.getShippingCost()));
         lines.add("Gesamtbetrag: " + formatMoney(quoteRequest.getTotalPrice()));
         lines.add("");
-        lines.add("Dieses Angebot kann innerhalb der Gueltigkeitsfrist im Kundenkonto in einen Warenkorb uebernommen werden.");
+        lines.add("Dieses Angebot kann innerhalb der Gueltigkeitsfrist im Kundenkonto in einen Warenkorb übernommen werden.");
         return PdfDocumentBuilder.build(lines);
     }
 

--- a/src/main/java/de/fhdw/webshop/recommendation/ProductRecommendationService.java
+++ b/src/main/java/de/fhdw/webshop/recommendation/ProductRecommendationService.java
@@ -51,7 +51,7 @@ public class ProductRecommendationService {
 
         List<ProductRecommendationItemResponse> aiRecommendations = requestAiRecommendations(
                 buildProductSystemPrompt(currentProduct, candidates, currentUser, resolvedLimit),
-                "Erzeuge passende Produktempfehlungen fuer die aktuelle Produktdetailseite.",
+                "Erzeuge passende Produktempfehlungen für die aktuelle Produktdetailseite.",
                 candidates,
                 resolvedLimit);
 
@@ -84,7 +84,7 @@ public class ProductRecommendationService {
 
         List<ProductRecommendationItemResponse> aiRecommendations = requestAiRecommendations(
                 buildCartSystemPrompt(cart, candidates, currentUser, resolvedLimit),
-                "Erzeuge passende Zusatzprodukte fuer den aktuellen Warenkorb.",
+                "Erzeuge passende Zusatzprodukte für den aktuellen Warenkorb.",
                 candidates,
                 resolvedLimit);
 
@@ -232,7 +232,7 @@ public class ProductRecommendationService {
                         product,
                         resolvedCategories.contains(product.category())
                                 ? "Ergaenzt die Kategorien aus Ihrem aktuellen Warenkorb."
-                                : "Sinnvolle Zusatzempfehlung fuer Ihren Einkauf.",
+                                : "Sinnvolle Zusatzempfehlung für Ihren Einkauf.",
                         "fallback"))
                 .toList();
     }
@@ -243,7 +243,7 @@ public class ProductRecommendationService {
             User currentUser,
             int limit) {
         StringBuilder builder = new StringBuilder("""
-                Du bist ein Empfehlungssystem fuer einen deutschen Webshop.
+                Du bist ein Empfehlungssystem für einen deutschen Webshop.
                 Antworte ausschliesslich mit JSON.
                 Format:
                 {
@@ -278,7 +278,7 @@ public class ProductRecommendationService {
             User currentUser,
             int limit) {
         StringBuilder builder = new StringBuilder("""
-                Du bist ein Empfehlungssystem fuer einen deutschen Webshop.
+                Du bist ein Empfehlungssystem für einen deutschen Webshop.
                 Antworte ausschliesslich mit JSON.
                 Format:
                 {
@@ -292,7 +292,7 @@ public class ProductRecommendationService {
                 - Waehle hoechstens %d Produkte aus.
                 - Nenne keine Produkte doppelt.
                 - Begruendungen muessen kurz, konkret und auf Deutsch sein.
-                - Empfiehl ergaenzende oder passende Zusatzprodukte fuer den Warenkorb.
+                - Empfiehl ergaenzende oder passende Zusatzprodukte für den Warenkorb.
                 """.formatted(limit));
 
         builder.append("\n[WARENKORB]\n");
@@ -354,7 +354,7 @@ public class ProductRecommendationService {
     }
 
     private String sanitizeReason(String reason) {
-        String normalized = defaultText(reason, "Passende Empfehlung fuer diesen Kontext.");
+        String normalized = defaultText(reason, "Passende Empfehlung für diesen Kontext.");
         return normalized.length() <= 140 ? normalized : normalized.substring(0, 137) + "...";
     }
 

--- a/src/main/java/de/fhdw/webshop/returnrequest/ReturnRequestService.java
+++ b/src/main/java/de/fhdw/webshop/returnrequest/ReturnRequestService.java
@@ -79,7 +79,7 @@ public class ReturnRequestService {
                 .orElseThrow(() -> new EntityNotFoundException("Order not found: " + request.orderId()));
 
         if (order.getStatus() != OrderStatus.DELIVERED) {
-            throw new IllegalStateException("Retouren koennen nur fuer zugestellte Bestellungen angemeldet werden.");
+            throw new IllegalStateException("Retouren können nur für zugestellte Bestellungen angemeldet werden.");
         }
 
         Instant deliveredAt = resolveDeliveredAt(order);
@@ -89,7 +89,7 @@ public class ReturnRequestService {
 
         List<RequestedReturnLine> requestedLines = normalizeRequestedLines(request, order);
         if (requestedLines.isEmpty()) {
-            throw new IllegalArgumentException("Bitte waehle mindestens einen Artikel fuer die Retoure aus.");
+            throw new IllegalArgumentException("Bitte waehle mindestens einen Artikel für die Retoure aus.");
         }
 
         Map<Long, OrderItem> orderItemsById = order.getItems().stream()
@@ -111,8 +111,8 @@ public class ReturnRequestService {
             int alreadyReturned = getActiveReturnedQuantity(orderItem.getId());
             int returnableQuantity = orderItem.getQuantity() - alreadyReturned;
             if (line.quantity() > returnableQuantity) {
-                throw new IllegalStateException("Fuer " + orderItem.getProduct().getName()
-                        + " koennen maximal " + Math.max(returnableQuantity, 0)
+                throw new IllegalStateException("Für " + orderItem.getProduct().getName()
+                        + " können maximal " + Math.max(returnableQuantity, 0)
                         + " Stueck retourniert werden.");
             }
             validateLineReason(line);
@@ -160,7 +160,7 @@ public class ReturnRequestService {
 
         ReturnRequest saved = returnRequestRepository.save(returnRequest);
         auditLogService.record(customer, "RETURN_REQUEST_CREATED", "ReturnRequest", saved.getId(),
-                AuditInitiator.USER, "Retoure " + saved.getId() + " fuer Bestellung "
+                AuditInitiator.USER, "Retoure " + saved.getId() + " für Bestellung "
                         + order.getOrderNumber() + " angemeldet.");
         return toResponse(saved);
     }
@@ -258,7 +258,7 @@ public class ReturnRequestService {
         if (returnRequest.getStatus() != ReturnRequestStatus.GOODS_RECEIVED
                 && returnRequest.getStatus() != ReturnRequestStatus.IN_REVIEW
                 && returnRequest.getStatus() != ReturnRequestStatus.APPROVED) {
-            throw new IllegalStateException("Ein Pruefvermerk ist erst nach dem Wareneingang moeglich.");
+            throw new IllegalStateException("Ein Pruefvermerk ist erst nach dem Wareneingang möglich.");
         }
 
         returnRequest.setInspectionCondition(request.condition());
@@ -266,7 +266,7 @@ public class ReturnRequestService {
 
         ReturnRequest saved = returnRequestRepository.save(returnRequest);
         auditLogService.recordSystemAction("RETURN_REQUEST_INSPECTED", "ReturnRequest", saved.getId(),
-                "Pruefvermerk fuer Retoure aktualisiert: " + request.condition());
+                "Pruefvermerk für Retoure aktualisiert: " + request.condition());
         return toResponse(saved);
     }
 
@@ -286,7 +286,7 @@ public class ReturnRequestService {
     public ReturnRequestResponse approveReturn(Long returnRequestId, User employee) {
         ReturnRequest returnRequest = loadReturnRequest(returnRequestId);
         if (returnRequest.getStatus() != ReturnRequestStatus.IN_REVIEW) {
-            throw new IllegalStateException("Nur Retouren in Pruefung koennen freigegeben werden.");
+            throw new IllegalStateException("Nur Retouren in Pruefung können freigegeben werden.");
         }
         returnRequest.setStatus(ReturnRequestStatus.APPROVED);
         returnRequest.setApprovedAt(Instant.now());
@@ -294,7 +294,7 @@ public class ReturnRequestService {
         returnRequest.setDecidedBy(employee);
         prepareRefund(returnRequest);
         return auditAndRespond(returnRequest, employee, "RETURN_REQUEST_APPROVED",
-                "Retoure freigegeben. Rueckerstattung fuer Fremdsystem vorbereitet: "
+                "Retoure freigegeben. Rueckerstattung für Fremdsystem vorbereitet: "
                         + returnRequest.getRefundReference());
     }
 
@@ -302,7 +302,7 @@ public class ReturnRequestService {
     public ReturnRequestResponse rejectReturn(Long returnRequestId, User employee, ReturnStatusDecisionRequest request) {
         ReturnRequest returnRequest = loadReturnRequest(returnRequestId);
         if (returnRequest.getStatus() != ReturnRequestStatus.IN_REVIEW) {
-            throw new IllegalStateException("Nur Retouren in Pruefung koennen abgelehnt werden.");
+            throw new IllegalStateException("Nur Retouren in Pruefung können abgelehnt werden.");
         }
         String reason = normalizeRequiredDecisionReason(request.reason());
         returnRequest.setStatus(ReturnRequestStatus.REJECTED);
@@ -318,7 +318,7 @@ public class ReturnRequestService {
     public ReturnRequestResponse markGoodsReceived(Long returnRequestId, User employee) {
         ReturnRequest returnRequest = loadReturnRequest(returnRequestId);
         if (returnRequest.getStatus() != ReturnRequestStatus.SUBMITTED) {
-            throw new IllegalStateException("Nur beantragte Retouren koennen als Wareneingang markiert werden.");
+            throw new IllegalStateException("Nur beantragte Retouren können als Wareneingang markiert werden.");
         }
         returnRequest.setStatus(ReturnRequestStatus.GOODS_RECEIVED);
         returnRequest.setGoodsReceivedAt(Instant.now());
@@ -437,7 +437,7 @@ public class ReturnRequestService {
 
         return returnRequestRepository.findByTrackingIdIgnoreCase(code)
                 .or(() -> parseRmaId(code).flatMap(returnRequestRepository::findById))
-                .orElseThrow(() -> new EntityNotFoundException("Keine Retoure fuer den Scan-Code gefunden: " + code));
+                .orElseThrow(() -> new EntityNotFoundException("Keine Retoure für den Scan-Code gefunden: " + code));
     }
 
     private java.util.Optional<Long> parseRmaId(String code) {
@@ -504,7 +504,7 @@ private BigDecimal calculateRefundAmount(ReturnRequest returnRequest) {
         if (!containsDefectiveLine) {
             if (description != null || !images.isEmpty()) {
                 throw new IllegalArgumentException(
-                        "Defektdetails duerfen nur fuer den Rueckgabegrund Defekt uebermittelt werden.");
+                        "Defektdetails duerfen nur für den Rueckgabegrund Defekt übermittelt werden.");
             }
             return;
         }
@@ -710,7 +710,7 @@ private BigDecimal calculateRefundAmount(ReturnRequest returnRequest) {
         StringBuilder svg = new StringBuilder();
         svg.append("<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 ")
                 .append(size).append(' ').append(size)
-                .append("\" role=\"img\" aria-label=\"QR-Code fuer Retourenlabel\">")
+                .append("\" role=\"img\" aria-label=\"QR-Code für Retourenlabel\">")
                 .append("<rect width=\"100%\" height=\"100%\" fill=\"#fff\"/>");
 
         for (int y = 0; y < matrix.getHeight(); y++) {

--- a/src/main/java/de/fhdw/webshop/sellerportal/SellerPayout.java
+++ b/src/main/java/de/fhdw/webshop/sellerportal/SellerPayout.java
@@ -75,6 +75,9 @@ public class SellerPayout {
     @Column(name = "net_payout_amount", nullable = false, precision = 12, scale = 2)
     private BigDecimal netPayoutAmount = BigDecimal.ZERO;
 
+    @Column(name = "payout_blocked", nullable = false)
+    private boolean payoutBlocked = false;
+
     @Column(name = "correction_reason", length = 500)
     private String correctionReason;
 

--- a/src/main/java/de/fhdw/webshop/sellerportal/SellerPayoutItemType.java
+++ b/src/main/java/de/fhdw/webshop/sellerportal/SellerPayoutItemType.java
@@ -4,5 +4,6 @@ public enum SellerPayoutItemType {
     SALE,
     RETURN_HOLDBACK,
     RETURN_SETTLEMENT,
+    DISPUTE_HOLDBACK,
     CORRECTION
 }

--- a/src/main/java/de/fhdw/webshop/sellerportal/SellerPortalService.java
+++ b/src/main/java/de/fhdw/webshop/sellerportal/SellerPortalService.java
@@ -2,6 +2,9 @@ package de.fhdw.webshop.sellerportal;
 
 import de.fhdw.webshop.admin.AuditInitiator;
 import de.fhdw.webshop.admin.AuditLogService;
+import de.fhdw.webshop.marketplacedispute.MarketplaceDispute;
+import de.fhdw.webshop.marketplacedispute.MarketplaceDisputeRepository;
+import de.fhdw.webshop.marketplacedispute.MarketplaceDisputeStatus;
 import de.fhdw.webshop.order.Order;
 import de.fhdw.webshop.order.OrderItem;
 import de.fhdw.webshop.order.OrderStatus;
@@ -61,6 +64,7 @@ public class SellerPortalService {
     private final SellerPayoutItemRepository sellerPayoutItemRepository;
     private final SellerPortalOrderItemRepository sellerPortalOrderItemRepository;
     private final SellerPortalReturnRequestItemRepository sellerPortalReturnRequestItemRepository;
+    private final MarketplaceDisputeRepository marketplaceDisputeRepository;
     private final AuditLogService auditLogService;
 
     @Transactional
@@ -226,6 +230,7 @@ public class SellerPortalService {
         SellerPayout payout = sellerPayoutRepository.findById(payoutId)
                 .orElseThrow(() -> new EntityNotFoundException("Auszahlung nicht gefunden: " + payoutId));
         ensureMutablePayout(payout);
+        ensureNoOpenDisputeBlock(payout);
         payout.setStatus(SellerPayoutStatus.APPROVED);
         payout.setAdminNote(blankToNull(request == null ? null : request.note()));
         payout.setApprovedAt(Instant.now());
@@ -265,6 +270,7 @@ public class SellerPortalService {
         if (payout.getStatus() == SellerPayoutStatus.PAID_OUT) {
             return toDetailResponse(payout);
         }
+        ensureNoOpenDisputeBlock(payout);
         payout.setStatus(SellerPayoutStatus.PAID_OUT);
         payout.setPaidOutAt(Instant.now());
         payout.setAdminNote(blankToNull(request == null ? null : request.note()));
@@ -373,6 +379,36 @@ public class SellerPortalService {
                     ));
                 });
 
+        snapshot.activeDisputes().forEach(dispute -> {
+            LineAmounts amounts = snapshot.lineAmountsByOrderItemId().get(dispute.getOrderItem().getId());
+            if (amounts == null) {
+                return;
+            }
+            Instant occurredAt = dispute.getCreatedAt() != null ? dispute.getCreatedAt() : resolveSaleInstant(dispute.getOrder());
+            LocalDate periodStart = resolveSaleInstant(dispute.getOrder())
+                    .atZone(ZoneId.of("Europe/Berlin"))
+                    .toLocalDate()
+                    .withDayOfMonth(1);
+            BigDecimal holdbackAmount = money(amounts.netAmount());
+            addComputationItem(itemsByPeriod, periodStart, new PayoutComputationItem(
+                    SellerPayoutItemType.DISPUTE_HOLDBACK,
+                    occurredAt,
+                    "DSP-" + dispute.getId(),
+                    dispute.getOrderItem().getProduct().getName() + " | Konfliktfall " + dispute.getStatus(),
+                    dispute.getOrder(),
+                    null,
+                    dispute.getOrderItem().getQuantity(),
+                    BigDecimal.ZERO,
+                    BigDecimal.ZERO,
+                    BigDecimal.ZERO,
+                    BigDecimal.ZERO,
+                    holdbackAmount,
+                    BigDecimal.ZERO,
+                    BigDecimal.ZERO,
+                    holdbackAmount.negate()
+            ));
+        });
+
         Map<LocalDate, SellerPayout> existingByPeriod = sellerPayoutRepository
                 .findBySellerProfileIdOrderByPeriodStartDesc(sellerProfile.getId())
                 .stream()
@@ -430,6 +466,7 @@ public class SellerPortalService {
         BigDecimal settled = sum(itemsToPersist, PayoutComputationItem::returnSettlementAmount);
         BigDecimal manualAdjustment = sum(itemsToPersist, PayoutComputationItem::manualAdjustmentAmount);
         BigDecimal net = sum(itemsToPersist, PayoutComputationItem::netAmount);
+        boolean payoutBlocked = itemsToPersist.stream().anyMatch(item -> item.type() == SellerPayoutItemType.DISPUTE_HOLDBACK);
 
         payout.setGrossSalesAmount(gross);
         payout.setDiscountAmount(discount);
@@ -439,6 +476,7 @@ public class SellerPortalService {
         payout.setSettledReturnAmount(settled);
         payout.setManualAdjustmentAmount(manualAdjustment);
         payout.setNetPayoutAmount(net);
+        payout.setPayoutBlocked(payoutBlocked);
         sellerPayoutRepository.save(payout);
 
         if (payout.getId() != null) {
@@ -454,6 +492,9 @@ public class SellerPortalService {
         List<OrderItem> orderItems = sellerPortalOrderItemRepository
                 .findBySellerNameIgnoreCaseOrderByOrderCreatedAtDesc(sellerProfile.getDisplayName());
         List<ReturnRequestItem> returnItems = sellerPortalReturnRequestItemRepository.findBySellerName(sellerProfile.getDisplayName());
+        List<MarketplaceDispute> activeDisputes = marketplaceDisputeRepository.findBySellerNameIgnoreCaseAndStatusIn(
+                sellerProfile.getDisplayName(),
+                Set.of(MarketplaceDisputeStatus.OPEN, MarketplaceDisputeStatus.UNDER_REVIEW));
         Map<Long, BigDecimal> subtotalCache = new HashMap<>();
         Map<Long, LineAmounts> lineAmountsByOrderItemId = new HashMap<>();
 
@@ -470,7 +511,7 @@ public class SellerPortalService {
             returnImpacts.computeIfAbsent(returnItem.getOrderItem().getId(), ignored -> new ArrayList<>()).add(impact);
         }
 
-        return new SellerSnapshot(orderItems, returnItems, lineAmountsByOrderItemId, returnImpacts);
+        return new SellerSnapshot(orderItems, returnItems, activeDisputes, lineAmountsByOrderItemId, returnImpacts);
     }
 
     private LineAmounts calculateLineAmounts(
@@ -579,6 +620,16 @@ public class SellerPortalService {
                     summary.hasActiveReturn = true;
                 }
             }
+            snapshot.activeDisputes().stream()
+                    .filter(dispute -> Objects.equals(dispute.getOrderItem().getId(), orderItem.getId()))
+                    .findAny()
+                    .ifPresent(dispute -> {
+                        LineAmounts disputeAmounts = snapshot.lineAmountsByOrderItemId().get(orderItem.getId());
+                        if (disputeAmounts != null) {
+                            summary.openReturnHoldback = summary.openReturnHoldback.add(disputeAmounts.netAmount());
+                            summary.payoutBlocked = true;
+                        }
+                    });
         }
 
         return byOrderId.values().stream()
@@ -605,6 +656,7 @@ public class SellerPortalService {
                 money(payout.getSettledReturnAmount()),
                 money(payout.getManualAdjustmentAmount()),
                 money(payout.getNetPayoutAmount()),
+                payout.isPayoutBlocked(),
                 payout.getCreatedAt(),
                 payout.getApprovedAt(),
                 payout.getPaidOutAt(),
@@ -719,6 +771,12 @@ public class SellerPortalService {
         }
     }
 
+    private void ensureNoOpenDisputeBlock(SellerPayout payout) {
+        if (payout.isPayoutBlocked()) {
+            throw new IllegalStateException("Diese Auszahlung ist wegen offener Marketplace-Konfliktfälle blockiert.");
+        }
+    }
+
     private String generatePayoutNumber(SellerProfile sellerProfile, LocalDate periodStart) {
         return "SPA-" + periodStart.format(DateTimeFormatter.ofPattern("yyyyMM"))
                 + "-" + String.format("%03d", sellerProfile.getId());
@@ -768,6 +826,7 @@ public class SellerPortalService {
     private record SellerSnapshot(
             List<OrderItem> orderItems,
             List<ReturnRequestItem> returnItems,
+            List<MarketplaceDispute> activeDisputes,
             Map<Long, LineAmounts> lineAmountsByOrderItemId,
             Map<Long, List<ReturnImpact>> returnImpacts
     ) {
@@ -825,6 +884,7 @@ public class SellerPortalService {
         private BigDecimal net = BigDecimal.ZERO;
         private boolean hasActiveReturn;
         private boolean hasSettledReturn;
+        private boolean payoutBlocked;
 
         private MutableOrderSummary(Order order) {
             this.order = order;
@@ -849,6 +909,7 @@ public class SellerPortalService {
                     net.setScale(2, RoundingMode.HALF_UP),
                     hasActiveReturn,
                     hasSettledReturn,
+                    payoutBlocked,
                     order.getStatus() == OrderStatus.CANCELLED
             );
         }

--- a/src/main/java/de/fhdw/webshop/sellerportal/dto/SellerOrderSummaryResponse.java
+++ b/src/main/java/de/fhdw/webshop/sellerportal/dto/SellerOrderSummaryResponse.java
@@ -22,6 +22,7 @@ public record SellerOrderSummaryResponse(
         BigDecimal netAmount,
         boolean hasActiveReturn,
         boolean hasSettledReturn,
+        boolean payoutBlocked,
         boolean cancelled
 ) {
 }

--- a/src/main/java/de/fhdw/webshop/sellerportal/dto/SellerPayoutSummaryResponse.java
+++ b/src/main/java/de/fhdw/webshop/sellerportal/dto/SellerPayoutSummaryResponse.java
@@ -21,6 +21,7 @@ public record SellerPayoutSummaryResponse(
         BigDecimal settledReturnAmount,
         BigDecimal manualAdjustmentAmount,
         BigDecimal netPayoutAmount,
+        boolean payoutBlocked,
         Instant createdAt,
         Instant approvedAt,
         Instant paidOutAt,

--- a/src/main/java/de/fhdw/webshop/sellerreview/SellerReviewService.java
+++ b/src/main/java/de/fhdw/webshop/sellerreview/SellerReviewService.java
@@ -99,7 +99,7 @@ public class SellerReviewService {
                 .orElseThrow(() -> new EntityNotFoundException("Order not found: " + orderId));
 
         if (NON_REVIEWABLE_STATUSES.contains(order.getStatus())) {
-            throw new IllegalArgumentException("Verkaeufer koennen erst nach Bestellbestaetigung bewertet werden.");
+            throw new IllegalArgumentException("Verkaeufer können erst nach Bestellbestaetigung bewertet werden.");
         }
 
         String requestedSeller = normalizeRequired(request.sellerName(), "Bitte einen Verkaeufer aus der Bestellung auswaehlen.");
@@ -112,7 +112,7 @@ public class SellerReviewService {
         }
 
         if (sellerReviewRepository.existsByOrderIdAndCustomerIdAndSellerNameIgnoreCase(orderId, currentUser.getId(), canonicalSeller)) {
-            throw new IllegalArgumentException("Fuer diesen Verkaeufer wurde zu dieser Bestellung bereits eine Bewertung abgegeben.");
+            throw new IllegalArgumentException("Für diesen Verkaeufer wurde zu dieser Bestellung bereits eine Bewertung abgegeben.");
         }
 
         SellerReview review = new SellerReview();
@@ -210,11 +210,11 @@ public class SellerReviewService {
             return;
         }
         if (images.size() > MAX_IMAGES_PER_REVIEW) {
-            throw new IllegalArgumentException("Es koennen maximal 3 Bilder pro Rezension hochgeladen werden.");
+            throw new IllegalArgumentException("Es können maximal 3 Bilder pro Rezension hochgeladen werden.");
         }
         for (MultipartFile image : images) {
             if (image == null || image.isEmpty()) {
-                throw new IllegalArgumentException("Leere Bilddateien koennen nicht hochgeladen werden.");
+                throw new IllegalArgumentException("Leere Bilddateien können nicht hochgeladen werden.");
             }
             if (image.getSize() > MAX_IMAGE_SIZE_BYTES) {
                 throw new IllegalArgumentException("Ein Rezensionsbild darf maximal 5 MB gross sein.");

--- a/src/main/java/de/fhdw/webshop/tradein/TradeInService.java
+++ b/src/main/java/de/fhdw/webshop/tradein/TradeInService.java
@@ -56,10 +56,10 @@ public class TradeInService {
         }
 
         if (!orderItem.getProduct().isTradeInEnabled()) {
-            throw new IllegalStateException("Trade-In ist fuer diesen Artikel deaktiviert.");
+            throw new IllegalStateException("Trade-In ist für diesen Artikel deaktiviert.");
         }
         if (!isReturnWindowExpired(order)) {
-            throw new IllegalStateException("Trade-In ist erst nach Ablauf der 14-taegigen Retourenfrist moeglich.");
+            throw new IllegalStateException("Trade-In ist erst nach Ablauf der 14-taegigen Retourenfrist möglich.");
         }
 
         boolean alreadyPending = tradeInRepository.existsByOrderItemIdAndStatusNot(

--- a/src/main/resources/db/dev-seed.sql
+++ b/src/main/resources/db/dev-seed.sql
@@ -93,8 +93,8 @@ INSERT INTO advertisements (title, description, content_type, image_url, target_
 SELECT title, description, content_type, image_url, target_url, active, start_date, end_date
 FROM (
     VALUES
-      ('Sommeraktion im Home Office', 'Ergonomische Favoriten, clevere Bundles und schnelle Upgrades fuer deinen Arbeitsplatz.', 'IMAGE', '/standing-desk.jpg', '/products/3', TRUE, CURRENT_DATE, CURRENT_DATE + INTERVAL '30 days'),
-      ('Top Auswahl fuer Entscheider', 'Vergleiche Bestseller, Empfehlungen und sofort verfuegbare Geraete direkt im Sortiment.', 'TEXT', NULL, '/', TRUE, CURRENT_DATE, CURRENT_DATE + INTERVAL '30 days'),
+      ('Sommeraktion im Home Office', 'Ergonomische Favoriten, clevere Bundles und schnelle Upgrades für deinen Arbeitsplatz.', 'IMAGE', '/standing-desk.jpg', '/products/3', TRUE, CURRENT_DATE, CURRENT_DATE + INTERVAL '30 days'),
+      ('Top Auswahl für Entscheider', 'Vergleiche Bestseller, Empfehlungen und sofort verfuegbare Geraete direkt im Sortiment.', 'TEXT', NULL, '/', TRUE, CURRENT_DATE, CURRENT_DATE + INTERVAL '30 days'),
       ('Verkaeufer-Aktion vorbereiten', 'Diese Werbeflaeche ist angelegt, aber noch nicht aktiv geschaltet.', 'TEXT', NULL, '/admin/marketing/placements', FALSE, CURRENT_DATE + INTERVAL '7 days', CURRENT_DATE + INTERVAL '21 days')
 ) AS seed_data(title, description, content_type, image_url, target_url, active, start_date, end_date)
 WHERE NOT EXISTS (

--- a/src/main/resources/db/loadtest-seed.sql
+++ b/src/main/resources/db/loadtest-seed.sql
@@ -27,7 +27,7 @@ INSERT INTO products (
 )
 SELECT
     'Load Test Produkt ' || series,
-    'Automatisch generiertes Produkt fuer den Lasttest, Nummer ' || series,
+    'Automatisch generiertes Produkt für den Lasttest, Nummer ' || series,
     ROUND((5 + random() * 995)::numeric, 2),
     ROUND((random() * 200)::numeric, 3),
     (ARRAY['A', 'B', 'C', 'D', 'E'])[1 + floor(random() * 5)::int],
@@ -59,7 +59,7 @@ INSERT INTO products (
 )
 VALUES (
     'Load Test Bestell Artikel',
-    'Hochlager-Artikel fuer den optionalen Bestell-Lasttest (siehe docs/loadtest.md)',
+    'Hochlager-Artikel für den optionalen Bestell-Lasttest (siehe docs/loadtest.md)',
     9.99, 'C', 'Loadtest', 100000000, 'LOAD-ORDER-PRODUCT', TRUE
 );
 

--- a/src/main/resources/db/migration/V104__create_marketplace_disputes.sql
+++ b/src/main/resources/db/migration/V104__create_marketplace_disputes.sql
@@ -1,0 +1,44 @@
+CREATE TABLE marketplace_disputes (
+    id BIGSERIAL PRIMARY KEY,
+    order_id BIGINT NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
+    order_item_id BIGINT NOT NULL REFERENCES order_items(id) ON DELETE CASCADE,
+    customer_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    seller_name VARCHAR(180) NOT NULL,
+    reason VARCHAR(40) NOT NULL,
+    status VARCHAR(40) NOT NULL,
+    description VARCHAR(2000),
+    payout_blocked BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    resolved_at TIMESTAMP WITH TIME ZONE
+);
+
+CREATE INDEX idx_marketplace_disputes_customer ON marketplace_disputes(customer_id, created_at DESC);
+CREATE INDEX idx_marketplace_disputes_seller ON marketplace_disputes(LOWER(seller_name), created_at DESC);
+CREATE INDEX idx_marketplace_disputes_status ON marketplace_disputes(status);
+
+CREATE UNIQUE INDEX ux_marketplace_disputes_active_item
+    ON marketplace_disputes(order_item_id)
+    WHERE status IN ('OPEN', 'UNDER_REVIEW');
+
+CREATE TABLE marketplace_dispute_history (
+    id BIGSERIAL PRIMARY KEY,
+    dispute_id BIGINT NOT NULL REFERENCES marketplace_disputes(id) ON DELETE CASCADE,
+    status VARCHAR(40) NOT NULL,
+    changed_by_id BIGINT REFERENCES users(id) ON DELETE SET NULL,
+    changed_by_username VARCHAR(120),
+    changed_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    note VARCHAR(1000)
+);
+
+CREATE INDEX idx_marketplace_dispute_history_dispute ON marketplace_dispute_history(dispute_id, changed_at ASC);
+
+CREATE TABLE marketplace_dispute_images (
+    id BIGSERIAL PRIMARY KEY,
+    dispute_id BIGINT NOT NULL REFERENCES marketplace_disputes(id) ON DELETE CASCADE,
+    image_url VARCHAR(1000) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE seller_payouts
+    ADD COLUMN payout_blocked BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/test/java/de/fhdw/webshop/admin/navigation/AdminNavigationServiceTest.java
+++ b/src/test/java/de/fhdw/webshop/admin/navigation/AdminNavigationServiceTest.java
@@ -48,7 +48,7 @@ class AdminNavigationServiceTest {
                 .containsExactly("Produktverwaltung", "Bestellungen");
         assertThat(navigation.stream().flatMap(group -> group.items().stream()))
                 .extracting(AdminNavigationItemResponse::id)
-                .containsExactly("warehouse", "return-requests");
+                .containsExactly("warehouse", "stock-reservations", "return-requests");
     }
 
     @Test

--- a/src/test/java/de/fhdw/webshop/admin/statistics/alerting/StatisticAlertServiceTest.java
+++ b/src/test/java/de/fhdw/webshop/admin/statistics/alerting/StatisticAlertServiceTest.java
@@ -37,7 +37,7 @@ class StatisticAlertServiceTest {
 
         assertThatThrownBy(() -> service.updateThreshold(7L, request))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Der Schwellwert muss groesser als 0 und maximal 1000 Prozent sein.");
+                .hasMessage("Der Schwellwert muss größer als 0 und maximal 1000 Prozent sein.");
     }
 
     @Test

--- a/src/test/java/de/fhdw/webshop/customer/CustomerControllerTest.java
+++ b/src/test/java/de/fhdw/webshop/customer/CustomerControllerTest.java
@@ -153,7 +153,7 @@ class CustomerControllerTest {
 
         mockMvc.perform(patch("/api/customers/9/deactivate"))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("Dieser Endpunkt gilt nur fuer Kundenkonten."));
+                .andExpect(jsonPath("$.message").value("Dieser Endpunkt gilt nur für Kundenkonten."));
 
         verify(userRepository, never()).save(any(User.class));
     }

--- a/src/test/java/de/fhdw/webshop/order/OrderServiceTest.java
+++ b/src/test/java/de/fhdw/webshop/order/OrderServiceTest.java
@@ -71,7 +71,7 @@ class OrderServiceTest {
         TestContext context = newContext(new BigDecimal("100.00"));
         when(context.orderRepository.save(any(Order.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        OrderResponse response = context.service.placeOrder(context.customer, request("Bitte fuer das Projekt freigeben"));
+        OrderResponse response = context.service.placeOrder(context.customer, request("Bitte für das Projekt freigeben"));
 
         ArgumentCaptor<Order> orderCaptor = ArgumentCaptor.forClass(Order.class);
         verify(context.orderRepository).save(orderCaptor.capture());
@@ -79,7 +79,7 @@ class OrderServiceTest {
 
         assertThat(response.status()).isEqualTo(OrderStatus.Pending_Approval);
         assertThat(savedOrder.getStatus()).isEqualTo(OrderStatus.Pending_Approval);
-        assertThat(savedOrder.getApprovalReason()).isEqualTo("Bitte fuer das Projekt freigeben");
+        assertThat(savedOrder.getApprovalReason()).isEqualTo("Bitte für das Projekt freigeben");
         assertThat(savedOrder.getApprovalBudgetLimit()).isEqualByComparingTo("100.00");
         assertThat(savedOrder.getItems()).hasSize(1);
         assertThat(context.product.getStock()).isEqualTo(5);
@@ -129,10 +129,10 @@ class OrderServiceTest {
         var approvalResponse = context.service.rejectApprovalRequest(
                 context.manager,
                 pendingOrder.getId(),
-                "Budget fuer dieses Quartal ausgeschoepft");
+                "Budget für dieses Quartal ausgeschöpft");
 
         assertThat(approvalResponse.status()).isEqualTo(OrderStatus.Rejected);
-        assertThat(approvalResponse.rejectionReason()).isEqualTo("Budget fuer dieses Quartal ausgeschoepft");
+        assertThat(approvalResponse.rejectionReason()).isEqualTo("Budget für dieses Quartal ausgeschöpft");
 
         ArgumentCaptor<String> addressCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> subjectCaptor = ArgumentCaptor.forClass(String.class);
@@ -140,7 +140,7 @@ class OrderServiceTest {
         verify(context.emailService).sendEmail(addressCaptor.capture(), subjectCaptor.capture(), bodyCaptor.capture());
         assertThat(addressCaptor.getValue()).isEqualTo(context.customer.getEmail());
         assertThat(subjectCaptor.getValue()).contains("Freigabe abgelehnt", pendingOrder.getOrderNumber());
-        assertThat(bodyCaptor.getValue()).contains("Budget fuer dieses Quartal ausgeschoepft", pendingOrder.getOrderNumber());
+        assertThat(bodyCaptor.getValue()).contains("Budget für dieses Quartal ausgeschöpft", pendingOrder.getOrderNumber());
     }
 
     @Test

--- a/src/test/java/de/fhdw/webshop/sellerportal/SellerPortalServiceTest.java
+++ b/src/test/java/de/fhdw/webshop/sellerportal/SellerPortalServiceTest.java
@@ -1,6 +1,7 @@
 package de.fhdw.webshop.sellerportal;
 
 import de.fhdw.webshop.admin.AuditLogService;
+import de.fhdw.webshop.marketplacedispute.MarketplaceDisputeRepository;
 import de.fhdw.webshop.order.Order;
 import de.fhdw.webshop.order.OrderItem;
 import de.fhdw.webshop.order.OrderStatus;
@@ -38,6 +39,7 @@ class SellerPortalServiceTest {
         SellerPayoutItemRepository sellerPayoutItemRepository = mock(SellerPayoutItemRepository.class);
         SellerPortalOrderItemRepository sellerPortalOrderItemRepository = mock(SellerPortalOrderItemRepository.class);
         SellerPortalReturnRequestItemRepository sellerPortalReturnRequestItemRepository = mock(SellerPortalReturnRequestItemRepository.class);
+        MarketplaceDisputeRepository marketplaceDisputeRepository = mock(MarketplaceDisputeRepository.class);
 
         SellerPortalService service = new SellerPortalService(
                 sellerProfileRepository,
@@ -45,6 +47,7 @@ class SellerPortalServiceTest {
                 sellerPayoutItemRepository,
                 sellerPortalOrderItemRepository,
                 sellerPortalReturnRequestItemRepository,
+                marketplaceDisputeRepository,
                 mock(AuditLogService.class));
 
         User seller = sellerUser();
@@ -73,6 +76,8 @@ class SellerPortalServiceTest {
                 .thenReturn(List.of(orderItem));
         when(sellerPortalReturnRequestItemRepository.findBySellerName(profile.getDisplayName()))
                 .thenReturn(List.of(returnItem));
+        when(marketplaceDisputeRepository.findBySellerNameIgnoreCaseAndStatusIn(any(), any()))
+                .thenReturn(List.of());
         when(sellerPayoutRepository.findBySellerProfileIdOrderByPeriodStartDesc(profile.getId()))
                 .thenAnswer(invocation -> storedPayouts.stream()
                         .sorted((left, right) -> right.getPeriodStart().compareTo(left.getPeriodStart()))


### PR DESCRIPTION
# Pull Request

## 📝 Beschreibung

Diese PR ergänzt im Backend die Marketplace-Konfliktfälle für Drittanbieter-Bestellungen. Kundinnen und Kunden können für zugestellte Marketplace-Artikel einen Konfliktfall eröffnen. Das Backend prüft dabei Bestellstatus, Kundenzuordnung, Drittanbieter-Artikel und verhindert doppelte offene Konfliktfälle pro Bestellposition.

Zusätzlich werden Konfliktfälle für Verkäufer, Mitarbeitende und Admins bereitgestellt. Offene Konfliktfälle blockieren zugehörige Verkäuferauszahlungen und werden als Rückbehalt in der Auszahlung berücksichtigt. Außerdem wurden sichtbare Backend-Fehlermeldungen mit korrekten deutschen Umlauten überarbeitet.

## 🎯 Ticket

Resolves #374

## 📋 Änderungen
*Hake an, welche Änderungen erfolgt sind:*

- [x] Neue Features hinzugefügt
- [x] Bugs behoben
- [ ] Code refaktoriert
- [ ] Code ist selbsterklärend mit Kommentaren
- [x] Tests geschrieben/aktualisiert
- [ ] Dokumentation aktualisiert

## 🔗 Related Issues

- Relates to #374

## ✅ Validierung

- `mvn -DskipTests compile` erfolgreich ausgeführt
- Gezielte Backend-Tests erfolgreich ausgeführt:
  - `SellerPortalServiceTest`
  - `AdminNavigationServiceTest`
  - `CustomerControllerTest`
  - `StatisticAlertServiceTest`
  - `OrderServiceTest`

---

**Wichtig:** Dieser PR geht zu `main` und schließt das Ticket automatisch über `Resolves #374`.