### PR TITLE
fix(#322): Produktseite auf eigene Produkte beschränken

### DIFF
--- a/src/main/java/de/fhdw/webshop/product/ProductRepository.java
+++ b/src/main/java/de/fhdw/webshop/product/ProductRepository.java
@@ -35,6 +35,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     @Query("""
             SELECT p FROM Product p
             WHERE p.parentProduct IS NULL
+              AND LOWER(p.sellerName) = 'webshop'
               AND (:purchasableOnly IS NULL OR p.purchasable = :purchasableOnly)
               AND (:category = '' OR LOWER(p.category) = LOWER(:category))
               AND (:filterByEcoScore = false OR p.ecoScore IN :ecoScores)


### PR DESCRIPTION
searchProducts-Query filtert jetzt auf sellerName = 'webshop', sodass /api/products ausschließlich Eigenprodukte zurückgibt. Marketplace-Produkte externer Händler erscheinen nur noch unter /api/marketplace/products.